### PR TITLE
Name PV as required by external provisioner contract

### DIFF
--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -71,7 +71,7 @@ func (p *nfsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: pvName,
+			Name: options.PVName,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,


### PR DESCRIPTION
The name is not as useful but it is the name the controller expects. Otherwise it will keep trying to Provision and Get the PV, wasting some API calls. https://github.com/kubernetes-incubator/external-storage/issues/174