### PR TITLE
Functional local storage provisioner

### DIFF
--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -1,0 +1,144 @@
+# Local Persistent Storage User Guide
+## Overview
+Local persistent volumes allows users to access local storage through the
+standard PVC interface in a simple and portable way.  The PV contains node
+affinity information that the system uses to schedule pods to the correct
+nodes.
+
+An external static provisioner is available to help simplify local storage
+management once the local volumes are configured.
+
+## Feature Status
+Current status: 1.7 - Alpha
+
+What works:
+* Create a PV specifying a directory with node affinity.
+* Pod using the PVC that is bound to this PV will always get scheduled to that node.
+* External static provisioner daemonset that discovers local directories,
+  creates, cleans up and deletes PVs.
+
+What doesn't work and workarounds:
+* Multiple local PVCs in a single pod.
+    * Goal for 1.8.
+    * No known workarounds.
+* PVC binding does not consider pod scheduling requirements and may make
+  suboptimal or incorrect decisions.
+    * Goal for 1.8.
+    * Workarounds:
+        * Run your pods that require local storage first.
+        * Give your pods high priority.
+        * Run this workaround controller that unbinds PVCs for pods that are
+          stuck pending. LINK
+* External provisioner cannot correctly detect capacity of mounts added after it
+  has been started.
+    * This requires mount propagation to work, which is targeted for 1.8.
+    * Workaround: Before adding any new mount points, stop the daemonset, add
+      the new mount points, start the daemonset.
+* Fsgroup conflict if multiple pods using the same PVC specify different fsgroup
+    * Workaround: Don't do this!
+
+Future features:
+* Local block devices as a volume source, with partitioning and fs formatting
+* Pod accessing local raw block device
+* Local PV health monitoring, taints and tolerations
+* Inline PV (use dedicated local disk as ephemeral storage)
+* Dynamic provisioning for shared local persistent storage
+
+## User Guide
+### Bringing up a cluster with local disks
+#### GCE
+``` console
+KUBE_FEATURE_GATES=PersistentLocalVolumes NODE_LOCAL_SSDS=<n> kube-up.sh
+```
+#### GKE
+``` console
+gcloud alpha container cluster create ... --local-ssd-count=<n>
+gcloud alpha container node-pools create ... --local-ssd-count=<n>
+```
+
+#### Baremetal environments
+1. Partition and format the disks on each node according to your application's requirements.
+2. Mount all the filesystems under one directory per StorageClass.
+3. Configure a Kubernetes cluster with the `PersistentLocalVolumes` feature gate.
+
+### Running the external static provisioner
+This is optional, only for automated creation and cleanup of local volumes.
+See `provisioner/` for details and sample configuration files.
+
+1. Create an admin account with persistentvolume provisioner and node system privileges.
+``` console
+$ kubectl create -f provisioner/deployment/kubernetes/admin_account.yaml
+```
+2. Create a ConfigMap with your local storage configuration details.
+The default StorageClass is `local-storage`.
+TODO: TBD
+
+3. Launch the DaemonSet
+``` console
+$ kubectl create -f provisioner/deployment/kubernetes/provisioner_daemonset.yaml
+```
+
+### Specifying local PV
+If you don't use the external provisioner, then you have to create the local PVs
+manually. Example PV:
+
+``` yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: example-local-pv
+  annotations:
+        "volume.alpha.kubernetes.io/node-affinity": `{
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    { "matchExpressions": [
+                        { "key": "kubernetes.io/hostname",
+                          "operator": "In",
+                          "values": ["my-node"]
+                        }
+                    ]}
+                 ]}
+              }`,
+spec:
+    capacity:
+      storage: 5Gi
+    accessModes:
+    - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Delete
+    storageClassName: local-storage
+    local:
+      path: /mnt/disks/ssd1
+```
+
+### Specifying local PVC
+In the PVC, specify the StorageClass of your local PVs.
+
+``` yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: example-local-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-storage
+```
+
+## Best Practices
+* For IO isolation, a whole disk per volume is recommended
+* For capacity isolation, separate partitions per volume is recommended
+* Avoid recreating nodes with the same node name while there are still old PVs
+  with that node's affinity specified. Otherwise, the system could think that
+  the new node contains the old PVs.
+
+### Deleting/removing the underlying volume
+When you want to decommission the local volume, here is a possible workflow.
+1. Stop the pods that are using the volume
+2. Remove the local volume from the node (ie unmounting, pulling out the disk, etc)
+3. Delete the PVC
+4. The provisioner will try to cleanup the volume, but will fail since the volume no longer exists
+5. Manually delete the PV object
+

--- a/local-volume/examples/local-statefulset.yaml
+++ b/local-volume/examples/local-statefulset.yaml
@@ -33,7 +33,7 @@ spec:
       name: local-vol
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "local-fast"
+      storageClassName: "local-storage"
       resources:
         requests:
           storage: 1Gi

--- a/local-volume/examples/manual-pv.yaml
+++ b/local-volume/examples/manual-pv.yaml
@@ -1,0 +1,28 @@
+``` yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: example-local-pv
+  annotations:
+        "volume.alpha.kubernetes.io/node-affinity": `{
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    { "matchExpressions": [
+                        { "key": "kubernetes.io/hostname",
+                          "operator": "In",
+                          "values": ["my-node"]
+                        }   
+                    ]}  
+                 ]}  
+              }`, 
+spec:
+    capacity:
+      storage: 5Gi 
+    accessModes:
+    - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Delete
+    storageClassName: local-storage
+    local:
+      path: /mnt/disks/ssd1
+```
+

--- a/local-volume/examples/simple-pvc.yaml
+++ b/local-volume/examples/simple-pvc.yaml
@@ -1,0 +1,14 @@
+``` yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: example-local-claim
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi 
+  storageClassName: local-storage
+```
+

--- a/local-volume/provisioner/README.md
+++ b/local-volume/provisioner/README.md
@@ -36,7 +36,7 @@ make push
 ### Setting up a cluster with local storage
 Bring up a GCE cluster with local SSDs
 ``` console
-NODE_LOCAL_SSDS=3 kube-up.sh
+KUBE_FEATURE_GATES=PersistentLocalVolumes NODE_LOCAL_SSDS=3 kube-up.sh
 ```
 
 ## Best Practices
@@ -62,4 +62,4 @@ Deleter: The deleter routine is invoked by the Informer when a PV phase changes.
 
 Cache: A central cache stores all the Local PersistentVolumes that the provisioner has created.  It is populated by a PV informer that filters out the PVs that belong to this node and have been created by this provisioner.  It is used by the Discovery and Deleter routines to get the existing PVs.
 
