### PR TITLE
Release nfs-client v2.0.0, efs v0.1.0, cephfs v0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ deploy:
     script: ./deploy.sh
     on:
       tags: true
-      conditions: $TEST_SUITE = everything-else
+      condition: $TEST_SUITE = everything-else

--- a/aws/efs/Dockerfile
+++ b/aws/efs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:latest
+FROM alpine:3.6
 RUN apk update --no-cache && apk add ca-certificates
 COPY efs-provisioner /
 ENTRYPOINT ["/efs-provisioner"]

--- a/aws/efs/README.md
+++ b/aws/efs/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/external_storage/efs-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/efs-provisioner)
 ```
-quay.io/external_storage/efs-provisioner:latest
+quay.io/external_storage/efs-provisioner:v0.1.0
 ```
 
 ## Prerequisites

--- a/aws/efs/deploy/deployment.yaml
+++ b/aws/efs/deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: efs-provisioner
-          image: quay.io/external_storage/efs-provisioner:latest
+          image: quay.io/external_storage/efs-provisioner:v0.1.0
           env:
             - name: FILE_SYSTEM_ID
               valueFrom:

--- a/aws/efs/deploy/pod.yaml
+++ b/aws/efs/deploy/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: efs-provisioner
-      image: quay.io/external_storage/efs-provisioner:latest
+      image: quay.io/external_storage/efs-provisioner:v0.1.0
       env:
         - name: PROVISIONER_NAME
           value: "example.com/aws-efs"

--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -1,5 +1,10 @@
 # CephFS Volume Provisioner for Kubernetes 1.5+
 
+[![Docker Repository on Quay](https://quay.io/repository/external_storage/cephfs-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/cephfs-provisioner)
+```
+quay.io/external_storage/cephfs-provisioner:v0.1.0
+```
+
 Using Ceph volume client
 
 # Test instruction

--- a/nfs-client/Dockerfile
+++ b/nfs-client/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.5
+FROM alpine:3.6
 RUN apk update --no-cache && apk add ca-certificates
 COPY nfs-client-provisioner /nfs-client-provisioner
 ENTRYPOINT ["/nfs-client-provisioner"]

--- a/nfs-client/README.md
+++ b/nfs-client/README.md
@@ -1,4 +1,10 @@
 # kubernetes nfs-client-provisioner
+
+[![Docker Repository on Quay](https://quay.io/repository/external_storage/nfs-client-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/nfs-client-provisioner)
+```
+quay.io/external_storage/nfs-client-provisioner:v2.0.0
+```
+
 - pv provisioned as ${namespace}-${pvcName}-${pvName}
 - pv recycled as archieved-${namespace}-${pvcName}-${pvName}
 

--- a/nfs-client/deploy/deployment.yaml
+++ b/nfs-client/deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:v1
+          image: quay.io/external_storage/nfs-client-provisioner:v2.0.0
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
Try to standardize: 
* nfs-client v1->v2.0.0. I would rather we have extra useless digits than modify my vx.x.x regex.
* Put the little quay badge on every README.