### PR TITLE
[local-volume] Added more information about storageClassName for local-volumes

### DIFF
--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -119,6 +119,37 @@ $ kubectl create -f bootstrapper/deployment/kubernetes/example-config.yaml
 $ kubectl create -f bootstrapper/deployment/kubernetes/bootstrapper.yaml
 ```
 
+The bootstrapper launches the external static provisioner, that discovers and creates local-volume PVs.
+
+For example, if the directory `/mnt/disks/` contained one directory `/mnt/disks/vol1` then the following
+local-volume PV would be created by the static provisioner:
+
+```
+$ kubectl get pv
+NAME                CAPACITY    ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS    REASON    AGE
+local-pv-ce05be60   1024220Ki   RWO           Delete          Available             local-storage             26s
+
+$ kubectl describe pv local-pv-ce05be60 
+Name:		local-pv-ce05be60
+Labels:		<none>
+Annotations:	pv.kubernetes.io/provisioned-by=local-volume-provisioner-minikube-18f57fb2-a186-11e7-b543-080027d51893
+		volume.alpha.kubernetes.io/node-affinity={"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["minikub...
+StorageClass:	local-fast
+Status:		Available
+Claim:		
+Reclaim Policy:	Delete
+Access Modes:	RWO
+Capacity:	1024220Ki
+Message:	
+Source:
+    Type:	LocalVolume (a persistent volume backed by local storage on a node)
+    Path:	/mnt/disks/vol1
+Events:		<none>
+
+```
+
+The PV described above can be claimed and bound to a PVC by referencing the `local-fast` storageClassName.
+
 #### Option 2: Manually create local persistent volume
 
 If you don't use the external provisioner, then you have to create the local PVs

--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -153,11 +153,12 @@ spec:
     path: /mnt/disks/vol1
 ```
 Please replace the following elements to reflect your configuration:
-  * "my-node" with the name of kubernetes node which is hosting this
+
+  * "my-node" with the name of kubernetes node that is hosting this
     local storage disk
   * "5Gi" with the required size of storage volume, same as specified in PVC
-  * "local-storage" with the name of storage class which should be used
-     for local volumes
+  * "local-storage" with the name of storage class to associate with
+     this local volume
   * "/mnt/disks/vol1" with the path to the mount point of local volumes
  
 ### Step 3: Create local persistent volume claim
@@ -176,9 +177,10 @@ spec:
   storageClassName: local-storage
 ```
 Please replace the following elements to reflect your configuration:
+
   * "5Gi" with required size of storage volume
-  * "local-storage" with the name of storage class which should be used
-     for local PVs
+  * "local-storage" with the name of storage class associated with the
+  local PVs that should be used for satisfying this PVC
 
 ## E2E Tests
 

--- a/local-volume/bootstrapper/README.md
+++ b/local-volume/bootstrapper/README.md
@@ -66,6 +66,31 @@ data:
     }
 ```
 
+If the directory `/mnt/ssds/` contained one diretory `/mnt/ssds/ssd1` then the following
+local storage PV would be created by the bootstrapper:
+
+```
+$ kubectl describe pv <example-local-pv>
+Name:	       	<example-local-pv>
+Labels:	        <snip>
+Annotations:	pv.kubernetes.io/provisioned-by=local-volume-provisioner
+		volume.alpha.kubernetes.io/node-affinity={"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["kuberne...
+StorageClass:	local-fast
+Status:		    Available
+Claim:		    <snip>
+Reclaim Policy:	Delete
+Access Modes:	RWO
+Capacity:	    <snip>
+Message:
+Source:
+    Type:	LocalVolume (a persistent volume backed by local storage on a node)
+    Path:	/mnt/ssds/ssd1
+Events:	    	<none>
+
+```
+
+The PV described above can be claimed and bound to a PVC by referencing the `local-fast` storageClassName.
+
 ### Command line options
 
 To see all options, compile bootstrapper and use `-h` option, below is a curated

--- a/local-volume/bootstrapper/README.md
+++ b/local-volume/bootstrapper/README.md
@@ -66,30 +66,7 @@ data:
     }
 ```
 
-If the directory `/mnt/ssds/` contained one diretory `/mnt/ssds/ssd1` then the following
-local storage PV would be created by the bootstrapper:
-
-```
-$ kubectl describe pv <example-local-pv>
-Name:	       	<example-local-pv>
-Labels:	        <snip>
-Annotations:	pv.kubernetes.io/provisioned-by=local-volume-provisioner
-		volume.alpha.kubernetes.io/node-affinity={"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/hostname","operator":"In","values":["kuberne...
-StorageClass:	local-fast
-Status:		    Available
-Claim:		    <snip>
-Reclaim Policy:	Delete
-Access Modes:	RWO
-Capacity:	    <snip>
-Message:
-Source:
-    Type:	LocalVolume (a persistent volume backed by local storage on a node)
-    Path:	/mnt/ssds/ssd1
-Events:	    	<none>
-
-```
-
-The PV described above can be claimed and bound to a PVC by referencing the `local-fast` storageClassName.
+An example of using the bootstraper is included [here](../README.md).
 
 ### Command line options
 


### PR DESCRIPTION
I slightly modified the text in the top level README.md to make it more clear about how to use the storage class name with local-volumes.

I updated the bootstrapper README.md to make it more explicit about the storageClassName that will be set for a local-pv that is discovered by providing an example.