-Controller: The controller runs a sync loop that coordinates the other components.
+Controller: The controller runs a sync loop that coordinates the other components.  The discovery and deleter run serially to simplify synchronization with the cache and create/delete operations.

--- a/local-volume/provisioner/README.md
+++ b/local-volume/provisioner/README.md
@@ -6,18 +6,6 @@ local-volume-provisioner is an out-of-tree static provisioner for the Local volu
 
 It runs on each node in the cluster and monitors specified directories to look for new local file-based volumes.  The volumes can be a mount point or a directory in a shared filesystem.  It then statically creates a Local PersistentVolume for each local volume.  It also monitors when the PersistentVolumes have been released, and will clean up the volume, and recreate the PV.
 
-
-## Quickstart
-Create an admin account with persistentvolume provisioner privileges.
-``` console
-$ kubectl create -f deployment/kubernetes/admin_account.yaml
-```
-
-Launch the DaemonSet
-``` console
-$ kubectl create -f deployment/kubernetes/provisioner_daemonset.yaml
-```
-
 ## Development
 Compile the provisioner
 ``` console
@@ -29,27 +17,7 @@ Make the container image and push to the registry
 make push
 ```
 
-## Deployment
-### Provisioner deployment arguments
-
-
-### Setting up a cluster with local storage
-Bring up a GCE cluster with local SSDs
-``` console
-KUBE_FEATURE_GATES=PersistentLocalVolumes NODE_LOCAL_SSDS=3 kube-up.sh
-```
-
-## Best Practices
-* For IO isolation, a whole disk per volume is recommended
-* For capacity isolation, separate partitions per volume is recommended
-
-### Deleting/removing the underlying volume
-When you want to decommission the local volume, here is a possible workflow.
-1. Stop the pods that are using the volume
-2. Remove the local volume from the node (ie unmounting, pulling out the disk, etc)
-3. Delete the PVC
-4. The provisioner will try to cleanup the volume, but will fail since the volume no longer exists
-5. Manually delete the PV object
+TODO: add making a release and pushing to public image registry
 
 ## Design
 There is one provisioner instance on each node in the cluster.  Each instance is reponsible for monitoring and managing the local volumes on its node.

--- a/local-volume/provisioner/TODO.md
+++ b/local-volume/provisioner/TODO.md
@@ -14,3 +14,5 @@
 ## P2
 * Partitioning, formatting, and mount extensions (needs mount propagation)
 * Block device support (needs API and volume plugin changes too)
+* Refactor to just use informer's cache (and need to stub out API calls for unit
+  testing)

--- a/local-volume/provisioner/TODO.md
+++ b/local-volume/provisioner/TODO.md
@@ -1,19 +1,16 @@
 # TODO
 
 ## P0
-* Update with Local volume API (msau42)
-* Give each provisioner a unique name (msau42)
 * Detect capacity of mount points (ddysher)
 * Deploy to public image repo (msau42)
 * E2E tests
 
 ## P1
+* Can we filter the PV watch to only certain fields?
 * Investigate nodename vs hostname issue (msau42)
-* Investigate better PV naming scheme - hashing?
 * PV events on deletion failure
 * Configmap for user parameters (ddysher)
 
 ## P2
 * Partitioning, formatting, and mount extensions (needs mount propagation)
 * Block device support (needs API and volume plugin changes too)
-* Independent sync loops for discovery and deleter.

