### PR TITLE
Remove provisioner versioning from efs,cephfs,nfs-client; use latest tag & CHANGELOGs instead

### DIFF
--- a/aws/efs/CHANGELOG.md
+++ b/aws/efs/CHANGELOG.md
@@ -1,0 +1,2 @@
+# v0.1.0
+- Initial release

--- a/aws/efs/README.md
+++ b/aws/efs/README.md
@@ -1,9 +1,6 @@
 # efs-provisioner
 
 [![Docker Repository on Quay](https://quay.io/repository/external_storage/efs-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/efs-provisioner)
-```
-quay.io/external_storage/efs-provisioner:v0.1.0
-```
 
 The efs-provisioner allows you to mount EFS storage as PersistentVolumes in kubernetes. It consists of a container that has access to an AWS [EFS](https://aws.amazon.com/efs/) resource. The container reads a configmap which contains the EFS filesystem ID, the AWS region and the name you want to use for your efs-provisioner. This name will be used later when you create a storage class.
 

--- a/aws/efs/deploy/deployment.yaml
+++ b/aws/efs/deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: efs-provisioner
-          image: quay.io/external_storage/efs-provisioner:v0.1.0
+          image: quay.io/external_storage/efs-provisioner:latest
           env:
             - name: FILE_SYSTEM_ID
               valueFrom:

--- a/aws/efs/deploy/manifest.yaml
+++ b/aws/efs/deploy/manifest.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: efs-provisioner
-          image: quay.io/external_storage/efs-provisioner:v0.1.0
+          image: quay.io/external_storage/efs-provisioner:latest
           env:
             - name: FILE_SYSTEM_ID
               valueFrom:

--- a/aws/efs/deploy/pod.yaml
+++ b/aws/efs/deploy/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: efs-provisioner
-      image: quay.io/external_storage/efs-provisioner:v0.1.0
+      image: quay.io/external_storage/efs-provisioner:latest
       env:
         - name: PROVISIONER_NAME
           value: "example.com/aws-efs"

--- a/ceph/cephfs/CHANGELOG.md
+++ b/ceph/cephfs/CHANGELOG.md
@@ -1,0 +1,9 @@
+# v0.1.2
+- Use provisioner name as identity by default instead of random string. See #267. (https://github.com/kubernetes-incubator/external-storage/pull/270)
+- Add PROVISIONER_NAME environment variable support (https://github.com/kubernetes-incubator/external-storage/pull/270)
+
+# v0.1.1
+- Fix docker file error "chmod: invalid mode: 'x+o'" (https://github.com/kubernetes-incubator/external-storage/pull/215)
+
+# v0.1.0
+- Initial release

--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -1,9 +1,6 @@
 # CephFS Volume Provisioner for Kubernetes 1.5+
 
 [![Docker Repository on Quay](https://quay.io/repository/external_storage/cephfs-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/cephfs-provisioner)
-```
-quay.io/external_storage/cephfs-provisioner:v0.1.0
-```
 
 Using Ceph volume client
 

--- a/ceph/rbd/CHANGELOG.md
+++ b/ceph/rbd/CHANGELOG.md
@@ -1,0 +1,6 @@
+# v0.1.1
+- Use provisioner name as identity by default instead of random string. (https://github.com/kubernetes-incubator/external-storage/pull/267)
+- Add PROVISIONER_NAME environment variable support (https://github.com/kubernetes-incubator/external-storage/pull/267)
+
+# v0.1.0
+- Initial release

--- a/nfs-client/CHANGELOG.md
+++ b/nfs-client/CHANGELOG.md
@@ -1,0 +1,8 @@
+# v2.0.1
+- Add support for ARM (Raspberry PI). Image at `quay.io/external_storage/nfs-client-provisioner-arm`. (https://github.com/kubernetes-incubator/external-storage/pull/275)
+
+# v2.0.0
+- Fix issue 149 - nfs-client-provisioner create folder with 755, not 777 (https://github.com/kubernetes-incubator/external-storage/pull/150)
+
+# v1
+- Initial release

--- a/nfs-client/README.md
+++ b/nfs-client/README.md
@@ -1,9 +1,6 @@
 # kubernetes nfs-client-provisioner
 
 [![Docker Repository on Quay](https://quay.io/repository/external_storage/nfs-client-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/external_storage/nfs-client-provisioner)
-```
-quay.io/external_storage/nfs-client-provisioner:v2.0.0
-```
 
 - pv provisioned as ${namespace}-${pvcName}-${pvName}
 - pv recycled as archieved-${namespace}-${pvcName}-${pvName}

--- a/nfs-client/deploy/deployment.yaml
+++ b/nfs-client/deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: nfs-client-provisioner
-          image: quay.io/external_storage/nfs-client-provisioner:v2.0.0
+          image: quay.io/external_storage/nfs-client-provisioner:latest
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
Instead of keeping manifest files & READMEs updated with the latest version, just point manifests to the latest tag and maintain changelogs.