### PR TITLE
Do clean up in NFS Dockerfile for smaller image

### DIFF
--- a/nfs/deploy/docker/Dockerfile
+++ b/nfs/deploy/docker/Dockerfile
@@ -34,9 +34,11 @@ RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-d
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
+	&& cd .. \
+	&& rm -rf nfs-ganesha-2.4.0.3 \
 	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all
 
-RUN dnf install -y dbus-x11 rpcbind-0.2.3-10.rc1.fc24.x86_64 hostname nfs-utils xfsprogs jemalloc libnfsidmap
+RUN dnf install -y dbus-x11 rpcbind-0.2.3-10.rc1.fc24.x86_64 hostname nfs-utils xfsprogs jemalloc libnfsidmap && dnf clean all
 
 RUN mkdir -p /var/run/dbus
 RUN mkdir -p /export


### PR DESCRIPTION
down to ~341.4MB, so like 140MB more than vanilla fedora image. I still need to reevaluate whether we need to build ganesha from scratch to begin with, will look soon.