### PR TITLE
[glusterfs] Disable CGO to build static binary

### DIFF
--- a/gluster/glusterfs/Makefile
+++ b/gluster/glusterfs/Makefile
@@ -23,7 +23,7 @@ MUTABLE_IMAGE = $(REGISTRY)glusterfs-simple-provisioner:latest
 
 all build:
 	GOOS=linux go install -v ./cmd/glusterfs-simple-provisioner
-	GOOS=linux go build ./cmd/glusterfs-simple-provisioner
+	GOOS=linux CGO_ENABLED=0 go build ./cmd/glusterfs-simple-provisioner
 .PHONY: all build
 
 build-mac:


### PR DESCRIPTION
`glusterfs-simple-provisioner` binary was dynamically linked
unless disable CGO_ENABLED flag. So that container image doesn't
work because alpine image doesn't contain dependent libraries.

This patch disable CGO_ENABLED flag to build container image
correctly.