### PR TITLE
Relaxing aws client version

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ excludeDirs:
 - nfs/test/e2e
 import:
 - package: github.com/aws/aws-sdk-go
-  version: v1.7.3
+  version: ^1.7.3
   subpackages:
   - aws
   - aws/session


### PR DESCRIPTION
[Rook](https://github.com/rook/rook) uses this project for creating a Kubernetes volume provisioner for rook volumes. Rook also uses the aws client for their end-to-end test. Rook requires version v1.8.3 of the aws client. However setting this version will conflict to the version that is pinned by the external-storage project.

This PR relaxes the version so that v1.7.3 - v2.0 of the aws client can be used 