### PR TITLE
 Have travis push to quay when commit tagged with <provisioner>-v#.#.#

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ install: true
 
 script:
   - ./test.sh
+
+deploy:
+  - provider: script
+    script: ./deploy.sh
+    on:
+      tags: true
+      conditions: $TEST_SUITE = everything-else

--- a/aws/efs/Makefile
+++ b/aws/efs/Makefile
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE = quay.io/external_storage/efs-provisioner
-# TODO
-VERSION = latest
+ifeq ($(REGISTRY),)
+	REGISTRY = quay.io/external_storage/
+endif
+ifeq ($(VERSION),)
+	VERSION = latest
+endif
+IMAGE = $(REGISTRY)efs-provisioner:$(VERSION)
+MUTABLE_IMAGE = $(REGISTRY)efs-provisioner:latest
 
 all build:
 	@mkdir -p .go/src/github.com/kubernetes-incubator/external-storage/aws/efs/vendor
@@ -39,11 +44,13 @@ container: build quick-container
 .PHONY: container
 
 quick-container:
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build -t $(MUTABLE_IMAGE) .
+	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 .PHONY: quick-container
 
 push: container
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE)
+	docker push $(MUTABLE_IMAGE)
 .PHONY: push
 
 test:

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export REGISTRY=quay.io/external_storage/
+
+docker login -e="${QUAY_EMAIL}" -u "${QUAY_USERNAME}" -p "${QUAY_PASSWORD}" quay.io
+
+provisioners=(
+efs-provisioner
+cephfs-provisioner
+glusterblock-provisioner
+local-volume
+nfs-client-provisioner
+nfs-provisioner
+)
+
+regex="^($(IFS=\|; echo "${provisioners[*]}"))-(v[0-9]\.[0-9]\.[0-9])$"
+if [[ "${TRAVIS_TAG}" =~ $regex ]]; then
+	PROVISIONER="${BASH_REMATCH[1]}"
+	export VERSION="${BASH_REMATCH[2]}"
+	if [[ "${PROVISIONER}" = nfs-provisioner ]]; then
+		export REGISTRY=quay.io/kubernetes_incubator/
+	fi
+	echo "Pushing image '${PROVISIONER}' with tags '${VERSION}' and 'latest' to '${REGISTRY}'."
+	make push-"${PROVISIONER}"
+else
+	echo "Nothing to deploy"
+fi
+

--- a/gluster/block/Makefile
+++ b/gluster/block/Makefile
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE = quay.io/external_storage/glusterblock-provisioner
-# TODO
-VERSION = latest
+ifeq ($(REGISTRY),)
+	REGISTRY = quay.io/external_storage/
+endif
+ifeq ($(VERSION),)
+	VERSION = latest
+endif
+IMAGE = $(REGISTRY)glusterblock-provisioner:$(VERSION)
+MUTABLE_IMAGE = $(REGISTRY)glusterblock-provisioner:latest
 
 all build:
 	@mkdir -p .go/src/github.com/kubernetes-incubator/external-storage/gluster/block/vendor
@@ -39,28 +44,18 @@ container: build quick-container
 .PHONY: container
 
 quick-container:
-	docker build -t $(IMAGE):$(VERSION) .
+	docker build -t $(MUTABLE_IMAGE) .
+	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 .PHONY: quick-container
 
 push: container
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE)
+	docker push $(MUTABLE_IMAGE)
 .PHONY: push
 
-test: verify
+test:
 	go test `go list ./... | grep -v 'vendor'`
 .PHONY: test
-
-verify:
-	@tput bold; echo Running gofmt:; tput sgr0
-	(gofmt -s -w -l `find . -type f -name "*.go" | grep -v vendor`) || exit 1
-	@tput bold; echo Running golint and go vet:; tput sgr0
-	for i in $$(find . -type f -name "*.go" | grep -v 'vendor\|minmax'); do \
-		golint --set_exit_status $$i || exit 1; \
-		go vet $$i; \
-	done
-	@tput bold; echo Running verify-boilerplate; tput sgr0
-	../../repo-infra/verify/verify-boilerplate.sh
-.PHONY: verify
 
 clean:
 	rm -rf .go


### PR DESCRIPTION
fix https://github.com/kubernetes-incubator/external-storage/issues/163

Method largely copied from service-catalog. The difference being we have a half dozen images to push in an identical-ish way, so lots of duplicate scripting. Will need to put this to the test, let's start by tagging all currently unversioned provisioners with v0.0.1