### PR TITLE
Remove unused endpoints permissions from EFS

### DIFF
--- a/aws/efs/deploy/auth/clusterrole.yaml
+++ b/aws/efs/deploy/auth/clusterrole.yaml
@@ -15,6 +15,3 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["services", "endpoints"]
-    verbs: ["get"]

--- a/aws/efs/deploy/auth/openshift-clusterrole.yaml
+++ b/aws/efs/deploy/auth/openshift-clusterrole.yaml
@@ -15,6 +15,3 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["services", "endpoints"]
-    verbs: ["get"]


### PR DESCRIPTION
With this talk of rbac, noticed this. these are (no longer?) needed.