### PR TITLE
Detect local volume capacity

### DIFF
--- a/local-volume/provisioner/deployment/kubernetes/provisioner-daemonset.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/provisioner-daemonset.yaml
@@ -12,6 +12,8 @@ spec:
       - name: provisioner
         image: "gcr.io/msau-k8s-dev/local-volume-provisioner:latest"
         imagePullPolicy: Always
+        securityContext:
+          privileged: true
         volumeMounts:
         - name: discovery-vol
           mountPath: "/local-disks"

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -65,6 +65,7 @@ type RuntimeConfig struct {
 type LocalPVConfig struct {
 	Name            string
 	HostPath        string
+	Capacity        uint64
 	StorageClass    string
 	ProvisionerName string
 	AffinityAnn     string
@@ -83,8 +84,7 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 			Capacity: v1.ResourceList{
-				// TODO: detect capacity
-				v1.ResourceName(v1.ResourceStorage): resource.MustParse("10Gi"),
+				v1.ResourceName(v1.ResourceStorage): *resource.NewQuantity(int64(config.Capacity), resource.BinarySI),
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				Local: &v1.LocalVolumeSource{


### PR DESCRIPTION
Detect local volume capacity, a couple of implementation notes:
- to correctly detect host devices, daemonset is changed to run in privileged mode
- after investigating cadvisor, i think we can just detect capacity using statfs, instead of collecting all information from device name, device number, mountpoint, etc; we don't need that much data
- statfs returns 'total, free, available'.  We use 'total - free + available' as pv [capacity](https://github.com/kubernetes-incubator/external-storage/pull/135#discussion_r119220717)
- if user just create regular directory, then the available space for the mount device is returned, in which case the behavior is similar to hostpath

Future work
- zfs and devicemapper might require [special handling](https://github.com/google/cadvisor/blob/86daf2b4db38364f86aca6af38b28f4844885872/fs/fs.go#L342)
- hostpath mount option should be [rshared](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/propagation.md)

@msau42 @jsafrane @humblec @wongma7 