### PR TITLE
Validate volume size before creating RBD image.

### DIFF
--- a/ceph/rbd/pkg/provision/rbd_util.go
+++ b/ceph/rbd/pkg/provision/rbd_util.go
@@ -44,6 +44,9 @@ func (u *RBDUtil) CreateImage(image string, pOpts *rbdProvisionOptions, options 
 	volSizeBytes := capacity.Value()
 	// convert to MB that rbd defaults on
 	sz := int(util.RoundUpSize(volSizeBytes, 1024*1024))
+	if sz <= 0 {
+		return nil, 0, fmt.Errorf("invalid storage '%s' requested for RBD provisioner, it must greater than zero", capacity.String())
+	}
 	volSz := fmt.Sprintf("%d", sz)
 	// rbd create
 	l := len(pOpts.monitors)


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubernetes apiserver only validates PVC `requests.storage` is
non-negative. If "0" is specified, RBD provisioner will provision a
PV with 0-byte image. `rbd` utility is able to create a 0-byte image
from pool, but it's useless and meaningless in Kubernetes, because no
pods can use it. No space to format fs on it, so 0-byte image cannot be
mounted on node, will fail at `mounter.FormatAndMount` stage.

It's better to report an error in provisioner, then user will know their
PVC spec is wrong (at least useless) at early stage.

**Special notes for your reviewer**:

- Minimum volume size except zero in RBD provisioner is 1 Megabytes, which is
  enough to format ext4-fs on it.

@rootfs 
/cc @wongma7