### PR TITLE
Check for 1.5's annStorageProvisioner, not annDynamicallyProvisioned

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -399,8 +399,8 @@ func (ctrl *ProvisionController) shouldProvision(claim *v1.PersistentVolumeClaim
 	}
 	ctrl.failedClaimsStatsMutex.Unlock()
 
-	// Kubernetes 1.5 provisioning with annDynamicallyProvisioned
-	if provisioner, found := claim.Annotations[annDynamicallyProvisioned]; found {
+	// Kubernetes 1.5 provisioning with annStorageProvisioner
+	if provisioner, found := claim.Annotations[annStorageProvisioner]; found {
 		if provisioner == ctrl.provisionerName {
 			return true
 		}

--- a/lib/controller/controller_test.go
+++ b/lib/controller/controller_test.go
@@ -307,14 +307,14 @@ func TestShouldProvision(t *testing.T) {
 			claim:           newClaim("claim-1", "1-1", "class-1", "", nil),
 			expectedShould:  false,
 		},
-		// Kubernetes 1.5 provisioning - annDynamicallyProvisioned is set
+		// Kubernetes 1.5 provisioning - annStorageProvisioner is set
 		// and only this annotation is evaluated
 		{
 			name:            "should provision 1.5",
 			provisionerName: "foo.bar/baz",
 			class:           newStorageClass("class-2", "abc.def/ghi"),
 			claim: newClaim("claim-1", "1-1", "class-1", "",
-				map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+				map[string]string{annStorageProvisioner: "foo.bar/baz"}),
 			expectedShould: true,
 		},
 		{
@@ -322,7 +322,7 @@ func TestShouldProvision(t *testing.T) {
 			provisionerName: "foo.bar/baz",
 			class:           newStorageClass("class-1", "foo.bar/baz"),
 			claim: newClaim("claim-1", "1-1", "class-1", "",
-				map[string]string{annDynamicallyProvisioned: "abc.def/ghi"}),
+				map[string]string{annStorageProvisioner: "abc.def/ghi"}),
 			expectedShould: false,
 		},
 	}


### PR DESCRIPTION
this is a small bug, we have actually been checking annDynamicallyProvisioned (which is set by provisioner after it has provisioned) vs annStorageProvisioner which is set by PV controller for external provisioners' convenience https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/volume/persistentvolume/pv_controller_base.go#L463

@jsafrane I think there is also the same error here https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/volume/persistentvolume/pv_controller_base.go#L448 , it shoudl check annStorageProvisioner not annDynamicallyProvisioner. will look tomorrow