### PR TITLE
Add RBAC examples for nfs-client

### DIFF
--- a/nfs-client/README.md
+++ b/nfs-client/README.md
@@ -12,6 +12,35 @@ quay.io/external_storage/nfs-client-provisioner:v2.0.0
 - modify and deploy `deploy/deployment.yaml`
 - modify and deploy `deploy/class.yaml`
 
+# authorization
+
+If your cluster has RBAC enabled or you are running OpenShift you must
+authorize the provisioner. If you are in a namespace/project other than
+"default" either edit `deploy/auth/clusterrolebinding.yaml` or edit the `oadm
+policy` command accordingly.
+
+## RBAC
+```console
+$ kubectl create -f deploy/auth/serviceaccount.yaml
+serviceaccount "nfs-client-provisioner" created
+$ kubectl create -f deploy/auth/clusterrole.yaml
+clusterrole "nfs-client-provisioner-runner" created
+$ kubectl create -f deploy/auth/clusterrolebinding.yaml
+clusterrolebinding "run-nfs-client-provisioner" created
+$ kubectl patch deployment nfs-client-provisioner -p '{"spec":{"template":{"spec":{"serviceAccount":"nfs-client-provisioner"}}}}'
+```
+
+## OpenShift
+```console
+$ oc create -f deploy/auth/serviceaccount.yaml
+serviceaccount "nfs-client-provisioner" created
+$ oc create -f deploy/auth/openshift-clusterrole.yaml
+clusterrole "nfs-client-provisioner-runner" created
+$ oadm policy add-scc-to-user hostmount-anyuid system:serviceaccount:default:nfs-client-provisioner
+$ oadm policy add-cluster-role-to-user nfs-client-provisioner-runner system:serviceaccount:default:nfs-client-provisioner
+$ oc patch deployment nfs-client-provisioner -p '{"spec":{"template":{"spec":{"serviceAccount":"nfs-client-provisioner"}}}}'
+```
+
 # test
 - `kubectl create -f deploy/test-claim.yaml`
 - `kubectl create -f deploy/test-pod.yaml`

--- a/nfs-client/deploy/auth/clusterrole.yaml
+++ b/nfs-client/deploy/auth/clusterrole.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: nfs-client-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]

--- a/nfs-client/deploy/auth/clusterrolebinding.yaml
+++ b/nfs-client/deploy/auth/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: run-nfs-client-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-client-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: nfs-client-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io

--- a/nfs-client/deploy/auth/openshift-clusterrole.yaml
+++ b/nfs-client/deploy/auth/openshift-clusterrole.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: nfs-client-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]

--- a/nfs-client/deploy/auth/serviceaccount.yaml
+++ b/nfs-client/deploy/auth/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-client-provisioner


### PR DESCRIPTION
Adds example configuration files for clusters that have RBAC enabled
(1.6) or OpenShift users.

This is mostly a cut and paste job from the EFS example.