### PR TITLE
[local-volume] Refactor local volume configMap for YAML

### DIFF
--- a/local-volume/bootstrapper/README.md
+++ b/local-volume/bootstrapper/README.md
@@ -50,20 +50,15 @@ metadata:
   name: local-volume-config
   namespace: kube-system
 data:
-  "local-fast": |
-    {
-      "hostDir": "/mnt/ssds",
-      "mountDir": "/local-ssds"
-    }
-  "local-slow": |
-    {
-      "hostDir": "/mnt/hdds",
-      "mountDir": "/local-hdds"
-    }
-  "local-storage": |
-    {
-      "hostDir": "/mnt/disks"
-    }
+  storageClassMap: |
+    local-fast: 
+       hostDir: "/mnt/ssds"
+       mountDir: "/local-ssds"
+    local-slow:
+       hostDir: "/mnt/hdds"
+       mountDir: "/local-hdds"
+    local-storage:
+      hostDir: "/mnt/disks"
 ```
 
 ### Command line options

--- a/local-volume/bootstrapper/deployment/kubernetes/config-gce-local-ssd.yaml
+++ b/local-volume/bootstrapper/deployment/kubernetes/config-gce-local-ssd.yaml
@@ -1,11 +1,11 @@
 # The config map is used to configure local volume discovery for Local SSDs on GCE and GKE. 
 # It is a map from storage class to its mount configuration.
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-volume-config
   namespace: kube-system
 data:
-  "local-storage": |
-    {
-      "hostDir": "/mnt/disks"
-    }
+  storageClassMap: |
+    local-storage:
+      hostDir: "/mnt/disks"

--- a/local-volume/bootstrapper/deployment/kubernetes/example-config.yaml
+++ b/local-volume/bootstrapper/deployment/kubernetes/example-config.yaml
@@ -1,21 +1,17 @@
 # The config map is used to configure local volume discovery; it is a map from
 # storage class to its mount configuration.
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: local-volume-config
   namespace: kube-system
 data:
-  "local-fast": |
-    {
-      "hostDir": "/mnt/ssds",
-      "mountDir": "/local-ssds"
-    }
-  "local-slow": |
-    {
-      "hostDir": "/mnt/hdds",
-      "mountDir": "/local-hdds"
-    }
-  "local-storage": |
-    {
-      "hostDir": "/mnt/disks"
-    }
+  storageClassMap: |
+    local-fast: 
+       hostDir: "/mnt/ssds"
+       mountDir: "/local-ssds"
+    local-slow:
+       hostDir: "/mnt/hdds"
+       mountDir: "/local-hdds"
+    local-storage:
+      hostDir: "/mnt/disks"

--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -30,6 +30,18 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var provisionerConfig common.ProvisionerConfiguration
+
+func init() {
+	provisionerConfig = common.ProvisionerConfiguration{
+		StorageClassConfig: make(map[string]common.MountConfig),
+	}
+	if err := common.LoadProvisionerConfigs(&provisionerConfig); err != nil {
+		glog.Fatalf("Error parsing Provisioner's configuration: %#v. Exiting...\n", err)
+	}
+	glog.Infof("Configuration parsing has been completed, ready to run...")
+}
+
 func setupClient() *kubernetes.Clientset {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -58,7 +70,7 @@ func main() {
 	glog.Info("Starting controller\n")
 	controller.StartLocalController(client, &common.UserConfig{
 		Node:         node,
-		DiscoveryMap: createDiscoveryMap(client),
+		DiscoveryMap: provisionerConfig.StorageClassConfig,
 	})
 }
 
@@ -68,14 +80,4 @@ func getNode(client *kubernetes.Clientset, name string) *v1.Node {
 		glog.Fatalf("Could not get node information: %v", err)
 	}
 	return node
-}
-
-func createDiscoveryMap(client *kubernetes.Clientset) map[string]common.MountConfig {
-	config, err := common.GetVolumeConfigFromMountedConfigMap()
-	if err != nil {
-		glog.Infof("Could not get config map due to: %v, using default configmap", err)
-		config = common.GetDefaultVolumeConfig()
-	}
-	glog.Infof("Running provisioner with config %+v\n", config)
-	return config
 }


### PR DESCRIPTION
Closes #343 
This version implements parsing of this format:
```
kind: ConfigMap
metadata:
  name: local-volume-config
  namespace: kube-system
data:
  someOtherParam: |
    foo value
  storageClassMap: |
    local-fast: 
       hostDir: "/mnt/ssds"
       mountDir: "/local-ssds"
    local-slow:
       hostDir: "/mnt/hdds"
       mountDir: "/local-hdds"
    local-storage:
      hostDir: "/mnt/disks"
```