### PR TITLE
Switching bootstrap to be Job instead of Pod

### DIFF
--- a/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
+++ b/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1 
+kind: Job
 metadata:
   name: local-volume-provisioner-bootstrap
   namespace: kube-system


### PR DESCRIPTION
Currently Bootstrap gets deployed as a generic Pod which requires then manual cleaning after it deploys Provisioner daemonset. Switching Bootstrap to be a Job.