--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -21,8 +21,8 @@ import (
 	"os"
 
 	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/controller"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -56,7 +56,7 @@ func main() {
 	node := getNode(client, nodeName)
 
 	glog.Info("Starting controller\n")
-	controller.StartLocalController(client, &types.UserConfig{
+	controller.StartLocalController(client, &common.UserConfig{
 		Node:         node,
 		HostDir:      "/mnt/disks",
 		MountDir:     "/local-disks",

--- a/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: local-storage-admin
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-pv-binding
@@ -17,7 +17,7 @@ roleRef:
   name: system:persistent-volume-provisioner
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding

--- a/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
@@ -6,7 +6,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
-  name: local-storage-provisioner
+  name: local-storage-provisioner-pv-binding
   namespace: default
 subjects:
 - kind: ServiceAccount
@@ -15,4 +15,18 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:node
   apiGroup: rbac.authorization.k8s.io

--- a/local-volume/provisioner/pkg/cache/cache.go
+++ b/local-volume/provisioner/pkg/cache/cache.go
@@ -32,10 +32,12 @@ type VolumeCache struct {
 	pvs   map[string]*v1.PersistentVolume
 }
 
+// NewVolumeCache creates a new PV cache object for storing PVs created by this provisioner.
 func NewVolumeCache() *VolumeCache {
 	return &VolumeCache{pvs: map[string]*v1.PersistentVolume{}}
 }
 
+// GetPV returns the PV object given the PV name
 func (cache *VolumeCache) GetPV(pvName string) (*v1.PersistentVolume, bool) {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()
@@ -44,6 +46,7 @@ func (cache *VolumeCache) GetPV(pvName string) (*v1.PersistentVolume, bool) {
 	return pv, exists
 }
 
+// AddPV adds the PV object to the cache
 func (cache *VolumeCache) AddPV(pv *v1.PersistentVolume) {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()
@@ -52,6 +55,7 @@ func (cache *VolumeCache) AddPV(pv *v1.PersistentVolume) {
 	glog.Infof("Added pv %q to cache", pv.Name)
 }
 
+// UpdatePV updates the PV object in the cache
 func (cache *VolumeCache) UpdatePV(pv *v1.PersistentVolume) {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()
@@ -60,6 +64,7 @@ func (cache *VolumeCache) UpdatePV(pv *v1.PersistentVolume) {
 	glog.Infof("Updated pv %q to cache", pv.Name)
 }
 
+// DeletePV deletes the PV object from the cache
 func (cache *VolumeCache) DeletePV(pvName string) {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()
@@ -68,6 +73,7 @@ func (cache *VolumeCache) DeletePV(pvName string) {
 	glog.Infof("Deleted pv %q from cache", pvName)
 }
 
+// ListPVs returns a list of all the PVs in the cache
 func (cache *VolumeCache) ListPVs() []*v1.PersistentVolume {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()

--- a/local-volume/provisioner/pkg/cache/cache.go
+++ b/local-volume/provisioner/pkg/cache/cache.go
@@ -33,16 +33,15 @@ type VolumeCache struct {
 }
 
 func NewVolumeCache() *VolumeCache {
-	cache := &VolumeCache{pvs: map[string]*v1.PersistentVolume{}}
-	return cache
+	return &VolumeCache{pvs: map[string]*v1.PersistentVolume{}}
 }
 
-func (cache *VolumeCache) PVExists(pvName string) bool {
+func (cache *VolumeCache) GetPV(pvName string) (*v1.PersistentVolume, bool) {
 	cache.mutex.Lock()
 	defer cache.mutex.Unlock()
 
-	_, exists := cache.pvs[pvName]
-	return exists
+	pv, exists := cache.pvs[pvName]
+	return pv, exists
 }
 
 func (cache *VolumeCache) AddPV(pv *v1.PersistentVolume) {

--- a/local-volume/provisioner/pkg/cache/cache.go
+++ b/local-volume/provisioner/pkg/cache/cache.go
@@ -24,6 +24,9 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+// VolumeCache keeps all the PersistentVolumes that have been created by this provisioner.
+// It is periodically updated by the Populator.
+// The Deleter and Discoverer use the VolumeCache to check on created PVs
 type VolumeCache struct {
 	mutex sync.Mutex
 	pvs   map[string]*v1.PersistentVolume

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package types
+package common
 
 import (
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	AnnProvisionedBy = "pv.kubernetes.io/provisioned-by"
-	// TODO: is this the correct key?
-	NodeLabelKey = "kubernetes.io/hostname"
+	// hostname is not the best choice, but it's what pod and node affinity also use
+	NodeLabelKey = metav1.LabelHostname
 )
 
 type UserConfig struct {

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -27,11 +27,14 @@ import (
 )
 
 const (
+	// External provisioner annotation in PV object
 	AnnProvisionedBy = "pv.kubernetes.io/provisioned-by"
+	// The label key that this provisioner uses for PV node affinity
 	// hostname is not the best choice, but it's what pod and node affinity also use
 	NodeLabelKey = metav1.LabelHostname
 )
 
+// UserConfig stores all the user-defined parameters to the provisioner
 type UserConfig struct {
 	// Node object for this node
 	Node *v1.Node
@@ -43,6 +46,7 @@ type UserConfig struct {
 	DiscoveryMap map[string]string
 }
 
+// RuntimeConfig stores all the objects that the provisioner needs to run
 type RuntimeConfig struct {
 	*UserConfig
 	// Unique name of this provisioner
@@ -57,6 +61,7 @@ type RuntimeConfig struct {
 	VolUtil util.VolumeUtil
 }
 
+// LocalPVConfig defines the parameters for creating a local PV
 type LocalPVConfig struct {
 	Name            string
 	HostPath        string
@@ -65,6 +70,7 @@ type LocalPVConfig struct {
 	AffinityAnn     string
 }
 
+// CreateLocalPVSpec returns a PV spec that can be used for PV creation
 func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -41,7 +41,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 		VolUtil:    util.NewVolumeUtil(),
 		APIUtil:    util.NewAPIUtil(client),
 		Client:     client,
-		Name:       fmt.Sprintf("local-volume-provisioner-%v", config.Node.UID),
+		Name:       fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID),
 	}
 
 	populator := populator.NewPopulator(runtimeConfig)

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -46,7 +46,12 @@ func StartLocalController(client *kubernetes.Clientset, config *types.UserConfig
 
 	populator := populator.NewPopulator(runtimeConfig)
 	populator.Start()
-	discoverer := discovery.NewDiscoverer(runtimeConfig)
+
+	discoverer, err := discovery.NewDiscoverer(runtimeConfig)
+	if err != nil {
+		glog.Fatalf("Error starting discoverer: %v", err)
+	}
+
 	deleter := deleter.NewDeleter(runtimeConfig)
 
 	glog.Info("Controller started\n")

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -23,19 +23,19 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/discovery"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/populator"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
 	"k8s.io/client-go/kubernetes"
 )
 
-func StartLocalController(client *kubernetes.Clientset, config *types.UserConfig) {
+func StartLocalController(client *kubernetes.Clientset, config *common.UserConfig) {
 	glog.Info("Initializing volume cache\n")
 
-	runtimeConfig := &types.RuntimeConfig{
+	runtimeConfig := &common.RuntimeConfig{
 		UserConfig: config,
 		Cache:      cache.NewVolumeCache(),
 		VolUtil:    util.NewVolumeUtil(),

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// StartLocalController starts the sync loop for the local PV discovery and deleter
 func StartLocalController(client *kubernetes.Clientset, config *common.UserConfig) {
 	glog.Info("Initializing volume cache\n")
 

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -40,8 +41,7 @@ func StartLocalController(client *kubernetes.Clientset, config *types.UserConfig
 		VolUtil:    util.NewVolumeUtil(),
 		APIUtil:    util.NewAPIUtil(client),
 		Client:     client,
-		// TODO: make this unique based on node name?
-		Name: "local-volume-provisioner",
+		Name:       fmt.Sprintf("local-volume-provisioner-%v", config.Node.UID),
 	}
 
 	populator := populator.NewPopulator(runtimeConfig)

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -25,20 +25,17 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
-type Deleter interface {
-	// Cleanup and delete all its owned PVs that have been released
-	DeletePVs()
-}
-
-type deleter struct {
+// Deleter handles PV cleanup and object deletion
+// For file-based volumes, it deletes the contents of the directory
+type Deleter struct {
 	*types.RuntimeConfig
 }
 
-func NewDeleter(config *types.RuntimeConfig) Deleter {
-	return &deleter{RuntimeConfig: config}
+func NewDeleter(config *types.RuntimeConfig) *Deleter {
+	return &Deleter{RuntimeConfig: config}
 }
 
-func (d *deleter) DeletePVs() {
+func (d *Deleter) DeletePVs() {
 	for _, pv := range d.Cache.ListPVs() {
 		if pv.Status.Phase == v1.VolumeReleased {
 			name := pv.Name
@@ -66,7 +63,7 @@ func (d *deleter) DeletePVs() {
 	}
 }
 
-func (d *deleter) cleanupPV(pv *v1.PersistentVolume) error {
+func (d *Deleter) cleanupPV(pv *v1.PersistentVolume) error {
 	// path := pv.Spec.Local.Path
 	// TODO: Need to extract the hostDir from the spec path, and replace with mountdir
 	path := "TODO-PLACEHOLDER"

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -32,10 +32,14 @@ type Deleter struct {
 	*common.RuntimeConfig
 }
 
+// NewDeleter creates a Deleter object to handle the cleanup and deletion of local PVs
+// allocated by this provisioner
 func NewDeleter(config *common.RuntimeConfig) *Deleter {
 	return &Deleter{RuntimeConfig: config}
 }
 
+// DeletePVs will scan through all the existing PVs that are released, and cleanup and
+// delete them
 func (d *Deleter) DeletePVs() {
 	for _, pv := range d.Cache.ListPVs() {
 		if pv.Status.Phase == v1.VolumeReleased {

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 
 	"k8s.io/client-go/pkg/api/v1"
 )
@@ -28,10 +28,10 @@ import (
 // Deleter handles PV cleanup and object deletion
 // For file-based volumes, it deletes the contents of the directory
 type Deleter struct {
-	*types.RuntimeConfig
+	*common.RuntimeConfig
 }
 
-func NewDeleter(config *types.RuntimeConfig) *Deleter {
+func NewDeleter(config *common.RuntimeConfig) *Deleter {
 	return &Deleter{RuntimeConfig: config}
 }
 

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -19,11 +19,19 @@ package deleter
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/pkg/api/v1"
+)
+
+const (
+	pollInterval = 1 * time.Second
+	// TODO: is this too fast?
+	waitForDeleteTimeout = 1 * time.Minute
 )
 
 // Deleter handles PV cleanup and object deletion
@@ -37,6 +45,7 @@ func NewDeleter(config *common.RuntimeConfig) *Deleter {
 }
 
 func (d *Deleter) DeletePVs() {
+	deletedPVs := []string{}
 	for _, pv := range d.Cache.ListPVs() {
 		if pv.Status.Phase == v1.VolumeReleased {
 			name := pv.Name
@@ -54,12 +63,26 @@ func (d *Deleter) DeletePVs() {
 			err = d.APIUtil.DeletePV(name)
 			if err != nil {
 				// TODO: Log event on PV
+				// TODO: Does delete return an error if object has already been deleted?
 				glog.Errorf("Error deleting PV %q: %v", name, err.Error())
 				continue
 			}
 
-			d.Cache.DeletePV(name)
+			deletedPVs = append(deletedPVs, name)
 			glog.Infof("Deleted PV %q", name)
+		}
+	}
+
+	// Wait for informer to delete PV objects from cache so we don't try to clean it up again.
+	for _, name := range deletedPVs {
+		err := wait.Poll(pollInterval, waitForDeleteTimeout, func() (bool, error) {
+			if d.Cache.PVExists(name) {
+				return false, nil
+			}
+			return true, nil
+		})
+		if err != nil {
+			glog.Errorf("PV %q not deleted from cache after %v", name, waitForDeleteTimeout)
 		}
 	}
 }

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -30,7 +30,6 @@ import (
 const (
 	testHostDir  = "/mnt/disks"
 	testMountDir = "/discoveryPath"
-	testNode     = "test-node"
 )
 
 type testConfig struct {
@@ -173,7 +172,6 @@ func testSetup(t *testing.T, config *testConfig) *Deleter {
 
 	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail)
 	userConfig := &types.UserConfig{
-		NodeName: testNode,
 		MountDir: testMountDir,
 		HostDir:  testHostDir,
 	}

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -40,7 +40,7 @@ type testConfig struct {
 	vols map[string]*testVol
 	// Expected names of deleted PV
 	expectedDeletedPVs map[string]string
-	// These two interfaces are set during setup
+	// The remaining fields are set during setup
 	volUtil *util.FakeVolumeUtil
 	apiUtil *util.FakeAPIUtil
 	cache   *cache.VolumeCache
@@ -149,7 +149,7 @@ func TestDeleteVolumes_CleanupFails(t *testing.T) {
 	verifyPVExists(t, test)
 }
 
-func testSetup(t *testing.T, config *testConfig) Deleter {
+func testSetup(t *testing.T, config *testConfig) *Deleter {
 	config.volUtil = util.NewFakeVolumeUtil(config.volDeleteShouldFail)
 	config.apiUtil = util.NewFakeAPIUtil(false)
 	config.cache = cache.NewVolumeCache()
@@ -168,10 +168,7 @@ func testSetup(t *testing.T, config *testConfig) Deleter {
 		if err != nil {
 			t.Fatalf("Error creating fake PV: %v", err)
 		}
-		err = config.cache.AddPV(pv)
-		if err != nil {
-			t.Fatalf("Error adding PV to cache: %v", err)
-		}
+		config.cache.AddPV(pv)
 	}
 
 	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail)

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -149,9 +149,9 @@ func TestDeleteVolumes_CleanupFails(t *testing.T) {
 }
 
 func testSetup(t *testing.T, config *testConfig) *Deleter {
-	config.volUtil = util.NewFakeVolumeUtil(config.volDeleteShouldFail)
-	config.apiUtil = util.NewFakeAPIUtil(false, nil)
 	config.cache = cache.NewVolumeCache()
+	config.volUtil = util.NewFakeVolumeUtil(config.volDeleteShouldFail)
+	config.apiUtil = util.NewFakeAPIUtil(false, config.cache)
 
 	fakePath := filepath.Join(testHostDir, "test-dir")
 	// Precreate PVs
@@ -197,7 +197,8 @@ func verifyDeletedPVs(t *testing.T, config *testConfig) {
 			t.Errorf("Did not expect deleted PVs %v", pvName)
 			continue
 		}
-		if config.cache.PVExists(pvName) {
+		_, found = config.cache.GetPV(pvName)
+		if found {
 			t.Errorf("PV %q still exists in cache", pvName)
 		}
 	}
@@ -205,8 +206,9 @@ func verifyDeletedPVs(t *testing.T, config *testConfig) {
 
 func verifyPVExists(t *testing.T, config *testConfig) {
 	for pvName := range config.vols {
-		if !config.cache.PVExists(pvName) {
-			t.Errorf("PV doesn't exists in cache", pvName)
+		_, found := config.cache.GetPV(pvName)
+		if !found {
+			t.Errorf("PV doesn't exist in cache", pvName)
 		}
 	}
 }

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -150,7 +150,7 @@ func TestDeleteVolumes_CleanupFails(t *testing.T) {
 
 func testSetup(t *testing.T, config *testConfig) *Deleter {
 	config.volUtil = util.NewFakeVolumeUtil(config.volDeleteShouldFail)
-	config.apiUtil = util.NewFakeAPIUtil(false)
+	config.apiUtil = util.NewFakeAPIUtil(false, nil)
 	config.cache = cache.NewVolumeCache()
 
 	fakePath := filepath.Join(testHostDir, "test-dir")
@@ -169,7 +169,7 @@ func testSetup(t *testing.T, config *testConfig) *Deleter {
 		config.cache.AddPV(pv)
 	}
 
-	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail)
+	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail, config.cache)
 	userConfig := &common.UserConfig{
 		MountDir: testMountDir,
 		HostDir:  testHostDir,

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -51,19 +51,19 @@ type testVol struct {
 
 func TestDeleteVolumes_Basic(t *testing.T) {
 	vols := map[string]*testVol{
-		"pv1": &testVol{
+		"pv1": {
 			pvPhase: v1.VolumePending,
 		},
-		"pv2": &testVol{
+		"pv2": {
 			pvPhase: v1.VolumeAvailable,
 		},
-		"pv3": &testVol{
+		"pv3": {
 			pvPhase: v1.VolumeBound,
 		},
-		"pv4": &testVol{
+		"pv4": {
 			pvPhase: v1.VolumeReleased,
 		},
-		"pv5": &testVol{
+		"pv5": {
 			pvPhase: v1.VolumeFailed,
 		},
 	}
@@ -80,7 +80,7 @@ func TestDeleteVolumes_Basic(t *testing.T) {
 
 func TestDeleteVolumes_Twice(t *testing.T) {
 	vols := map[string]*testVol{
-		"pv4": &testVol{
+		"pv4": {
 			pvPhase: v1.VolumeReleased,
 		},
 	}
@@ -114,7 +114,7 @@ func TestDeleteVolumes_Empty(t *testing.T) {
 
 func TestDeleteVolumes_DeletePVFails(t *testing.T) {
 	vols := map[string]*testVol{
-		"pv4": &testVol{
+		"pv4": {
 			pvPhase: v1.VolumeReleased,
 		},
 	}
@@ -132,7 +132,7 @@ func TestDeleteVolumes_DeletePVFails(t *testing.T) {
 
 func TestDeleteVolumes_CleanupFails(t *testing.T) {
 	vols := map[string]*testVol{
-		"pv4": &testVol{
+		"pv4": {
 			pvPhase: v1.VolumeReleased,
 		},
 	}
@@ -208,7 +208,7 @@ func verifyPVExists(t *testing.T, config *testConfig) {
 	for pvName := range config.vols {
 		_, found := config.cache.GetPV(pvName)
 		if !found {
-			t.Errorf("PV doesn't exist in cache", pvName)
+			t.Errorf("PV %q doesn't exist in cache", pvName)
 		}
 	}
 }

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,11 +171,11 @@ func testSetup(t *testing.T, config *testConfig) *Deleter {
 	}
 
 	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail)
-	userConfig := &types.UserConfig{
+	userConfig := &common.UserConfig{
 		MountDir: testMountDir,
 		HostDir:  testHostDir,
 	}
-	runtimeConfig := &types.RuntimeConfig{
+	runtimeConfig := &common.RuntimeConfig{
 		UserConfig: userConfig,
 		Cache:      config.cache,
 		VolUtil:    config.volUtil,

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package deleter
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -153,16 +153,15 @@ func testSetup(t *testing.T, config *testConfig) *Deleter {
 	config.apiUtil = util.NewFakeAPIUtil(false)
 	config.cache = cache.NewVolumeCache()
 
+	fakePath := filepath.Join(testHostDir, "test-dir")
 	// Precreate PVs
 	for pvName, vol := range config.vols {
-		pv := &v1.PersistentVolume{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: pvName,
-			},
-			Status: v1.PersistentVolumeStatus{
-				Phase: vol.pvPhase,
-			},
-		}
+		pv := common.CreateLocalPVSpec(&common.LocalPVConfig{
+			Name:     pvName,
+			HostPath: fakePath,
+		})
+		pv.Status.Phase = vol.pvPhase
+
 		_, err := config.apiUtil.CreatePV(pv)
 		if err != nil {
 			t.Fatalf("Error creating fake PV: %v", err)

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -35,6 +35,8 @@ type Discoverer struct {
 	nodeAffinityAnn string
 }
 
+// NewDiscoverer creates a Discoverer object that will scan through
+// the configured directories and create local PVs for any new directories found
 func NewDiscoverer(config *common.RuntimeConfig) (*Discoverer, error) {
 	affinity, err := generateNodeAffinity(config.Node)
 	if err != nil {

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+// Discoverer finds available volumes and creates PVs for them
+// It looks for volumes in the directories specified in the discoveryMap
 type Discoverer struct {
 	*types.RuntimeConfig
 }

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -57,7 +57,7 @@ func (d *Discoverer) discoverVolumesAtPath(class, relativePath string) {
 
 	for _, file := range files {
 		// Check if PV already exists for it
-		pvName := generatePVName(file, d.NodeName, class)
+		pvName := generatePVName(file, d.Node.Name, class)
 		if !d.Cache.PVExists(pvName) {
 			filePath := filepath.Join(fullPath, file)
 			err = d.validateFile(filePath)
@@ -88,7 +88,7 @@ func generatePVName(file, node, class string) string {
 }
 
 func (d *Discoverer) createPV(file, relativePath, class string) {
-	pvName := generatePVName(file, d.NodeName, class)
+	pvName := generatePVName(file, d.Node.Name, class)
 	outsidePath := filepath.Join(d.HostDir, relativePath, file)
 
 	glog.Infof("Found new volume at host path %q, creating Local PV %q", outsidePath, pvName)

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -68,13 +68,13 @@ type testConfig struct {
 
 func TestDiscoverVolumes_Basic(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
-			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
+		"dir1": {
+			{Name: "mount1", Hash: 0xaaaafef5},
+			{Name: "mount2", Hash: 0x79412c38},
 		},
-		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
-			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
+		"dir2": {
+			{Name: "mount1", Hash: 0xa7aafa3c},
+			{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -89,13 +89,13 @@ func TestDiscoverVolumes_Basic(t *testing.T) {
 
 func TestDiscoverVolumes_BasicTwice(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
-			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
+		"dir1": {
+			{Name: "mount1", Hash: 0xaaaafef5},
+			{Name: "mount2", Hash: 0x79412c38},
 		},
-		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
-			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
+		"dir2": {
+			{Name: "mount1", Hash: 0xa7aafa3c},
+			{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -127,7 +127,7 @@ func TestDiscoverVolumes_NoDir(t *testing.T) {
 
 func TestDiscoverVolumes_EmptyDir(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{},
+		"dir1": {},
 	}
 	test := &testConfig{
 		dirLayout:       vols,
@@ -141,13 +141,13 @@ func TestDiscoverVolumes_EmptyDir(t *testing.T) {
 
 func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
-			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
+		"dir1": {
+			{Name: "mount1", Hash: 0xaaaafef5},
+			{Name: "mount2", Hash: 0x79412c38},
 		},
-		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
-			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
+		"dir2": {
+			{Name: "mount1", Hash: 0xa7aafa3c},
+			{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -162,9 +162,9 @@ func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 
 	// Some new mount points show up
 	newVols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount3", Hash: 0xf34b8003},
-			&util.FakeFile{Name: "mount4", Hash: 0x144e29de},
+		"dir1": {
+			{Name: "mount3", Hash: 0xf34b8003},
+			{Name: "mount4", Hash: 0x144e29de},
 		},
 	}
 	test.volUtil.AddNewFiles(testMountDir, newVols)
@@ -177,13 +177,13 @@ func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 
 func TestDiscoverVolumes_CreatePVFails(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
-			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
+		"dir1": {
+			{Name: "mount1", Hash: 0xaaaafef5},
+			{Name: "mount2", Hash: 0x79412c38},
 		},
-		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
-			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
+		"dir2": {
+			{Name: "mount1", Hash: 0xa7aafa3c},
+			{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -201,8 +201,8 @@ func TestDiscoverVolumes_CreatePVFails(t *testing.T) {
 
 func TestDiscoverVolumes_BadVolume(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
-		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1", IsNotDir: true},
+		"dir1": {
+			{Name: "mount1", IsNotDir: true},
 		},
 	}
 	test := &testConfig{

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -22,11 +22,11 @@ import (
 	"testing"
 
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ktypes "k8s.io/apimachinery/pkg/types"
+	kcommon "k8s.io/apimachinery/pkg/common"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -34,7 +34,7 @@ const (
 	testHostDir         = "/mnt/disks"
 	testMountDir        = "/discoveryPath"
 	testNodeName        = "test-node"
-	testNodeUID         = ktypes.UID(1234)
+	testNodeUID         = kcommon.UID(1234)
 	testProvisionerName = "test-provisioner"
 )
 
@@ -43,7 +43,7 @@ var testNode = &v1.Node{
 		Name: testNodeName,
 		UID:  testNodeUID,
 		Labels: map[string]string{
-			types.NodeLabelKey: testNodeName,
+			common.NodeLabelKey: testNodeName,
 		},
 	},
 }
@@ -225,13 +225,13 @@ func testSetup(t *testing.T, test *testConfig) *Discoverer {
 	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail)
 	test.cache = cache.NewVolumeCache()
 
-	userConfig := &types.UserConfig{
+	userConfig := &common.UserConfig{
 		Node:         testNode,
 		MountDir:     testMountDir,
 		HostDir:      testHostDir,
 		DiscoveryMap: scMapping,
 	}
-	runConfig := &types.RuntimeConfig{
+	runConfig := &common.RuntimeConfig{
 		UserConfig: userConfig,
 		Cache:      test.cache,
 		VolUtil:    test.volUtil,
@@ -276,8 +276,8 @@ func verifyNodeAffinity(t *testing.T, pv *v1.PersistentVolume) {
 		return
 	}
 	req := reqs[0]
-	if req.Key != types.NodeLabelKey {
-		t.Errorf("Node selector requirement key is %v, expected %v", req.Key, types.NodeLabelKey)
+	if req.Key != common.NodeLabelKey {
+		t.Errorf("Node selector requirement key is %v, expected %v", req.Key, common.NodeLabelKey)
 	}
 	if req.Operator != v1.NodeSelectorOpIn {
 		t.Errorf("Node selector requirement operator is %v, expected %v", req.Operator, v1.NodeSelectorOpIn)
@@ -296,7 +296,7 @@ func verifyProvisionerName(t *testing.T, pv *v1.PersistentVolume) {
 		t.Errorf("Annotations not set")
 		return
 	}
-	name, found := pv.Annotations[types.AnnProvisionedBy]
+	name, found := pv.Annotations[common.AnnProvisionedBy]
 	if !found {
 		t.Errorf("Provisioned by annotations not set")
 		return

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/pkg/api/v1"
 	v1helper "k8s.io/client-go/pkg/api/v1/helper"
 )
@@ -35,14 +34,12 @@ const (
 	testHostDir         = "/mnt/disks"
 	testMountDir        = "/discoveryPath"
 	testNodeName        = "test-node"
-	testNodeUID         = types.UID(1234)
 	testProvisionerName = "test-provisioner"
 )
 
 var testNode = &v1.Node{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: testNodeName,
-		UID:  testNodeUID,
 		Labels: map[string]string{
 			common.NodeLabelKey: testNodeName,
 		},

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"k8s.io/client-go/pkg/api/v1"
+
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
@@ -29,8 +31,12 @@ import (
 const (
 	testHostDir  = "/mnt/disks"
 	testMountDir = "/discoveryPath"
-	testNode     = "test-node"
+	testNodeName = "test-node"
 )
+
+var testNode = &v1.Node{
+	Name: testNodeName,
+}
 
 var scMapping = map[string]string{
 	"sc1": "dir1",
@@ -210,7 +216,7 @@ func testSetup(t *testConfig) *Discoverer {
 	t.cache = cache.NewVolumeCache()
 
 	userConfig := &types.UserConfig{
-		NodeName:     testNode,
+		Node:         testNode,
 		MountDir:     testMountDir,
 		HostDir:      testHostDir,
 		DiscoveryMap: scMapping,

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -71,12 +71,12 @@ type testConfig struct {
 func TestDiscoverVolumes_Basic(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
 		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
+			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
 		},
 		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
+			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -92,12 +92,12 @@ func TestDiscoverVolumes_Basic(t *testing.T) {
 func TestDiscoverVolumes_BasicTwice(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
 		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
+			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
 		},
 		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
+			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -144,12 +144,12 @@ func TestDiscoverVolumes_EmptyDir(t *testing.T) {
 func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
 		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
+			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
 		},
 		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
+			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -165,8 +165,8 @@ func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 	// Some new mount points show up
 	newVols := map[string][]*util.FakeFile{
 		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount3"},
-			&util.FakeFile{Name: "mount4"},
+			&util.FakeFile{Name: "mount3", Hash: 0xf34b8003},
+			&util.FakeFile{Name: "mount4", Hash: 0x144e29de},
 		},
 	}
 	test.volUtil.AddNewFiles(testMountDir, newVols)
@@ -180,12 +180,12 @@ func TestDiscoverVolumes_NewVolumesLater(t *testing.T) {
 func TestDiscoverVolumes_CreatePVFails(t *testing.T) {
 	vols := map[string][]*util.FakeFile{
 		"dir1": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xaaaafef5},
+			&util.FakeFile{Name: "mount2", Hash: 0x79412c38},
 		},
 		"dir2": []*util.FakeFile{
-			&util.FakeFile{Name: "mount1"},
-			&util.FakeFile{Name: "mount2"},
+			&util.FakeFile{Name: "mount1", Hash: 0xa7aafa3c},
+			&util.FakeFile{Name: "mount2", Hash: 0x7c4130f1},
 		},
 	}
 	test := &testConfig{
@@ -309,9 +309,8 @@ func verifyProvisionerName(t *testing.T, pv *v1.PersistentVolume) {
 func verifyCreatedPVs(t *testing.T, test *testConfig) {
 	expectedPVs := map[string]string{}
 	for dir, files := range test.expectedVolumes {
-		sc := findSCName(t, dir, test)
 		for _, file := range files {
-			pvName := fmt.Sprintf("%v-%v-%v", sc, testNodeName, file.Name)
+			pvName := fmt.Sprintf("local-pv-%x", file.Hash)
 			path := filepath.Join(testHostDir, dir, file.Name)
 			expectedPVs[pvName] = path
 		}
@@ -338,6 +337,7 @@ func verifyCreatedPVs(t *testing.T, test *testConfig) {
 		if !test.cache.PVExists(pvName) {
 			t.Errorf("PV %q not in cache", pvName)
 		}
+		// TODO: verify storage class
 		verifyProvisionerName(t, pv)
 		verifyNodeAffinity(t, pv)
 	}

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -223,7 +223,7 @@ func TestDiscoverVolumes_BadVolume(t *testing.T) {
 func testSetup(t *testing.T, test *testConfig) *Discoverer {
 	test.volUtil = util.NewFakeVolumeUtil(false)
 	test.volUtil.AddNewFiles(testMountDir, test.dirLayout)
-	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail)
+	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, nil)
 	test.cache = cache.NewVolumeCache()
 
 	userConfig := &common.UserConfig{

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -31,6 +31,7 @@ import (
 	kcache "k8s.io/client-go/tools/cache"
 )
 
+// The Populator uses an Informer to populate the VolumeCache.
 type Populator struct {
 	*types.RuntimeConfig
 }

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -36,10 +36,12 @@ type Populator struct {
 	*common.RuntimeConfig
 }
 
+// NewPopulator returns a Populator object to update the PV cache
 func NewPopulator(config *common.RuntimeConfig) *Populator {
 	return &Populator{RuntimeConfig: config}
 }
 
+// Start launches the PV informer
 func (p *Populator) Start() {
 	_, controller := kcache.NewInformer(
 		&kcache.ListWatch{

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/types"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,10 +33,10 @@ import (
 
 // The Populator uses an Informer to populate the VolumeCache.
 type Populator struct {
-	*types.RuntimeConfig
+	*common.RuntimeConfig
 }
 
-func NewPopulator(config *types.RuntimeConfig) *Populator {
+func NewPopulator(config *common.RuntimeConfig) *Populator {
 	return &Populator{RuntimeConfig: config}
 }
 
@@ -98,7 +98,7 @@ func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
 		p.Cache.UpdatePV(pv)
 	} else {
 		if pv.Annotations != nil {
-			provisioner, found := pv.Annotations[types.AnnProvisionedBy]
+			provisioner, found := pv.Annotations[common.AnnProvisionedBy]
 			if !found {
 				return
 			}

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -81,7 +81,7 @@ func (p *Populator) Start() {
 	)
 
 	glog.Infof("Starting Informer controller")
-	// Controller never stops TODO: will this go out of scope and stop the controller?
+	// Controller never stops
 	go controller.Run(make(chan struct{}))
 
 	glog.Infof("Waiting for Informer initial sync")

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -48,6 +48,7 @@ func (p *Populator) Start() {
 				return pvs, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				// TODO: can we just watch for changes on the phase field?
 				w, err := p.Client.Core().PersistentVolumes().Watch(options)
 				return w, err
 			},

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -95,7 +95,8 @@ func (p *Populator) Start() {
 }
 
 func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
-	if p.Cache.PVExists(pv.Name) {
+	_, exists := p.Cache.GetPV(pv.Name)
+	if exists {
 		p.Cache.UpdatePV(pv)
 	} else {
 		if pv.Annotations != nil {
@@ -112,7 +113,8 @@ func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
 }
 
 func (p *Populator) handlePVDelete(pv *v1.PersistentVolume) {
-	if p.Cache.PVExists(pv.Name) {
+	_, exists := p.Cache.GetPV(pv.Name)
+	if exists {
 		// Don't do cleanup, just delete from cache
 		p.Cache.DeletePV(pv.Name)
 	}

--- a/local-volume/provisioner/pkg/types/types.go
+++ b/local-volume/provisioner/pkg/types/types.go
@@ -25,6 +25,8 @@ import (
 
 const (
 	AnnProvisionedBy = "pv.kubernetes.io/provisioned-by"
+	// TODO: is this the correct key?
+	NodeLabelKey = "kubernetes.io/hostname"
 )
 
 type UserConfig struct {

--- a/local-volume/provisioner/pkg/types/types.go
+++ b/local-volume/provisioner/pkg/types/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 const (
@@ -27,9 +28,8 @@ const (
 )
 
 type UserConfig struct {
-	// Name of the node this is running on
-	// TODO: Need to resolve nodename vs hostname
-	NodeName string
+	// Node object for this node
+	Node *v1.Node
 	// The hostpath directory
 	HostDir string
 	// The mount point of the hostpath volume

--- a/local-volume/provisioner/pkg/util/api_util.go
+++ b/local-volume/provisioner/pkg/util/api_util.go
@@ -41,20 +41,24 @@ type apiUtil struct {
 	client *kubernetes.Clientset
 }
 
+// NewAPIUtil creates a new APIUtil object that represents the K8s API
 func NewAPIUtil(client *kubernetes.Clientset) APIUtil {
 	return &apiUtil{client: client}
 }
 
+// CreatePV will create a PersistentVolume
 func (u *apiUtil) CreatePV(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	return u.client.Core().PersistentVolumes().Create(pv)
 }
 
+// DeletePV will delete a PersistentVolume
 func (u *apiUtil) DeletePV(pvName string) error {
 	return u.client.Core().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
 }
 
 var _ APIUtil = &FakeAPIUtil{}
 
+// FakeAPIUtil is a fake API wrapper for unit testing
 type FakeAPIUtil struct {
 	createdPVs map[string]*v1.PersistentVolume
 	deletedPVs map[string]*v1.PersistentVolume
@@ -62,6 +66,7 @@ type FakeAPIUtil struct {
 	cache      *cache.VolumeCache
 }
 
+// NewFakeAPIUtil returns an APIUtil object that can be used for unit testing
 func NewFakeAPIUtil(shouldFail bool, cache *cache.VolumeCache) *FakeAPIUtil {
 	return &FakeAPIUtil{
 		createdPVs: map[string]*v1.PersistentVolume{},
@@ -71,6 +76,7 @@ func NewFakeAPIUtil(shouldFail bool, cache *cache.VolumeCache) *FakeAPIUtil {
 	}
 }
 
+// CreatePV will add the PV to the created list and cache
 func (u *FakeAPIUtil) CreatePV(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	if u.shouldFail {
 		return nil, fmt.Errorf("API failed")
@@ -81,6 +87,7 @@ func (u *FakeAPIUtil) CreatePV(pv *v1.PersistentVolume) (*v1.PersistentVolume, e
 	return pv, nil
 }
 
+// DeletePV will delete the PV from the created list and cache, and also add it to the deleted list
 func (u *FakeAPIUtil) DeletePV(pvName string) error {
 	if u.shouldFail {
 		return fmt.Errorf("API failed")

--- a/local-volume/provisioner/pkg/util/api_util.go
+++ b/local-volume/provisioner/pkg/util/api_util.go
@@ -19,6 +19,8 @@ package util
 import (
 	"fmt"
 
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
@@ -58,14 +60,16 @@ type FakeAPIUtil struct {
 	createdPVs map[string]*v1.PersistentVolume
 	deletedPVs map[string]*v1.PersistentVolume
 	shouldFail bool
+	cache      *cache.VolumeCache
 }
 
-func NewFakeAPIUtil(shouldFail bool) *FakeAPIUtil {
+func NewFakeAPIUtil(shouldFail bool, cache *cache.VolumeCache) *FakeAPIUtil {
 	return &FakeAPIUtil{
 		allPVs:     map[string]*v1.PersistentVolume{},
 		createdPVs: map[string]*v1.PersistentVolume{},
 		deletedPVs: map[string]*v1.PersistentVolume{},
 		shouldFail: shouldFail,
+		cache:      cache,
 	}
 }
 
@@ -87,6 +91,9 @@ func (u *FakeAPIUtil) DeletePV(pvName string) error {
 	u.deletedPVs[pvName] = u.allPVs[pvName]
 	delete(u.allPVs, pvName)
 	delete(u.createdPVs, pvName)
+	if u.cache != nil {
+		u.cache.DeletePV(pvName)
+	}
 	return nil
 }
 

--- a/local-volume/provisioner/pkg/util/api_util.go
+++ b/local-volume/provisioner/pkg/util/api_util.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+// APIUtil is an interface for the K8s API
 type APIUtil interface {
 	// Create PersistentVolume object
 	CreatePV(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)

--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -107,6 +107,8 @@ type FakeVolumeUtil struct {
 type FakeFile struct {
 	Name     string
 	IsNotDir bool
+	// Expected hash value of the PV name
+	Hash uint32
 }
 
 func NewFakeVolumeUtil(deleteShouldFail bool) *FakeVolumeUtil {

--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 )
 
+// VolumeUtil is an interface for local filesystem operations
 type VolumeUtil interface {
 	// IsDir checks if the given path is a directory
 	IsDir(fullPath string) (bool, error)

--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -40,10 +40,12 @@ var _ VolumeUtil = &volumeUtil{}
 
 type volumeUtil struct{}
 
+// NewVolumeUtil returns a VolumeUtil object for performing local filesystem operations
 func NewVolumeUtil() VolumeUtil {
 	return &volumeUtil{}
 }
 
+// IsDir checks if the given path is a directory
 func (u *volumeUtil) IsDir(fullPath string) (bool, error) {
 	dir, err := os.Open(fullPath)
 	if err != nil {
@@ -59,6 +61,7 @@ func (u *volumeUtil) IsDir(fullPath string) (bool, error) {
 	return stat.IsDir(), nil
 }
 
+// ReadDir returns a list all the files under the given directory
 func (u *volumeUtil) ReadDir(fullPath string) ([]string, error) {
 	dir, err := os.Open(fullPath)
 	if err != nil {
@@ -73,6 +76,7 @@ func (u *volumeUtil) ReadDir(fullPath string) ([]string, error) {
 	return files, nil
 }
 
+// DeleteContents deletes all the contents under the given directory
 func (u *volumeUtil) DeleteContents(fullPath string) error {
 	dir, err := os.Open(fullPath)
 	if err != nil {
@@ -97,6 +101,7 @@ func (u *volumeUtil) DeleteContents(fullPath string) error {
 
 var _ VolumeUtil = &FakeVolumeUtil{}
 
+// FakeVolumeUtil is a stub interface for unit testing
 type FakeVolumeUtil struct {
 	// List of files underneath the given path
 	directoryFiles map[string][]*FakeFile
@@ -104,6 +109,7 @@ type FakeVolumeUtil struct {
 	deleteShouldFail bool
 }
 
+// FakeFile contains a representation of a file under a directory
 type FakeFile struct {
 	Name     string
 	IsNotDir bool
@@ -111,6 +117,7 @@ type FakeFile struct {
 	Hash uint32
 }
 
+// NewFakeVolumeUtil returns a VolumeUtil object for use in unit testing
 func NewFakeVolumeUtil(deleteShouldFail bool) *FakeVolumeUtil {
 	return &FakeVolumeUtil{
 		directoryFiles:   map[string][]*FakeFile{},
@@ -118,6 +125,7 @@ func NewFakeVolumeUtil(deleteShouldFail bool) *FakeVolumeUtil {
 	}
 }
 
+// IsDir checks if the given path is a directory
 func (u *FakeVolumeUtil) IsDir(fullPath string) (bool, error) {
 	dir, file := filepath.Split(fullPath)
 	dir = filepath.Clean(dir)
@@ -134,6 +142,7 @@ func (u *FakeVolumeUtil) IsDir(fullPath string) (bool, error) {
 	return false, fmt.Errorf("File %q not found", fullPath)
 }
 
+// ReadDir returns the list of all files under the given directory
 func (u *FakeVolumeUtil) ReadDir(fullPath string) ([]string, error) {
 	fileNames := []string{}
 	files, found := u.directoryFiles[fullPath]
@@ -146,6 +155,7 @@ func (u *FakeVolumeUtil) ReadDir(fullPath string) ([]string, error) {
 	return fileNames, nil
 }
 
+// DeleteContents removes all the contents under the given directory
 func (u *FakeVolumeUtil) DeleteContents(fullPath string) error {
 	if u.deleteShouldFail {
 		return fmt.Errorf("Fake delete contents failed")


### PR DESCRIPTION
This PR makes the local storage provisioner functional, and also addresses the comments from the last review.  Changes include:
* Using the new local volume API
* Using the new storage node affinity annotation
* Make each provisioner use the node UUID in its name
* Generate FNV hash as the PV name
* Only have informer update the cache
