### PR TITLE
RBD provisioner use provisioner name as identitiy by default instead of random string

### DIFF
--- a/ceph/rbd/deployment.yaml
+++ b/ceph/rbd/deployment.yaml
@@ -14,3 +14,6 @@ spec:
       containers:
       - name: rbd-provisioner
         image: "quay.io/external_storage/rbd-provisioner:latest"
+        env:
+        - name: PROVISIONER_NAME
+          value: ceph.com/rbd


### PR DESCRIPTION
**What this PR does / why we need it**:

In production, provisioner should not use random identity on start.

Because, provisioner Pod may crash or be recreated on different nodes, if a provisioner generates random identity string each time, then it will cannot delete old PVs it provisioned before. Example errors logs:

```
I0801 11:03:05.685653    1901 controller.go:1068] scheduleOperation[delete-pvc-e2be4095-76a8-11e7-88c1-000c291fbe71[e2c845d1-76a8-11e7-88c1-000c291fbe71]]
I0801 11:03:05.688484    1901 controller.go:1035] deletion of volume "pvc-e2be4095-76a8-11e7-88c1-000c291fbe71" ignored: ignored because identity annotation on PV does not match ours
...
```

Most users deployed their RBD provisioner without specifying `-id` flag. So I change the default behavior to use provisioner name as identity (like some other provisions, `gluster/block`, etc) instead of random string.

**Special notes for your reviewer**:

In this PR, I also add `PROVISIONER_NAME` environment variable support, like many other provisioners do.