### PR TITLE
"glide up" nfs tests to remove warning

### DIFF
--- a/nfs/test/e2e/glide.lock
+++ b/nfs/test/e2e/glide.lock
@@ -1,5 +1,5 @@
-hash: 4ea16afc94e0bbd7447f76035be1cd4d77a43fed252af8fdbb2826e149c38583
-updated: 2017-05-31T17:00:01.044589482-04:00
+hash: 08346c54408b243ce985ff86cc89a9fd0ac71566d55415f51b4014e01c626801
+updated: 2017-08-03T15:41:36.461895401-05:00
 imports: []
 testImports:
 - name: bitbucket.org/ww/goautoneg
@@ -742,7 +742,6 @@ testImports:
   - pkg/kubelet/types
   - pkg/kubelet/util/format
   - pkg/kubelet/util/ioutils
-  - pkg/labels
   - pkg/master/ports
   - pkg/metrics
   - pkg/security/apparmor


### PR DESCRIPTION
This will remove this warning from the tests: 

```
[WARN]	Lock file may be out of date. Hash check of YAML failed. You may need to run 'update'
```

The `glide up` reveals a few inconsistencies, can be dealt with later:

```
[WARN]	Conflict: k8s.io/apimachinery rev is currently d3c1641, but k8s.io/client-go wants 7080e31e90e981181435294bca96c80a37db8941
[WARN]	Conflict: github.com/golang/protobuf rev is currently c9c7427, but github.com/opencontainers/runc wants f7137ae6b19afbfd61a94b746fda3b3fe0491874
[WARN]	Conflict: k8s.io/client-go rev is currently a0a77784, but k8s.io/apiserver wants 5571124637a98cbc6579b0d1cfb78c0fc4b3f035
[WARN]	Conflict: github.com/docker/go-units rev is currently v0.3.1, but github.com/opencontainers/runc wants 9b001659dd36225e356b4467c465d732e745f53d

```