### PR TITLE
Fix Issue #263 - Parent process termination prevents monitoring nfs-ganesha daemon

### DIFF
--- a/nfs/pkg/server/server.go
+++ b/nfs/pkg/server/server.go
@@ -119,10 +119,15 @@ func Setup(ganeshaConfig string, gracePeriod uint) error {
 	return nil
 }
 
-// Start starts the NFS server.
-func Start(ganeshaLog, ganeshaPid, ganeshaConfig string) error {
+// Runs the NFS server in the foreground until it exits
+// Ideally, it should never exit when run in foreground mode
+// We force foreground to allow the provisioner process to restart
+// the server if it crashes - daemonization prevents us from using Wait()
+// for this purpose
+func Run(ganeshaLog, ganeshaPid, ganeshaConfig string) error {
 	// Start ganesha.nfsd
-	cmd := exec.Command("ganesha.nfsd", "-L", ganeshaLog, "-p", ganeshaPid, "-f", ganeshaConfig)
+	glog.Infof("Running NFS server!")
+	cmd := exec.Command("ganesha.nfsd", "-F", "-L", ganeshaLog, "-p", ganeshaPid, "-f", ganeshaConfig)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("ganesha.nfsd failed with error: %v, output: %s", err, out)
 	}

--- a/nfs/pkg/server/server.go
+++ b/nfs/pkg/server/server.go
@@ -119,7 +119,7 @@ func Setup(ganeshaConfig string, gracePeriod uint) error {
 	return nil
 }
 
-// Runs the NFS server in the foreground until it exits
+// Run : run the NFS server in the foreground until it exits
 // Ideally, it should never exit when run in foreground mode
 // We force foreground to allow the provisioner process to restart
 // the server if it crashes - daemonization prevents us from using Wait()


### PR DESCRIPTION
This fixes [#263](https://github.com/kubernetes-incubator/external-storage/issues/263) by running ganesha in the foreground in a dedicated goroutine and restarting as needed. 

Deploying using the demo `deployment.yaml` reveals that the logs no longer contain any errors: 

```
I0803 02:47:17.150883       7 main.go:81] Setting up NFS server!
I0803 02:47:17.423612       7 server.go:144] starting RLIMIT_NOFILE rlimit.Cur 1048576, rlimit.Max 1048576
I0803 02:47:17.423681       7 server.go:155] ending RLIMIT_NOFILE rlimit.Cur 1048576, rlimit.Max 1048576
I0803 02:47:17.427806       7 server.go:129] Running NFS server!
I0803 02:47:22.463479       7 controller.go:407] Starting provisioner controller 131fa682-77f6-11e7-806c-02420ae96703!
```

The provisioner and ganesha processes now have the correct parent-child relationship (according to `docker top`): 

```
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
root                1419                1402                0                   02:47               ?                   00:00:00            /nfs-provisioner -provisioner=example.com/nfs -grace-period=10
root                1458                1419                0                   02:47               ?                   00:00:00            ganesha.nfsd -F -L /export/ganesha.log -p /var/run/ganesha.pid -f /export/vfs.conf
```

After manually killing the ganesha process, can see that it recovers from the pod logs:

```
E0803 02:51:03.212671       7 main.go:91] NFS server Exited Unexpectedly with err: ganesha.nfsd failed with error: signal: segmentation fault (core dumped), output:
I0803 02:51:04.213100       7 server.go:129] Running NFS server!
```
The process also returns to the list:
```
root                2411                1419                0                   02:51               ?                   00:00:00            ganesha.nfsd -F -L /export/ganesha.log -p /var/run/ganesha.pid -f /export/vfs.conf
```

Finally, a subsequently issued PVC is bound successfully: 

```
nfs       Bound     pvc-d336ce17-77f6-11e7-bef1-080027192ca4   1Mi        RWX           example-nfs    1m
```