### PR TITLE
Set umask to 0 to make sure the pvc directories have proper permissions

### DIFF
--- a/docs/demo/hostpath-provisioner/hostpath-provisioner.go
+++ b/docs/demo/hostpath-provisioner/hostpath-provisioner.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
+	"syscall"
 )
 
 const (
@@ -117,6 +118,8 @@ func (p *hostPathProvisioner) Delete(volume *v1.PersistentVolume) error {
 }
 
 func main() {
+	syscall.Umask(0)
+
 	flag.Parse()
 	flag.Set("logtostderr", "true")
 


### PR DESCRIPTION
Depending on the umask, the PVC directories permissions weren't always 777 and were not writable by certain containers.