### PR TITLE
Enable repo verify-go-src & local-volume build+test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 services: docker
 
 env:
-# - TEST_SUITE=local-volume
+  - TEST_SUITE=local-volume
   - TEST_SUITE=everything-else
   - TEST_SUITE=nfs ETCD_VER=v3.0.14 KUBE_VERSION=1.5.4
   - TEST_SUITE=nfs ETCD_VER=v3.0.17 KUBE_VERSION=1.6.0

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,15 @@
 # limitations under the License.
 
 clean: clean-aws/efs clean-ceph/cephfs clean-flex clean-gluster/block clean-local-volume/provisioner clean-nfs-client clean-nfs
+.PHONY: clean
 
 test: test-aws/efs test-local-volume/provisioner test-nfs
+.PHONY: test
+
+verify:
+	repo-infra/verify/verify-go-src.sh -v
+	repo-infra/verify/verify-boilerplate.sh
+.PHONY: verify
 
 aws/efs:
 	cd aws/efs; \

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	// External provisioner annotation in PV object
+	// AnnProvisionedBy is the external provisioner annotation in PV object
 	AnnProvisionedBy = "pv.kubernetes.io/provisioned-by"
-	// The label key that this provisioner uses for PV node affinity
+	// NodeLabelKey is the label key that this provisioner uses for PV node affinity
 	// hostname is not the best choice, but it's what pod and node affinity also use
 	NodeLabelKey = metav1.LabelHostname
 )

--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -181,6 +181,7 @@ func (u *FakeVolumeUtil) DeleteContents(fullPath string) error {
 	return nil
 }
 
+// GetFsAvailableByte returns available capacity in byte about a mounted filesystem.
 func (u *FakeVolumeUtil) GetFsAvailableByte(fullPath string) (uint64, error) {
 	dir, file := filepath.Split(fullPath)
 	dir = filepath.Clean(dir)

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,7 @@ go get -u github.com/golang/lint/golint
 export PATH=$PATH:$GOPATH/bin
 go get -u github.com/alecthomas/gometalinter
 gometalinter --install
-#repo-infra/verify/verify-go-src.sh -v
+repo-infra/verify/verify-go-src.sh -v
 repo-infra/verify/verify-boilerplate.sh
 
 if [ "$TEST_SUITE" = "nfs" ]; then

--- a/test.sh
+++ b/test.sh
@@ -25,8 +25,7 @@ go get -u github.com/golang/lint/golint
 export PATH=$PATH:$GOPATH/bin
 go get -u github.com/alecthomas/gometalinter
 gometalinter --install
-repo-infra/verify/verify-go-src.sh -v
-repo-infra/verify/verify-boilerplate.sh
+make verify
 
 if [ "$TEST_SUITE" = "nfs" ]; then
 	# Install nfs, cfssl


### PR DESCRIPTION
At the moment, NFS build+integration+e2e tests takes about 12 minutes, so should keep all "suites" under that time. The NFS build can definitely be shortened (in the future) though.