### PR TITLE
Fix invalid podspec on the bootstrapper job.

### DIFF
--- a/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
+++ b/local-volume/bootstrapper/deployment/kubernetes/bootstrapper.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1 
+apiVersion: batch/v1
 kind: Job
 metadata:
   name: local-volume-provisioner-bootstrap
@@ -6,16 +6,18 @@ metadata:
   labels:
     app: local-volume-provisioner-bootstrap
 spec:
-  restartPolicy: Never
-  serviceAccountName: local-storage-bootstrapper
-  containers:
-  - name: bootstrapper
-    image: quay.io/external_storage/local-volume-provisioner-bootstrap:latest
-    env:
-    - name: MY_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
-    args:
-    - --image=quay.io/external_storage/local-volume-provisioner:v1.0.0
-    - --volume-config=local-volume-config
+  template:
+    spec:
+      serviceAccountName: local-storage-bootstrapper
+      restartPolicy: Never
+      containers:
+      - name: bootstrapper
+        image: quay.io/external_storage/local-volume-provisioner-bootstrap:latest
+        env:
+        - name: MY_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - --image=quay.io/external_storage/local-volume-provisioner:v1.0.0
+        - --volume-config=local-volume-config


### PR DESCRIPTION
On kubectl create -f bootstrapper.yaml, kubectl gives the following error:
`error: error validating "bootstrapper/deployment/kubernetes/bootstrapper.yaml": error validating data: [field spec.template for v1.JobSpec is required, found invalid field containers for v1.JobSpec, found invalid field restartPolicy for v1.JobSpec, found invalid field serviceAccountName for v1.JobSpec]; if you choose to ignore these errors, turn validation off with --validate=false`

I found an improper podspec in the manifest, so I just fixed that.