### PR TITLE
local-volume README updates

### DIFF
--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -75,7 +75,7 @@ TODO: TBD
 
 3. Launch the DaemonSet
 ``` console
-$ kubectl create -f provisioner/deployment/kubernetes/provisioner_daemonset.yaml
+$ kubectl create -f provisioner/deployment/kubernetes/provisioner-daemonset.yaml
 ```
 
 ### Specifying local PV

--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -63,6 +63,26 @@ gcloud alpha container node-pools create ... --local-ssd-count=<n>
    configurable in the future.
 3. Configure a Kubernetes cluster with the `PersistentLocalVolumes` feature gate.
 
+#### Local test cluster
+
+1. Create `/mnt/disks` directory and mount several volumes into its subdirectories. The example
+   below uses three ram disks to simulate real local volumes:
+```console
+$ mkdir /mnt/disks
+$ for vol in vol1 vol2 vol3; do
+    mkdir /mnt/disks/$vol
+    mount -t tmpfs $vol /mnt/disks/$vol
+done
+```
+
+2. Run the local cluster.
+```console
+$ ALLOW_PRIVILEGED=true LOG_LEVEL=5 FEATURE_GATES=PersistentLocalVolumes=true hack/local-up-cluster.sh
+```
+
+3. Continue with [Running the external static provisioner](#running-the-external-static-provisioner)
+   below.
+
 ### Running the external static provisioner
 This is optional, only for automated creation and cleanup of local volumes.
 See `provisioner/` for details and sample configuration files.

--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -58,7 +58,9 @@ gcloud alpha container node-pools create ... --local-ssd-count=<n>
 
 #### Baremetal environments
 1. Partition and format the disks on each node according to your application's requirements.
-2. Mount all the filesystems under one directory per StorageClass.
+2. Mount all the filesystems under one directory per StorageClass. The directory is currently
+   specified in the daemonset pod definition (`/mnt/disks` by default) and may be more
+   configurable in the future.
 3. Configure a Kubernetes cluster with the `PersistentLocalVolumes` feature gate.
 
 ### Running the external static provisioner
@@ -69,9 +71,9 @@ See `provisioner/` for details and sample configuration files.
 ``` console
 $ kubectl create -f provisioner/deployment/kubernetes/admin_account.yaml
 ```
-2. Create a ConfigMap with your local storage configuration details.
-The default StorageClass is `local-storage`.
-TODO: TBD
+2. Create a ConfigMap with your local storage configuration details. There is nothing to configure at this
+point, the default StorageClass is hardcoded to `local-storage`.
+TBD: fill in the details and examples as the provisioner becomes more configurable.
 
 3. Launch the DaemonSet
 ``` console


### PR DESCRIPTION
- fix a typo in daemonset file name
- explicitly write that there is nothing to configure at this point
- add an example how to test with `hack/local-up-cluster.sh` that everybody loves