### PR TITLE
If openshift >= 3.6, use new clusterrole because older pv-* ones are gone

### DIFF
--- a/iscsi/targetd/README.md
+++ b/iscsi/targetd/README.md
@@ -231,10 +231,11 @@ Run the following commands. The secret correspond to username and password you h
 ```
 oc new-project iscsi-provisioner
 oc create sa iscsi-provisioner
-oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-provisioner-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-binder-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-recycler-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
+# if Openshift is version < 3.6 add the iscsi-provisioner-runner role
+oc create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/iscsi/targetd/openshift/iscsi-auth.yaml
+# else if Openshift is version >= 3.6 add the system:persistent-volume-provisioner role
+oc adm policy add-cluster-role-to-user system:persistent-volume-provisioner system:serviceaccount:iscsi-provisioner:iscsi-provisioner
+#
 oc secret new-basicauth targetd-account --username=admin --password=ciao
 oc create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/iscsi/targetd/openshift/iscsi-provisioner-dc.yaml
 ```

--- a/iscsi/targetd/ansible/iscsi-auth.yaml
+++ b/iscsi/targetd/ansible/iscsi-auth.yaml
@@ -1,0 +1,35 @@
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: iscsi-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: v1
+metadata:
+  name: run-iscsi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: iscsi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: iscsi-provisioner-runner
+  apiGroup: v1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iscsi-provisioner

--- a/iscsi/targetd/ansible/provisioner-playbook.yaml
+++ b/iscsi/targetd/ansible/provisioner-playbook.yaml
@@ -50,26 +50,23 @@
          --password={{ targetd_password }} -n iscsi-provisioner
        when: secret_test.rc == 1
    
-     - name: Add cluster-reader role to service account
+     - name: Add system:persistent-volume-provisioner role to service account
        command: >
          /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig
-         policy add-cluster-role-to-user cluster-reader system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-   
-     - name: Add pv-provisioner-controller role to service account
-       command: >
-         /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig
-         policy add-cluster-role-to-user system:pv-provisioner-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-   
-     - name: Add pv-binder-controller role to service account
-       command: >
-         /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig
-         policy add-cluster-role-to-user system:pv-binder-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-   
-     - name: Add pv-recycler-controller role to service account
-       command: >
-         /usr/bin/oc adm --config=/etc/origin/master/admin.kubeconfig
-         policy add-cluster-role-to-user system:pv-recycler-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-   
+         policy add-cluster-role-to-user system:persistent-volume-provisioner system:serviceaccount:iscsi-provisioner:iscsi-provisioner
+       failed_when: false
+       changed_when: system_role.rc == 0
+       register: system_role
+
+     - name: Create iscsi-provisioner-runner role and add to service account if system:persistent-volume-provisioner DNE
+       shell: >
+           /usr/bin/oc --config=/etc/origin/master/admin.kubeconfig
+           create -f ./iscsi-auth.yaml
+       failed_when: "'already exists' not in iscsi_role.stderr and iscsi_role.rc != 0"
+       changed_when: "'already exists' not in iscsi_role.stderr"
+       register: iscsi_role
+       when: system_role.rc == 1
+
      - name: create iscsi class template
        template: 
          src: ./iscsi-provisioner-class.yaml.j2

--- a/iscsi/targetd/kubernetes/iscsi-provisioner-d.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-d.yaml
@@ -14,11 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["watch", "create", "update", "patch"]
-  - apiGroups: ["extensions"]
-    resources: ["podsecuritypolicies"]
-    resourceNames: ["nfs-provisioner"]
-    verbs: ["use"]
+    verbs: ["list", "watch", "create", "update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
@@ -57,7 +53,7 @@ spec:
             - "start"
           env:
             - name: PROVISIONER_NAME
-              value: iscsi   
+              value: iscsi
             - name: LOG_LEVEL
               value: debug
             - name: TARGETD_USERNAME
@@ -69,7 +65,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: targetd-account
-                  key: password                    
+                  key: password
             - name: TARGETD_ADDRESS
-              value: 192.168.99.100                                                                   
-      serviceAccount: iscsi-provisioner   
+              value: 192.168.99.100
+      serviceAccount: iscsi-provisioner

--- a/iscsi/targetd/openshift/README.md
+++ b/iscsi/targetd/openshift/README.md
@@ -3,12 +3,13 @@
 ```
 oc new-project iscsi-provisioner
 oc create sa iscsi-provisioner
-oc adm policy add-cluster-role-to-user cluster-reader system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-provisioner-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-binder-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
-oc adm policy add-cluster-role-to-user system:pv-recycler-controller system:serviceaccount:iscsi-provisioner:iscsi-provisioner
+# if Openshift is version < 3.6 add the iscsi-provisioner-runner role
+oc create -f iscsi-auth.yaml
+# else if Openshift is version >= 3.6 add the system:persistent-volume-provisioner role
+oc adm policy add-cluster-role-to-user system:persistent-volume-provisioner system:serviceaccount:iscsi-provisioner:iscsi-provisioner
+#
 oc create -f iscsi-provisioner-class.yaml 
 oc secret new-basicauth targetd-account --username=admin --password=ciao
 oc create -f iscsi-provisioner-dc.yaml
 oc create -f iscsi-provisioner-pvc.yaml
-``` 
+```

--- a/iscsi/targetd/openshift/iscsi-auth.yaml
+++ b/iscsi/targetd/openshift/iscsi-auth.yaml
@@ -1,0 +1,35 @@
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: iscsi-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: v1
+metadata:
+  name: run-iscsi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: iscsi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: iscsi-provisioner-runner
+  apiGroup: v1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iscsi-provisioner

--- a/iscsi/targetd/openshift/iscsi-provisioner-dc.yaml
+++ b/iscsi/targetd/openshift/iscsi-provisioner-dc.yaml
@@ -17,7 +17,7 @@ spec:
             - "start"
           env:
             - name: PROVISIONER_NAME
-              value: iscsi   
+              value: iscsi
             - name: LOG_LEVEL
               value: debug
             - name: TARGETD_USERNAME
@@ -29,7 +29,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: targetd-account
-                  key: password                    
+                  key: password
             - name: TARGETD_ADDRESS
-              value: 192.168.99.100                                                                   
-      serviceAccount: iscsi-provisioner   
+              value: 192.168.99.100
+      serviceAccount: iscsi-provisioner


### PR DESCRIPTION
fixes https://github.com/kubernetes-incubator/external-storage/issues/284

@raffaelespazzoli fyi.

This should be sufficient, if ugly. I am no expert in ansible.