### PR TITLE
Pre-create /tmp/local-up-cluster.log before tail

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -48,6 +48,7 @@ if [ "$TEST_SUITE" = "nfs" ]; then
 	mkdir -p $HOME/.kube
 	sudo chmod -R 777 $HOME/.kube
 	sudo "PATH=$PATH" KUBECTL=$HOME/kubernetes/server/bin/kubectl ALLOW_SECURITY_CONTEXT=true API_HOST_IP=0.0.0.0 $HOME/kubernetes-${KUBE_VERSION}/hack/local-up-cluster.sh -o $HOME/kubernetes/server/bin >/tmp/local-up-cluster.log 2>&1 &
+	touch /tmp/local-up-cluster.log
 	timeout 30 grep -q "Local Kubernetes cluster is running." <(tail -f /tmp/local-up-cluster.log)
 	if [ $? == 124 ]; then
 		cat /tmp/local-up-cluster.log


### PR DESCRIPTION
to avoid tail: cannot open ‘/tmp/local-up-cluster.log’ for reading: No such file or directory