### PR TITLE
Print all non-efs mount entries for easier debugging

### DIFF
--- a/aws/efs/CHANGELOG.md
+++ b/aws/efs/CHANGELOG.md
@@ -1,2 +1,5 @@
+# v0.1.1
+- Print all non-efs mount entries when efs mount entry is not found, for easier debugging (#298)
+
 # v0.1.0
 - Initial release

--- a/aws/efs/cmd/efs-provisioner/efs-provisioner.go
+++ b/aws/efs/cmd/efs-provisioner/efs-provisioner.go
@@ -109,7 +109,11 @@ func getMount(dnsName string) (string, string, error) {
 		}
 	}
 
-	return "", "", fmt.Errorf("no mount entry found for %s", dnsName)
+	entriesStr := ""
+	for _, e := range entries {
+		entriesStr += e.Source + ":" + e.Mountpoint + ", "
+	}
+	return "", "", fmt.Errorf("no mount entry found for %s among entries %s", dnsName, entriesStr)
 }
 
 var _ controller.Provisioner = &efsProvisioner{}


### PR DESCRIPTION
Might help debug https://github.com/kubernetes-incubator/external-storage/issues/260