### PR TITLE
[local-volume] Changed Capacity for local PVs to use FsInfo capacity

### DIFF
--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -84,7 +84,7 @@ type RuntimeConfig struct {
 type LocalPVConfig struct {
 	Name            string
 	HostPath        string
-	Capacity        uint64
+	Capacity        int64
 	StorageClass    string
 	ProvisionerName string
 	AffinityAnn     string

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -105,12 +105,12 @@ func (d *Discoverer) discoverVolumesAtPath(class string, config common.MountConf
 			glog.Errorf("Mount path %q validation failed: %v", filePath, err)
 			continue
 		}
-		availByte, err := d.VolUtil.GetFsAvailableByte(filePath)
+		capacityByte, err := d.VolUtil.GetFsCapacityByte(filePath)
 		if err != nil {
 			glog.Errorf("Path %q fs stats error: %v", filePath, err)
 			continue
 		}
-		d.createPV(file, class, config, availByte)
+		d.createPV(file, class, config, capacityByte)
 	}
 }
 
@@ -134,15 +134,15 @@ func generatePVName(file, node, class string) string {
 	return fmt.Sprintf("local-pv-%x", h.Sum32())
 }
 
-func (d *Discoverer) createPV(file, class string, config common.MountConfig, availByte uint64) {
+func (d *Discoverer) createPV(file, class string, config common.MountConfig, capacityByte int64) {
 	pvName := generatePVName(file, d.Node.Name, class)
 	outsidePath := filepath.Join(config.HostDir, file)
 
-	glog.Infof("Found new volume at host path %q with capacity %d, creating Local PV %q", outsidePath, availByte, pvName)
+	glog.Infof("Found new volume at host path %q with capacity %d, creating Local PV %q", outsidePath, capacityByte, pvName)
 	pvSpec := common.CreateLocalPVSpec(&common.LocalPVConfig{
 		Name:            pvName,
 		HostPath:        outsidePath,
-		Capacity:        availByte,
+		Capacity:        capacityByte,
 		StorageClass:    class,
 		ProvisionerName: d.Name,
 		AffinityAnn:     d.nodeAffinityAnn,

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -324,7 +324,7 @@ func verifyCapacity(t *testing.T, createdPV *v1.PersistentVolume, expectedPV *te
 	if !ok {
 		t.Errorf("Unable to convert resource storage into int64")
 	}
-	if uint64(capacityInt) != expectedPV.capacity {
+	if capacityInt != expectedPV.capacity {
 		t.Errorf("Expected capacity %d, got %d", expectedPV.capacity, capacityInt)
 	}
 }
@@ -333,7 +333,7 @@ func verifyCapacity(t *testing.T, createdPV *v1.PersistentVolume, expectedPV *te
 type testPVInfo struct {
 	pvName       string
 	path         string
-	capacity     uint64
+	capacity     int64
 	storageClass string
 }
 

--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -37,8 +37,8 @@ type VolumeUtil interface {
 	// Delete all the contents under the given path, but not the path itself
 	DeleteContents(fullPath string) error
 
-	// Get available capacity for fs on full path
-	GetFsAvailableByte(fullPath string) (uint64, error)
+	// Get capacity for fs on full path
+	GetFsCapacityByte(fullPath string) (int64, error)
 }
 
 var _ VolumeUtil = &volumeUtil{}
@@ -104,12 +104,12 @@ func (u *volumeUtil) DeleteContents(fullPath string) error {
 	return nil
 }
 
-// GetFsAvailableByte returns available capacity in byte about a mounted filesystem.
+// GetFsCapacityByte returns capacity in bytes about a mounted filesystem.
 // fullPath is the pathname of any file within the mounted filesystem. Capacity
-// returned here is total capacity available.
-func (u *volumeUtil) GetFsAvailableByte(fullPath string) (uint64, error) {
-	available, _, _, _, _, _, err := util.FsInfo(fullPath)
-	return uint64(available), err
+// returned here is total capacity.
+func (u *volumeUtil) GetFsCapacityByte(fullPath string) (int64, error) {
+	_, capacity, _, _, _, _, err := util.FsInfo(fullPath)
+	return capacity, err
 }
 
 var _ VolumeUtil = &FakeVolumeUtil{}
@@ -128,7 +128,7 @@ type FakeFile struct {
 	IsNotDir bool
 	// Expected hash value of the PV name
 	Hash     uint32
-	Capacity uint64
+	Capacity int64
 }
 
 // NewFakeVolumeUtil returns a VolumeUtil object for use in unit testing
@@ -177,8 +177,8 @@ func (u *FakeVolumeUtil) DeleteContents(fullPath string) error {
 	return nil
 }
 
-// GetFsAvailableByte returns available capacity in byte about a mounted filesystem.
-func (u *FakeVolumeUtil) GetFsAvailableByte(fullPath string) (uint64, error) {
+// GetFsCapacityByte returns capacity in byte about a mounted filesystem.
+func (u *FakeVolumeUtil) GetFsCapacityByte(fullPath string) (int64, error) {
 	dir, file := filepath.Split(fullPath)
 	dir = filepath.Clean(dir)
 	files, found := u.directoryFiles[dir]


### PR DESCRIPTION
Earlier version used "available" from FsInfo
New version uses "capacity" from FsInfo
I also changed uint64 to int64