### PR TITLE
[local-volume] Fix wrong version tag for bootstrapper

### DIFF
--- a/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
+++ b/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
@@ -17,5 +17,5 @@ spec:
         fieldRef:
           fieldPath: metadata.namespace
     args:
-    - --image=quay.io/external_storage/local-volume-provisioner:1.0.0
+    - --image=quay.io/external_storage/local-volume-provisioner:v1.0.0
     - --volume-config=local-volume-config


### PR DESCRIPTION
The bootstrapper needs to have 'v' prefixed tag