### PR TITLE
Fix issue 149 - nfs-client-provisioner create folder with 755, not 777

### DIFF
--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -65,6 +65,7 @@ func (p *nfsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 	if err := os.MkdirAll(fullPath, 0777); err != nil {
 		return nil, errors.New("unable to create directory to provision new pv: " + err.Error())
 	}
+	os.Chmod(fullPath, 0777)
 
 	path := filepath.Join(p.path, pvName)
 


### PR DESCRIPTION
REF:
https://github.com/kubernetes-incubator/external-storage/issues/149