### PR TITLE
Fix golint errors

### DIFF
--- a/snapshot/cmd/snapshot-controller/snapshot-controller.go
+++ b/snapshot/cmd/snapshot-controller/snapshot-controller.go
@@ -36,9 +36,9 @@ import (
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/cloudprovider/providers/openstack"
 	snapshotcontroller "github.com/kubernetes-incubator/external-storage/snapshot/pkg/controller/snapshot-controller"
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume"
-	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/aws_ebs"
+	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/awsebs"
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/cinder"
-	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/gce_pd"
+	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/gcepd"
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/volume/hostpath"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
@@ -51,7 +51,7 @@ var (
 	kubeconfig      = flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
 	cloudProvider   = flag.String("cloudprovider", "", "aws|gce|openstack")
 	cloudConfigFile = flag.String("cloudconfig", "", "Path to a Cloud config. Only required if cloudprovider is set.")
-	volumePlugins   = make(map[string]volume.VolumePlugin)
+	volumePlugins   = make(map[string]volume.Plugin)
 )
 
 func main() {
@@ -115,16 +115,16 @@ func buildVolumePlugins() {
 		cloud, err := cloudprovider.InitCloudProvider(*cloudProvider, *cloudConfigFile)
 		if err == nil && cloud != nil {
 			if *cloudProvider == aws.ProviderName {
-				awsPlugin := aws_ebs.RegisterPlugin()
+				awsPlugin := awsebs.RegisterPlugin()
 				awsPlugin.Init(cloud)
-				volumePlugins[aws_ebs.GetPluginName()] = awsPlugin
+				volumePlugins[awsebs.GetPluginName()] = awsPlugin
 				glog.Info("Register cloudprovider aws")
 			}
 			if *cloudProvider == gce.ProviderName {
-				gcePlugin := gce_pd.RegisterPlugin()
+				gcePlugin := gcepd.RegisterPlugin()
 				gcePlugin.Init(cloud)
-				volumePlugins[gce_pd.GetPluginName()] = gcePlugin
-				glog.Info("Register cloudprovider %s", gce_pd.GetPluginName())
+				volumePlugins[gcepd.GetPluginName()] = gcePlugin
+				glog.Info("Register cloudprovider %s", gcepd.GetPluginName())
 			}
 			if *cloudProvider == openstack.ProviderName {
 				cinderPlugin := cinder.RegisterPlugin()

--- a/snapshot/pkg/apis/crd/v1/register.go
+++ b/snapshot/pkg/apis/crd/v1/register.go
@@ -26,8 +26,10 @@ import (
 const GroupName = "volume-snapshot-data.external-storage.k8s.io"
 
 var (
+	// SchemeBuilder is the new scheme builder
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme adds to scheme
+	AddToScheme = SchemeBuilder.AddToScheme
 	// SchemeGroupVersion is the group version used to register these objects.
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 )

--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -25,12 +25,17 @@ import (
 )
 
 const (
+	// VolumeSnapshotDataResourcePlural is "volumesnapshotdatas"
 	VolumeSnapshotDataResourcePlural = "volumesnapshotdatas"
-	VolumeSnapshotDataResource       = "volume-snapshot-data"
-	VolumeSnapshotResourcePlural     = "volumesnapshots"
-	VolumeSnapshotResource           = "volume-snapshot"
+	// VolumeSnapshotDataResource is "volume-snapshot-data"
+	VolumeSnapshotDataResource = "volume-snapshot-data"
+	// VolumeSnapshotResourcePlural is "volumesnapshots"
+	VolumeSnapshotResourcePlural = "volumesnapshots"
+	// VolumeSnapshotResource is "volume-snapshot"
+	VolumeSnapshotResource = "volume-snapshot"
 )
 
+// VolumeSnapshotStatus is the status of the VolumeSnapshot
 type VolumeSnapshotStatus struct {
 	// The time the snapshot was successfully created
 	// +optional
@@ -40,6 +45,7 @@ type VolumeSnapshotStatus struct {
 	Conditions []VolumeSnapshotCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
 }
 
+// VolumeSnapshotConditionType is the type of VolumeSnapshot conditions
 type VolumeSnapshotConditionType string
 
 // These are valid conditions of a volume snapshot.
@@ -56,7 +62,7 @@ const (
 	VolumeSnapshotConditionError VolumeSnapshotConditionType = "Error"
 )
 
-// VolumeSnapshot Condition describes the state of a volume snapshot  at a certain point.
+// VolumeSnapshotCondition describes the state of a volume snapshot  at a certain point.
 type VolumeSnapshotCondition struct {
 	// Type of replication controller condition.
 	Type VolumeSnapshotConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=VolumeSnapshotConditionType"`
@@ -75,7 +81,7 @@ type VolumeSnapshotCondition struct {
 
 // +genclient=true
 
-// The volume snapshot object accessible to the user. Upon succesful creation of the actual
+// VolumeSnapshot is the volume snapshot object accessible to the user. Upon succesful creation of the actual
 // snapshot by the volume provider it is bound to the corresponding VolumeSnapshotData through
 // the VolumeSnapshotSpec
 type VolumeSnapshot struct {
@@ -91,13 +97,14 @@ type VolumeSnapshot struct {
 	Status VolumeSnapshotStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
 }
 
+// VolumeSnapshotList is a list of VolumeSnapshot objects
 type VolumeSnapshotList struct {
 	metav1.TypeMeta `json:",inline"`
 	Metadata        metav1.ListMeta  `json:"metadata"`
 	Items           []VolumeSnapshot `json:"items"`
 }
 
-// The desired state of the volume snapshot
+// VolumeSnapshotSpec is the desired state of the volume snapshot
 type VolumeSnapshotSpec struct {
 	// PersistentVolumeClaimName is the name of the PVC being snapshotted
 	// +optional
@@ -108,7 +115,7 @@ type VolumeSnapshotSpec struct {
 	SnapshotDataName string `json:"snapshotDataName" protobuf:"bytes,2,opt,name=snapshotDataName"`
 }
 
-// The actual state of the volume snapshot
+// VolumeSnapshotDataStatus is the actual state of the volume snapshot
 type VolumeSnapshotDataStatus struct {
 	// The time the snapshot was successfully created
 	// +optional
@@ -118,12 +125,14 @@ type VolumeSnapshotDataStatus struct {
 	Conditions []VolumeSnapshotDataCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
 }
 
+// VolumeSnapshotDataList is a list of VolumeSnapshotData objects
 type VolumeSnapshotDataList struct {
 	metav1.TypeMeta `json:",inline"`
 	Metadata        metav1.ListMeta      `json:"metadata"`
 	Items           []VolumeSnapshotData `json:"items"`
 }
 
+// VolumeSnapshotDataConditionType is the type of the VolumeSnapshotData condition
 type VolumeSnapshotDataConditionType string
 
 // These are valid conditions of a volume snapshot.
@@ -136,7 +145,7 @@ const (
 	VolumeSnapshotDataConditionError VolumeSnapshotDataConditionType = "Error"
 )
 
-// VolumeSnapshot Condition describes the state of a volume snapshot  at a certain point.
+// VolumeSnapshotDataCondition describes the state of a volume snapshot  at a certain point.
 type VolumeSnapshotDataCondition struct {
 	// Type of volume snapshot condition.
 	Type VolumeSnapshotDataConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=VolumeSnapshotDataConditionType"`
@@ -171,7 +180,7 @@ type VolumeSnapshotData struct {
 	Status VolumeSnapshotDataStatus `json:"status" protobuf:"bytes,3,opt,name=status"`
 }
 
-// The desired state of the volume snapshot
+// VolumeSnapshotDataSpec is the spec of the volume snapshot data
 type VolumeSnapshotDataSpec struct {
 	// Source represents the location and type of the volume snapshot
 	VolumeSnapshotDataSource `json:",inline" protobuf:"bytes,1,opt,name=volumeSnapshotDataSource"`
@@ -187,31 +196,31 @@ type VolumeSnapshotDataSpec struct {
 	PersistentVolumeRef *core_v1.ObjectReference `json:"persistentVolumeRef" protobuf:"bytes,3,opt,name=persistentVolumeRef"`
 }
 
-// HostPath volume snapshot source
+// HostPathVolumeSnapshotSource is HostPath volume snapshot source
 type HostPathVolumeSnapshotSource struct {
 	// Path represents a tar file that stores the HostPath volume source
 	Path string `json:"snapshot"`
 }
 
-// AWS EBS volume snapshot source
+// AWSElasticBlockStoreVolumeSnapshotSource is AWS EBS volume snapshot source
 type AWSElasticBlockStoreVolumeSnapshotSource struct {
 	// Unique id of the persistent disk snapshot resource. Used to identify the disk snapshot in AWS
 	SnapshotID string `json:"snapshotId"`
 }
 
-// Cinder volume snapshot source
+// CinderVolumeSnapshotSource is Cinder volume snapshot source
 type CinderVolumeSnapshotSource struct {
 	// Unique id of the cinder volume snapshot resource. Used to identify the snapshot in OpenStack
 	SnapshotID string `json:"snapshotId"`
 }
 
-// GCE PD volume snapshot source
+// GCEPersistentDiskSnapshotSource is GCE PD volume snapshot source
 type GCEPersistentDiskSnapshotSource struct {
 	// Unique id of the persistent disk snapshot resource. Used to identify the disk snapshot in GCE
 	SnapshotName string `json:"snapshotId"`
 }
 
-// Represents the actual location and type of the snapshot. Only one of its members may be specified.
+// VolumeSnapshotDataSource represents the actual location and type of the snapshot. Only one of its members may be specified.
 type VolumeSnapshotDataSource struct {
 	// HostPath represents a directory on the host.
 	// Provisioned by a developer or tester.
@@ -233,6 +242,7 @@ type VolumeSnapshotDataSource struct {
 	CinderSnapshot *CinderVolumeSnapshotSource `json:"cinderVolume,omitempty"`
 }
 
+// GetSupportedVolumeFromPVSpec gets supported volume from PV spec
 func GetSupportedVolumeFromPVSpec(spec *core_v1.PersistentVolumeSpec) string {
 	if spec.HostPath != nil {
 		return "hostPath"
@@ -249,6 +259,7 @@ func GetSupportedVolumeFromPVSpec(spec *core_v1.PersistentVolumeSpec) string {
 	return ""
 }
 
+// GetSupportedVolumeFromSnapshotDataSpec gets supported volume from snapshot data spec
 func GetSupportedVolumeFromSnapshotDataSpec(spec *VolumeSnapshotDataSpec) string {
 	if spec.HostPath != nil {
 		return "hostPath"
@@ -265,91 +276,102 @@ func GetSupportedVolumeFromSnapshotDataSpec(spec *VolumeSnapshotDataSpec) string
 	return ""
 }
 
-// Required to satisfy Object interface
+// GetObjectKind is required to satisfy Object interface
 func (v *VolumeSnapshotData) GetObjectKind() schema.ObjectKind {
 	return &v.TypeMeta
 }
 
-// Required to satisfy ObjectMetaAccessor interface
+// GetObjectMeta is required to satisfy ObjectMetaAccessor interface
 func (v *VolumeSnapshotData) GetObjectMeta() metav1.Object {
 	return &v.Metadata
 }
 
-// Required to satisfy Object interface
+// GetObjectKind is required to satisfy Object interface
 func (vd *VolumeSnapshotDataList) GetObjectKind() schema.ObjectKind {
 	return &vd.TypeMeta
 }
 
-// Required to satisfy ListMetaAccessor interface
+// GetListMeta is required to satisfy ListMetaAccessor interface
 func (vd *VolumeSnapshotDataList) GetListMeta() metav1.List {
 	return &vd.Metadata
 }
 
-// Required to satisfy Object interface
+// GetObjectKind is required to satisfy Object interface
 func (v *VolumeSnapshot) GetObjectKind() schema.ObjectKind {
 	return &v.TypeMeta
 }
 
-// Required to satisfy ObjectMetaAccessor interface
+// GetObjectMeta is required to satisfy ObjectMetaAccessor interface
 func (v *VolumeSnapshot) GetObjectMeta() metav1.Object {
 	return &v.Metadata
 }
 
-// Required to satisfy Object interface
+// GetObjectKind is required to satisfy Object interface
 func (vd *VolumeSnapshotList) GetObjectKind() schema.ObjectKind {
 	return &vd.TypeMeta
 }
 
-// Required to satisfy ListMetaAccessor interface
+// GetListMeta is required to satisfy ListMetaAccessor interface
 func (vd *VolumeSnapshotList) GetListMeta() metav1.List {
 	return &vd.Metadata
 }
 
+// VolumeSnapshotDataListCopy is a VolumeSnapshotDataList type
 type VolumeSnapshotDataListCopy VolumeSnapshotDataList
+
+// VolumeSnapshotDataCopy is a VolumeSnapshotData type
 type VolumeSnapshotDataCopy VolumeSnapshotData
+
+// VolumeSnapshotListCopy is a VolumeSnapshotList type
 type VolumeSnapshotListCopy VolumeSnapshotList
+
+// VolumeSnapshotCopy is a VolumeSnapshot type
 type VolumeSnapshotCopy VolumeSnapshot
 
-func (e *VolumeSnapshot) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON unmarshalls json data
+func (v *VolumeSnapshot) UnmarshalJSON(data []byte) error {
 	tmp := VolumeSnapshotCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
 	}
 	tmp2 := VolumeSnapshot(tmp)
-	*e = tmp2
+	*v = tmp2
 	return nil
 }
 
-func (el *VolumeSnapshotList) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON unmarshals json data
+func (vd *VolumeSnapshotList) UnmarshalJSON(data []byte) error {
 	tmp := VolumeSnapshotListCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
 	}
 	tmp2 := VolumeSnapshotList(tmp)
-	*el = tmp2
+	*vd = tmp2
 	return nil
 }
 
-func (e *VolumeSnapshotData) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON unmarshals json data
+func (v *VolumeSnapshotData) UnmarshalJSON(data []byte) error {
 	tmp := VolumeSnapshotDataCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
 	}
 	tmp2 := VolumeSnapshotData(tmp)
-	*e = tmp2
+	*v = tmp2
 	return nil
 }
 
-func (el *VolumeSnapshotDataList) UnmarshalJSON(data []byte) error {
+// UnmarshalJSON unmarshals json data
+func (vd *VolumeSnapshotDataList) UnmarshalJSON(data []byte) error {
 	tmp := VolumeSnapshotDataListCopy{}
 	err := json.Unmarshal(data, &tmp)
 	if err != nil {
 		return err
 	}
 	tmp2 := VolumeSnapshotDataList(tmp)
-	*el = tmp2
+	*vd = tmp2
 	return nil
 }

--- a/snapshot/pkg/client/client.go
+++ b/snapshot/pkg/client/client.go
@@ -34,9 +34,11 @@ import (
 )
 
 const (
+	// SnapshotPVCAnnotation is "snapshot.alpha.kubernetes.io/snapshot"
 	SnapshotPVCAnnotation = "snapshot.alpha.kubernetes.io/snapshot"
 )
 
+// NewClient creates a new RESTClient
 func NewClient(cfg *rest.Config) (*rest.RESTClient, *runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 	if err := crdv1.AddToScheme(scheme); err != nil {
@@ -57,6 +59,7 @@ func NewClient(cfg *rest.Config) (*rest.RESTClient, *runtime.Scheme, error) {
 	return client, scheme, nil
 }
 
+// CreateCRD creates CustomResourceDefinition
 func CreateCRD(clientset apiextensionsclient.Interface) error {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
@@ -101,6 +104,7 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 	return nil
 }
 
+// WaitForSnapshotResource waits for the snapshot resource
 func WaitForSnapshotResource(snapshotClient *rest.RESTClient) error {
 	return wait.Poll(100*time.Millisecond, 60*time.Second, func() (bool, error) {
 		_, err := snapshotClient.Get().Namespace(apiv1.NamespaceDefault).Resource(crdv1.VolumeSnapshotDataResourcePlural).DoRaw()

--- a/snapshot/pkg/cloudprovider/cloud.go
+++ b/snapshot/pkg/cloudprovider/cloud.go
@@ -51,6 +51,7 @@ type Clusters interface {
 	Master(clusterName string) (string, error)
 }
 
+// GetLoadBalancerName gets the name of the load balancer.
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
 func GetLoadBalancerName(service *v1.Service) string {
@@ -64,6 +65,7 @@ func GetLoadBalancerName(service *v1.Service) string {
 	return ret
 }
 
+// GetInstanceProviderID gets the instance provider ID
 func GetInstanceProviderID(cloud Interface, nodeName types.NodeName) (string, error) {
 	instances, ok := cloud.Instances()
 	if !ok {
@@ -153,8 +155,10 @@ type Routes interface {
 }
 
 var (
-	InstanceNotFound = errors.New("instance not found")
-	DiskNotFound     = errors.New("disk is not found")
+	// ErrInstanceNotFound is the error for instance not found
+	ErrInstanceNotFound = errors.New("instance not found")
+	// ErrDiskNotFound is the error for disk not found
+	ErrDiskNotFound = errors.New("disk is not found")
 )
 
 // Zone represents the location of a particular machine.

--- a/snapshot/pkg/cloudprovider/plugins.go
+++ b/snapshot/pkg/cloudprovider/plugins.go
@@ -87,7 +87,7 @@ func GetCloudProvider(name string, config io.Reader) (Interface, error) {
 	return f(config)
 }
 
-// Detects if the string is an external cloud provider
+// IsExternal detects if the string is an external cloud provider
 func IsExternal(name string) bool {
 	return name == externalCloudProvider
 }

--- a/snapshot/pkg/cloudprovider/providers/aws/aws_instancegroups.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/aws_instancegroups.go
@@ -42,8 +42,7 @@ func ResizeInstanceGroup(asg ASG, instanceGroupName string, size int) error {
 	return nil
 }
 
-// Implement InstanceGroups.ResizeInstanceGroup
-// Set the size to the fixed size
+// ResizeInstanceGroup sets the size to the fixed size
 func (c *Cloud) ResizeInstanceGroup(instanceGroupName string, size int) error {
 	return ResizeInstanceGroup(c.asg, instanceGroupName, size)
 }
@@ -70,8 +69,7 @@ func DescribeInstanceGroup(asg ASG, instanceGroupName string) (InstanceGroupInfo
 	return &awsInstanceGroup{group: group}, nil
 }
 
-// Implement InstanceGroups.DescribeInstanceGroup
-// Queries the cloud provider for information about the specified instance group
+// DescribeInstanceGroup queries the cloud provider for information about the specified instance group
 func (c *Cloud) DescribeInstanceGroup(instanceGroupName string) (InstanceGroupInfo, error) {
 	return DescribeInstanceGroup(c.asg, instanceGroupName)
 }

--- a/snapshot/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// ProxyProtocolPolicyName is the proxy protocol policy name
 const ProxyProtocolPolicyName = "k8s-proxyprotocol-enabled"
 
 func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBalancerName string, listeners []*elb.Listener, subnetIDs []string, securityGroupIDs []string, internalELB, proxyProtocol bool, loadBalancerAttributes *elb.LoadBalancerAttributes) (*elb.LoadBalancerDescription, error) {
@@ -393,16 +394,16 @@ func (c *Cloud) ensureLoadBalancerInstances(loadBalancerName string, lbInstances
 	removals := actual.Difference(expected)
 
 	addInstances := []*elb.Instance{}
-	for _, instanceId := range additions.List() {
+	for _, instanceID := range additions.List() {
 		addInstance := &elb.Instance{}
-		addInstance.InstanceId = aws.String(instanceId)
+		addInstance.InstanceId = aws.String(instanceID)
 		addInstances = append(addInstances, addInstance)
 	}
 
 	removeInstances := []*elb.Instance{}
-	for _, instanceId := range removals.List() {
+	for _, instanceID := range removals.List() {
 		removeInstance := &elb.Instance{}
-		removeInstance.InstanceId = aws.String(instanceId)
+		removeInstance.InstanceId = aws.String(instanceID)
 		removeInstances = append(removeInstances, removeInstance)
 	}
 

--- a/snapshot/pkg/cloudprovider/providers/aws/aws_metrics.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/aws_metrics.go
@@ -18,7 +18,7 @@ package aws
 
 import "github.com/prometheus/client_golang/prometheus"
 
-var awsApiMetric = prometheus.NewHistogramVec(
+var awsAPIMetric = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name: "cloudprovider_aws_api_request_duration_seconds",
 		Help: "Latency of aws api call",
@@ -26,7 +26,7 @@ var awsApiMetric = prometheus.NewHistogramVec(
 	[]string{"request"},
 )
 
-var awsApiErrorMetric = prometheus.NewCounterVec(
+var awsAPIErrorMetric = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cloudprovider_aws_api_request_errors",
 		Help: "AWS Api errors",
@@ -35,6 +35,6 @@ var awsApiErrorMetric = prometheus.NewCounterVec(
 )
 
 func registerMetrics() {
-	prometheus.MustRegister(awsApiMetric)
-	prometheus.MustRegister(awsApiErrorMetric)
+	prometheus.MustRegister(awsAPIMetric)
+	prometheus.MustRegister(awsAPIErrorMetric)
 }

--- a/snapshot/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/aws_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const TestClusterId = "clusterid.test"
+const TestClusterID = "clusterid.test"
 const TestClusterName = "testCluster"
 
 func TestReadAWSCloudConfig(t *testing.T) {
@@ -147,7 +147,7 @@ func NewFakeAWSServices() *FakeAWSServices {
 
 	var tag ec2.Tag
 	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
-	tag.Value = aws.String(TestClusterId)
+	tag.Value = aws.String(TestClusterID)
 	selfInstance.Tags = []*ec2.Tag{&tag}
 
 	return s
@@ -283,7 +283,7 @@ func instanceMatchesFilter(instance *ec2.Instance, filter *ec2.Filter) bool {
 	panic("Unknown filter name: " + name)
 }
 
-func (self *FakeEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
+func (e *FakeEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*ec2.Instance, error) {
 	matches := []*ec2.Instance{}
 	for _, instance := range self.aws.instances {
 		if request.InstanceIds != nil {
@@ -325,7 +325,7 @@ type FakeMetadata struct {
 	aws *FakeAWSServices
 }
 
-func (self *FakeMetadata) GetMetadata(key string) (string, error) {
+func (fake *FakeMetadata) GetMetadata(key string) (string, error) {
 	networkInterfacesPrefix := "network/interfaces/macs/"
 	i := self.aws.selfInstance
 	if key == "placement/availability-zone" {
@@ -347,28 +347,26 @@ func (self *FakeMetadata) GetMetadata(key string) (string, error) {
 	} else if strings.HasPrefix(key, networkInterfacesPrefix) {
 		if key == networkInterfacesPrefix {
 			return strings.Join(self.aws.networkInterfacesMacs, "/\n") + "/\n", nil
-		} else {
-			keySplit := strings.Split(key, "/")
-			macParam := keySplit[3]
-			if len(keySplit) == 5 && keySplit[4] == "vpc-id" {
-				for i, macElem := range self.aws.networkInterfacesMacs {
-					if macParam == macElem {
-						return self.aws.networkInterfacesVpcIDs[i], nil
-					}
+		}
+		keySplit := strings.Split(key, "/")
+		macParam := keySplit[3]
+		if len(keySplit) == 5 && keySplit[4] == "vpc-id" {
+			for i, macElem := range self.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return self.aws.networkInterfacesVpcIDs[i], nil
 				}
 			}
-			return "", nil
 		}
-	} else {
 		return "", nil
 	}
+	return "", nil
 }
 
-func (ec2 *FakeEC2) AttachVolume(request *ec2.AttachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
+func (e *FakeEC2) AttachVolume(request *ec2.AttachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DetachVolume(request *ec2.DetachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
+func (e *FakeEC2) DetachVolume(request *ec2.DetachVolumeInput) (resp *ec2.VolumeAttachment, err error) {
 	panic("Not implemented")
 }
 
@@ -377,57 +375,57 @@ func (e *FakeEC2) DescribeVolumes(request *ec2.DescribeVolumesInput) ([]*ec2.Vol
 	return args.Get(0).([]*ec2.Volume), nil
 }
 
-func (ec2 *FakeEC2) CreateVolume(request *ec2.CreateVolumeInput) (resp *ec2.Volume, err error) {
+func (e *FakeEC2) CreateVolume(request *ec2.CreateVolumeInput) (resp *ec2.Volume, err error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DeleteVolume(request *ec2.DeleteVolumeInput) (resp *ec2.DeleteVolumeOutput, err error) {
+func (e *FakeEC2) DeleteVolume(request *ec2.DeleteVolumeInput) (resp *ec2.DeleteVolumeOutput, err error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
+func (e *FakeEC2) DescribeSecurityGroups(request *ec2.DescribeSecurityGroupsInput) ([]*ec2.SecurityGroup, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
+func (e *FakeEC2) CreateSecurityGroup(*ec2.CreateSecurityGroupInput) (*ec2.CreateSecurityGroupOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+func (e *FakeEC2) DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
+func (e *FakeEC2) AuthorizeSecurityGroupIngress(*ec2.AuthorizeSecurityGroupIngressInput) (*ec2.AuthorizeSecurityGroupIngressOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+func (e *FakeEC2) RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
+func (e *FakeEC2) DescribeSubnets(request *ec2.DescribeSubnetsInput) ([]*ec2.Subnet, error) {
 	ec2.DescribeSubnetsInput = request
 	return ec2.Subnets, nil
 }
 
-func (ec2 *FakeEC2) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
+func (e *FakeEC2) CreateTags(*ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {
 	panic("Not implemented")
 }
 
-func (ec2 *FakeEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
+func (e *FakeEC2) DescribeRouteTables(request *ec2.DescribeRouteTablesInput) ([]*ec2.RouteTable, error) {
 	ec2.DescribeRouteTablesInput = request
 	return ec2.RouteTables, nil
 }
 
-func (s *FakeEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
+func (e *FakeEC2) CreateRoute(request *ec2.CreateRouteInput) (*ec2.CreateRouteOutput, error) {
 	panic("Not implemented")
 }
 
-func (s *FakeEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
+func (e *FakeEC2) DeleteRoute(request *ec2.DeleteRouteInput) (*ec2.DeleteRouteOutput, error) {
 	panic("Not implemented")
 }
 
-func (s *FakeEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
+func (e *FakeEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttributeInput) (*ec2.ModifyInstanceAttributeOutput, error) {
 	panic("Not implemented")
 }
 
@@ -476,23 +474,23 @@ func (ec2 *FakeELB) ApplySecurityGroupsToLoadBalancer(*elb.ApplySecurityGroupsTo
 	panic("Not implemented")
 }
 
-func (elb *FakeELB) ConfigureHealthCheck(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error) {
+func (ec2 *FakeELB) ConfigureHealthCheck(*elb.ConfigureHealthCheckInput) (*elb.ConfigureHealthCheckOutput, error) {
 	panic("Not implemented")
 }
 
-func (elb *FakeELB) CreateLoadBalancerPolicy(*elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error) {
+func (ec2 *FakeELB) CreateLoadBalancerPolicy(*elb.CreateLoadBalancerPolicyInput) (*elb.CreateLoadBalancerPolicyOutput, error) {
 	panic("Not implemented")
 }
 
-func (elb *FakeELB) SetLoadBalancerPoliciesForBackendServer(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error) {
+func (ec2 *FakeELB) SetLoadBalancerPoliciesForBackendServer(*elb.SetLoadBalancerPoliciesForBackendServerInput) (*elb.SetLoadBalancerPoliciesForBackendServerOutput, error) {
 	panic("Not implemented")
 }
 
-func (elb *FakeELB) DescribeLoadBalancerAttributes(*elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error) {
+func (ec2 *FakeELB) DescribeLoadBalancerAttributes(*elb.DescribeLoadBalancerAttributesInput) (*elb.DescribeLoadBalancerAttributesOutput, error) {
 	panic("Not implemented")
 }
 
-func (elb *FakeELB) ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error) {
+func (ec2 *FakeELB) ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttributesInput) (*elb.ModifyLoadBalancerAttributesOutput, error) {
 	panic("Not implemented")
 }
 
@@ -752,13 +750,13 @@ func TestSubnetIDsinVPC(t *testing.T) {
 		return
 	}
 
-	result_set := make(map[string]bool)
+	resultSet := make(map[string]bool)
 	for _, v := range result {
-		result_set[v] = true
+		resultSet[v] = true
 	}
 
 	for i := range subnets {
-		if !result_set[subnets[i]["id"]] {
+		if !resultSet[subnets[i]["id"]] {
 			t.Errorf("Expected subnet%d '%s' in result: %v", i, subnets[i]["id"], result)
 			return
 		}
@@ -778,13 +776,13 @@ func TestSubnetIDsinVPC(t *testing.T) {
 		return
 	}
 
-	result_set = make(map[string]bool)
+	resultSet = make(map[string]bool)
 	for _, v := range result {
-		result_set[v] = true
+		resultSet[v] = true
 	}
 
 	for i := range subnets {
-		if !result_set[subnets[i]["id"]] {
+		if !resultSet[subnets[i]["id"]] {
 			t.Errorf("Expected subnet%d '%s' in result: %v", i, subnets[i]["id"], result)
 			return
 		}
@@ -848,7 +846,7 @@ func TestSubnetIDsinVPC(t *testing.T) {
 }
 
 func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {
-	oldIpPermission := ec2.IpPermission{
+	oldIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("firstGroupId")},
 			{GroupId: aws.String("secondGroupId")},
@@ -856,24 +854,24 @@ func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {
 		},
 	}
 
-	existingIpPermission := ec2.IpPermission{
+	existingIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("secondGroupId")},
 		},
 	}
 
-	newIpPermission := ec2.IpPermission{
+	newIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("fourthGroupId")},
 		},
 	}
 
-	equals := ipPermissionExists(&existingIpPermission, &oldIpPermission, false)
+	equals := ipPermissionExists(&existingIPPermission, &oldIPPermission, false)
 	if !equals {
 		t.Errorf("Should have been considered equal since first is in the second array of groups")
 	}
 
-	equals = ipPermissionExists(&newIpPermission, &oldIpPermission, false)
+	equals = ipPermissionExists(&newIPPermission, &oldIPPermission, false)
 	if equals {
 		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
 	}
@@ -881,9 +879,9 @@ func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {
 
 func TestIpPermissionExistsHandlesRangeSubsets(t *testing.T) {
 	// Two existing scenarios we'll test against
-	emptyIpPermission := ec2.IpPermission{}
+	emptyIPPermission := ec2.IpPermission{}
 
-	oldIpPermission := ec2.IpPermission{
+	oldIPPermission := ec2.IpPermission{
 		IpRanges: []*ec2.IpRange{
 			{CidrIp: aws.String("10.0.0.0/8")},
 			{CidrIp: aws.String("192.168.1.0/24")},
@@ -891,53 +889,53 @@ func TestIpPermissionExistsHandlesRangeSubsets(t *testing.T) {
 	}
 
 	// Two already existing ranges and a new one
-	existingIpPermission := ec2.IpPermission{
+	existingIPPermission := ec2.IpPermission{
 		IpRanges: []*ec2.IpRange{
 			{CidrIp: aws.String("10.0.0.0/8")},
 		},
 	}
-	existingIpPermission2 := ec2.IpPermission{
+	existingIPPermission2 := ec2.IpPermission{
 		IpRanges: []*ec2.IpRange{
 			{CidrIp: aws.String("192.168.1.0/24")},
 		},
 	}
 
-	newIpPermission := ec2.IpPermission{
+	newIPPermission := ec2.IpPermission{
 		IpRanges: []*ec2.IpRange{
 			{CidrIp: aws.String("172.16.0.0/16")},
 		},
 	}
 
-	exists := ipPermissionExists(&emptyIpPermission, &emptyIpPermission, false)
+	exists := ipPermissionExists(&emptyIPPermission, &emptyIPPermission, false)
 	if !exists {
 		t.Errorf("Should have been considered existing since we're comparing a range array against itself")
 	}
-	exists = ipPermissionExists(&oldIpPermission, &oldIpPermission, false)
+	exists = ipPermissionExists(&oldIPPermission, &oldIPPermission, false)
 	if !exists {
 		t.Errorf("Should have been considered existing since we're comparing a range array against itself")
 	}
 
-	exists = ipPermissionExists(&existingIpPermission, &oldIpPermission, false)
+	exists = ipPermissionExists(&existingIPPermission, &oldIPPermission, false)
 	if !exists {
 		t.Errorf("Should have been considered existing since 10.* is in oldIpPermission's array of ranges")
 	}
-	exists = ipPermissionExists(&existingIpPermission2, &oldIpPermission, false)
+	exists = ipPermissionExists(&existingIPPermission2, &oldIPPermission, false)
 	if !exists {
 		t.Errorf("Should have been considered existing since 192.* is in oldIpPermission2's array of ranges")
 	}
 
-	exists = ipPermissionExists(&newIpPermission, &emptyIpPermission, false)
+	exists = ipPermissionExists(&newIPPermission, &emptyIPPermission, false)
 	if exists {
 		t.Errorf("Should have not been considered existing since we compared against a missing array of ranges")
 	}
-	exists = ipPermissionExists(&newIpPermission, &oldIpPermission, false)
+	exists = ipPermissionExists(&newIPPermission, &oldIPPermission, false)
 	if exists {
 		t.Errorf("Should have not been considered existing since 172.* is not in oldIpPermission's array of ranges")
 	}
 }
 
 func TestIpPermissionExistsHandlesMultipleGroupIdsWithUserIds(t *testing.T) {
-	oldIpPermission := ec2.IpPermission{
+	oldIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("firstGroupId"), UserId: aws.String("firstUserId")},
 			{GroupId: aws.String("secondGroupId"), UserId: aws.String("secondUserId")},
@@ -945,24 +943,24 @@ func TestIpPermissionExistsHandlesMultipleGroupIdsWithUserIds(t *testing.T) {
 		},
 	}
 
-	existingIpPermission := ec2.IpPermission{
+	existingIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("secondGroupId"), UserId: aws.String("secondUserId")},
 		},
 	}
 
-	newIpPermission := ec2.IpPermission{
+	newIPPermission := ec2.IpPermission{
 		UserIdGroupPairs: []*ec2.UserIdGroupPair{
 			{GroupId: aws.String("secondGroupId"), UserId: aws.String("anotherUserId")},
 		},
 	}
 
-	equals := ipPermissionExists(&existingIpPermission, &oldIpPermission, true)
+	equals := ipPermissionExists(&existingIPPermission, &oldIPPermission, true)
 	if !equals {
 		t.Errorf("Should have been considered equal since first is in the second array of groups")
 	}
 
-	equals = ipPermissionExists(&newIpPermission, &oldIpPermission, true)
+	equals = ipPermissionExists(&newIPPermission, &oldIPPermission, true)
 	if equals {
 		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
 	}
@@ -975,7 +973,7 @@ func TestFindInstanceByNodeNameExcludesTerminatedInstances(t *testing.T) {
 
 	var tag ec2.Tag
 	tag.Key = aws.String(TagNameKubernetesClusterLegacy)
-	tag.Value = aws.String(TestClusterId)
+	tag.Value = aws.String(TestClusterID)
 	tags := []*ec2.Tag{&tag}
 
 	var runningInstance ec2.Instance
@@ -1018,7 +1016,7 @@ func TestFindInstancesByNodeNameCached(t *testing.T) {
 	nodeNameTwo := "my-dns-two.internal"
 
 	var tag ec2.Tag
-	tag.Key = aws.String(TagNameKubernetesClusterPrefix + TestClusterId)
+	tag.Key = aws.String(TagNameKubernetesClusterPrefix + TestClusterID)
 	tag.Value = aws.String("")
 	tags := []*ec2.Tag{&tag}
 
@@ -1071,16 +1069,16 @@ func TestGetVolumeLabels(t *testing.T) {
 	awsServices := NewFakeAWSServices()
 	c, err := newAWSCloud(strings.NewReader("[global]"), awsServices)
 	assert.Nil(t, err, "Error building aws cloud: %v", err)
-	volumeId := awsVolumeID("vol-VolumeId")
-	expectedVolumeRequest := &ec2.DescribeVolumesInput{VolumeIds: []*string{volumeId.awsString()}}
+	volumeID := awsVolumeID("vol-VolumeId")
+	expectedVolumeRequest := &ec2.DescribeVolumesInput{VolumeIds: []*string{volumeID.awsString()}}
 	awsServices.ec2.On("DescribeVolumes", expectedVolumeRequest).Return([]*ec2.Volume{
 		{
-			VolumeId:         volumeId.awsString(),
+			VolumeId:         volumeID.awsString(),
 			AvailabilityZone: aws.String("us-east-1a"),
 		},
 	})
 
-	labels, err := c.GetVolumeLabels(KubernetesVolumeID("aws:///" + string(volumeId)))
+	labels, err := c.GetVolumeLabels(KubernetesVolumeID("aws:///" + string(volumeID)))
 
 	assert.Nil(t, err, "Error creating Volume %v", err)
 	assert.Equal(t, map[string]string{
@@ -1089,7 +1087,7 @@ func TestGetVolumeLabels(t *testing.T) {
 	awsServices.ec2.AssertExpectations(t)
 }
 
-func (self *FakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
+func (ec2 *FakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
 	self.On("DescribeLoadBalancers", &elb.DescribeLoadBalancersInput{LoadBalancerNames: []*string{aws.String(loadBalancerName)}}).Return(&elb.DescribeLoadBalancersOutput{
 		LoadBalancerDescriptions: []*elb.LoadBalancerDescription{{}},
 	})

--- a/snapshot/pkg/cloudprovider/providers/aws/device_allocator.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/device_allocator.go
@@ -25,14 +25,14 @@ import "fmt"
 // "/dev/xvdba".
 type ExistingDevices map[mountDevice]awsVolumeID
 
-// On AWS, we should assign new (not yet used) device names to attached volumes.
-// If we reuse a previously used name, we may get the volume "attaching" forever,
-// see https://aws.amazon.com/premiumsupport/knowledge-center/ebs-stuck-attaching/.
 // DeviceAllocator finds available device name, taking into account already
 // assigned device names from ExistingDevices map. It tries to find the next
 // device name to the previously assigned one (from previous DeviceAllocator
 // call), so all available device names are used eventually and it minimizes
 // device name reuse.
+// On AWS, we should assign new (not yet used) device names to attached volumes.
+// If we reuse a previously used name, we may get the volume "attaching" forever,
+// see https://aws.amazon.com/premiumsupport/knowledge-center/ebs-stuck-attaching/.
 // All these allocations are in-memory, nothing is written to / read from
 // /dev directory.
 type DeviceAllocator interface {
@@ -47,7 +47,7 @@ type deviceAllocator struct {
 	lastIndex       int
 }
 
-// Allocates device names according to scheme ba..bz, ca..cz
+// NewDeviceAllocator allocates device names according to scheme ba..bz, ca..cz
 // it moves along the ring and always picks next device until
 // device list is exhausted.
 func NewDeviceAllocator(lastIndex int) DeviceAllocator {

--- a/snapshot/pkg/cloudprovider/providers/aws/retry_handler.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/retry_handler.go
@@ -39,14 +39,14 @@ type CrossRequestRetryDelay struct {
 	backoff Backoff
 }
 
-// Create a new CrossRequestRetryDelay
+// NewCrossRequestRetryDelay creates a new CrossRequestRetryDelay
 func NewCrossRequestRetryDelay() *CrossRequestRetryDelay {
 	c := &CrossRequestRetryDelay{}
 	c.backoff.init(decayIntervalSeconds, decayFraction, maxDelay)
 	return c
 }
 
-// Added to the Sign chain; called before each request
+// BeforeSign is added to the Sign chain; called before each request
 func (c *CrossRequestRetryDelay) BeforeSign(r *request.Request) {
 	now := time.Now()
 	delay := c.backoff.ComputeDelayForRequest(now)
@@ -72,7 +72,7 @@ func describeRequest(r *request.Request) string {
 	return service + "::" + name
 }
 
-// Added to the AfterRetry chain; called after any error
+// AfterRetry is added to the AfterRetry chain; called after any error
 func (c *CrossRequestRetryDelay) AfterRetry(r *request.Request) {
 	if r.Error == nil {
 		return
@@ -113,7 +113,7 @@ func (b *Backoff) init(decayIntervalSeconds int, decayFraction float64, maxDelay
 	b.maxDelay = maxDelay
 }
 
-// Computes the delay required for a request, also updating internal state to count this request
+// ComputeDelayForRequest computes the delay required for a request, also updating internal state to count this request
 func (b *Backoff) ComputeDelayForRequest(now time.Time) time.Duration {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
@@ -152,7 +152,7 @@ func (b *Backoff) ComputeDelayForRequest(now time.Time) time.Duration {
 	return time.Second * time.Duration(int(delay.Seconds()))
 }
 
-// Called when we observe a throttling error
+// ReportError is called when we observe a throttling error
 func (b *Backoff) ReportError() {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()

--- a/snapshot/pkg/cloudprovider/providers/aws/sets_ippermissions.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/sets_ippermissions.go
@@ -23,8 +23,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
+// IPPermissionSet is the IP Permission Set
 type IPPermissionSet map[string]*ec2.IpPermission
 
+// NewIPPermissionSet creates a IPPermissionSet
 func NewIPPermissionSet(items ...*ec2.IpPermission) IPPermissionSet {
 	s := make(IPPermissionSet)
 	s.Insert(items...)
@@ -97,10 +99,10 @@ func (s IPPermissionSet) List() []*ec2.IpPermission {
 	return res
 }
 
-// IsSuperset returns true if and only if s1 is a superset of s2.
-func (s1 IPPermissionSet) IsSuperset(s2 IPPermissionSet) bool {
+// IsSuperset returns true if and only if s is a superset of s2.
+func (s IPPermissionSet) IsSuperset(s2 IPPermissionSet) bool {
 	for k := range s2 {
-		_, found := s1[k]
+		_, found := s[k]
 		if !found {
 			return false
 		}
@@ -108,19 +110,19 @@ func (s1 IPPermissionSet) IsSuperset(s2 IPPermissionSet) bool {
 	return true
 }
 
-// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Equal returns true if and only if s is equal (as a set) to s2.
 // Two sets are equal if their membership is identical.
 // (In practice, this means same elements, order doesn't matter)
-func (s1 IPPermissionSet) Equal(s2 IPPermissionSet) bool {
-	return len(s1) == len(s2) && s1.IsSuperset(s2)
+func (s IPPermissionSet) Equal(s2 IPPermissionSet) bool {
+	return len(s) == len(s2) && s.IsSuperset(s2)
 }
 
 // Difference returns a set of objects that are not in s2
 // For example:
-// s1 = {a1, a2, a3}
+// s = {a1, a2, a3}
 // s2 = {a1, a2, a4, a5}
-// s1.Difference(s2) = {a3}
-// s2.Difference(s1) = {a4, a5}
+// s.Difference(s2) = {a3}
+// s2.Difference(s) = {a4, a5}
 func (s IPPermissionSet) Difference(s2 IPPermissionSet) IPPermissionSet {
 	result := NewIPPermissionSet()
 	for k, v := range s {

--- a/snapshot/pkg/cloudprovider/providers/aws/tags.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/tags.go
@@ -38,6 +38,7 @@ const TagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
 // did not allow shared resources.
 const TagNameKubernetesClusterLegacy = "KubernetesCluster"
 
+// ResourceLifecycle is the value we use when tagging the resource life cycle
 type ResourceLifecycle string
 
 const (
@@ -152,13 +153,13 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 // Ensure that a resource has the correct tags
 // If it has no tags, we assume that this was a problem caused by an error in between creation and tagging,
 // and we add the tags.  If it has a different cluster's tags, that is an error.
-func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags []*ec2.Tag) error {
+func (t *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags []*ec2.Tag) error {
 	actualTagMap := make(map[string]string)
 	for _, tag := range observedTags {
 		actualTagMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 	}
 
-	expectedTags := c.buildTags(lifecycle, additionalTags)
+	expectedTags := t.buildTags(lifecycle, additionalTags)
 
 	addTags := make(map[string]string)
 	for k, expected := range expectedTags {
@@ -174,7 +175,7 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 		}
 	}
 
-	if err := c.createTags(client, resourceID, lifecycle, additionalTags); err != nil {
+	if err := t.createTags(client, resourceID, lifecycle, additionalTags); err != nil {
 		return fmt.Errorf("error adding missing tags to resource %q: %v", resourceID, err)
 	}
 

--- a/snapshot/pkg/cloudprovider/providers/aws/tags_test.go
+++ b/snapshot/pkg/cloudprovider/providers/aws/tags_test.go
@@ -31,7 +31,7 @@ func TestFilterTags(t *testing.T) {
 		return
 	}
 
-	if c.tagging.ClusterID != TestClusterId {
+	if c.tagging.ClusterID != TestClusterID {
 		t.Errorf("unexpected ClusterID: %v", c.tagging.ClusterID)
 	}
 }

--- a/snapshot/pkg/cloudprovider/providers/gce/token_source.go
+++ b/snapshot/pkg/cloudprovider/providers/gce/token_source.go
@@ -57,6 +57,7 @@ func init() {
 	prometheus.MustRegister(getTokenFailCounter)
 }
 
+// AltTokenSource defines a token source
 type AltTokenSource struct {
 	oauthClient *http.Client
 	tokenURL    string
@@ -64,6 +65,7 @@ type AltTokenSource struct {
 	throttle    flowcontrol.RateLimiter
 }
 
+// Token returns a token
 func (a *AltTokenSource) Token() (*oauth2.Token, error) {
 	a.throttle.Accept()
 	getTokenCounter.Inc()
@@ -100,6 +102,7 @@ func (a *AltTokenSource) token() (*oauth2.Token, error) {
 	}, nil
 }
 
+// NewAltTokenSource creates a TokenSource
 func NewAltTokenSource(tokenURL, tokenBody string) oauth2.TokenSource {
 	client := oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource(""))
 	a := &AltTokenSource{

--- a/snapshot/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/snapshot/pkg/cloudprovider/providers/openstack/metadata.go
@@ -32,11 +32,11 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
-// metadataUrl is URL to OpenStack metadata server. It's hardcoded IPv4
+// metadataURL is URL to OpenStack metadata server. It's hardcoded IPv4
 // link-local address as documented in "OpenStack Cloud Administrator Guide",
 // chapter Compute - Networking with nova-network.
 // https://docs.openstack.org/admin-guide/compute-networking-nova.html#metadata-service
-const metadataUrl = "http://169.254.169.254/openstack/2012-08-10/meta_data.json"
+const metadataURL = "http://169.254.169.254/openstack/2012-08-10/meta_data.json"
 
 // Config drive is defined as an iso9660 or vfat (deprecated) drive
 // with the "config-2" label.
@@ -44,12 +44,13 @@ const metadataUrl = "http://169.254.169.254/openstack/2012-08-10/meta_data.json"
 const configDriveLabel = "config-2"
 const configDrivePath = "openstack/2012-08-10/meta_data.json"
 
+// ErrBadMetadata is an error for bad metadata
 var ErrBadMetadata = errors.New("Invalid OpenStack metadata, got empty uuid")
 
-// Assumes the "2012-08-10" meta_data.json format.
+// Metadata assumes the "2012-08-10" meta_data.json format.
 // See http://docs.openstack.org/user-guide/cli_config_drive.html
 type Metadata struct {
-	Uuid             string `json:"uuid"`
+	UUID             string `json:"uuid"`
 	Name             string `json:"name"`
 	AvailabilityZone string `json:"availability_zone"`
 	// .. and other fields we don't care about.  Expand as necessary.
@@ -64,7 +65,7 @@ func parseMetadata(r io.Reader) (*Metadata, error) {
 		return nil, err
 	}
 
-	if metadata.Uuid == "" {
+	if metadata.UUID == "" {
 		return nil, ErrBadMetadata
 	}
 
@@ -121,16 +122,16 @@ func getMetadataFromConfigDrive() (*Metadata, error) {
 
 func getMetadataFromMetadataService() (*Metadata, error) {
 	// Try to get JSON from metdata server.
-	glog.V(4).Infof("Attempting to fetch metadata from %s", metadataUrl)
-	resp, err := http.Get(metadataUrl)
+	glog.V(4).Infof("Attempting to fetch metadata from %s", metadataURL)
+	resp, err := http.Get(metadataURL)
 	if err != nil {
-		glog.V(3).Infof("Cannot read %s: %v", metadataUrl, err)
+		glog.V(3).Infof("Cannot read %s: %v", metadataURL, err)
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("Unexpected status code when reading metadata from %s: %s", metadataUrl, resp.Status)
+		err = fmt.Errorf("Unexpected status code when reading metadata from %s: %s", metadataURL, resp.Status)
 		glog.V(3).Infof("%v", err)
 		return nil, err
 	}

--- a/snapshot/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/snapshot/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 )
 
+// NewNetworkV2 creates a new Network V2 endpoint
 func (os *OpenStack) NewNetworkV2() (*gophercloud.ServiceClient, error) {
 	network, err := openstack.NewNetworkV2(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -34,6 +35,7 @@ func (os *OpenStack) NewNetworkV2() (*gophercloud.ServiceClient, error) {
 	return network, nil
 }
 
+// NewComputeV2 creates a new Compute V2 endpoint
 func (os *OpenStack) NewComputeV2() (*gophercloud.ServiceClient, error) {
 	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -45,6 +47,9 @@ func (os *OpenStack) NewComputeV2() (*gophercloud.ServiceClient, error) {
 	return compute, nil
 }
 
+// NewBlockStorageV1 creates a new BlockStorage V1 endpoint
+// TODO(xyang): This should be removed at some point after the OpenStack Queens release
+// because V1 API has been deprecated for many releases and was finally removed from Cinder in Queens.
 func (os *OpenStack) NewBlockStorageV1() (*gophercloud.ServiceClient, error) {
 	storage, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,
@@ -56,6 +61,7 @@ func (os *OpenStack) NewBlockStorageV1() (*gophercloud.ServiceClient, error) {
 	return storage, nil
 }
 
+// NewBlockStorageV2 creates a new BlockStorage V2 endpoint
 func (os *OpenStack) NewBlockStorageV2() (*gophercloud.ServiceClient, error) {
 	storage, err := openstack.NewBlockStorageV2(os.provider, gophercloud.EndpointOpts{
 		Region: os.region,

--- a/snapshot/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/snapshot/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// Instances defines compute instances
 type Instances struct {
 	compute *gophercloud.ServiceClient
 }
@@ -47,11 +48,12 @@ func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 	return &Instances{compute}, true
 }
 
-func (i *Instances) List(name_filter string) ([]types.NodeName, error) {
-	glog.V(4).Infof("openstack List(%v) called", name_filter)
+// List lists node names
+func (i *Instances) List(nameFilter string) ([]types.NodeName, error) {
+	glog.V(4).Infof("openstack List(%v) called", nameFilter)
 
 	opts := servers.ListOpts{
-		Name:   name_filter,
+		Name:   nameFilter,
 		Status: "ACTIVE",
 	}
 	pager := servers.List(i.compute, opts)
@@ -72,12 +74,12 @@ func (i *Instances) List(name_filter string) ([]types.NodeName, error) {
 	}
 
 	glog.V(3).Infof("Found %v instances matching %v: %v",
-		len(ret), name_filter, ret)
+		len(ret), nameFilter, ret)
 
 	return ret, nil
 }
 
-// Implementation of Instances.CurrentNodeName
+// CurrentNodeName is an implementation of Instances.CurrentNodeName
 // Note this is *not* necessarily the same as hostname.
 func (i *Instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 	md, err := getMetadata()
@@ -87,10 +89,12 @@ func (i *Instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 	return types.NodeName(md.Name), nil
 }
 
+// AddSSHKeyToAllInstances adds SSH key to all instances
 func (i *Instances) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("unimplemented")
 }
 
+// NodeAddresses gets node addresses
 func (i *Instances) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 	glog.V(4).Infof("NodeAddresses(%v) called", name)
 
@@ -115,7 +119,7 @@ func (i *Instances) ExternalID(name types.NodeName) (string, error) {
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
 		if err == ErrNotFound {
-			return "", cloudprovider.InstanceNotFound
+			return "", cloudprovider.ErrInstanceNotFound
 		}
 		return "", err
 	}

--- a/snapshot/pkg/cloudprovider/providers/openstack/openstack_snapshots.go
+++ b/snapshot/pkg/cloudprovider/providers/openstack/openstack_snapshots.go
@@ -183,8 +183,8 @@ func (os *OpenStack) DeleteSnapshot(snapshotID string) error {
 	return nil
 }
 
-// FIXME(j-griffith): Name doesn't fit at all here, this is actually more like is `IsAvailable`
 // DescribeSnapshot returns the status of the snapshot
+// FIXME(j-griffith): Name doesn't fit at all here, this is actually more like is `IsAvailable`
 func (os *OpenStack) DescribeSnapshot(snapshotID string) (status string, isCompleted bool, err error) {
 	ss, err := os.snapshotService()
 	if err != nil || ss == nil {
@@ -206,7 +206,7 @@ func (os *OpenStack) DescribeSnapshot(snapshotID string) (status string, isCompl
 	return snap.Status, true, nil
 }
 
-// Find snapshot by metadata
+// FindSnapshot finds snapshot by metadata
 func (os *OpenStack) FindSnapshot(tags map[string]string) ([]string, []string, error) {
 	var snapshotIDs, statuses []string
 	ss, err := os.snapshotService()

--- a/snapshot/pkg/controller/cache/actual_state_of_world.go
+++ b/snapshot/pkg/controller/cache/actual_state_of_world.go
@@ -27,6 +27,10 @@ import (
 	crdv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 )
 
+// ActualStateOfWorld defines a set of thread-safe operations supported on
+// the snapshot controller's actual state of the world cache.
+// This cache contains snapshots the snapshot controller believes are
+// successfully created.
 type ActualStateOfWorld interface {
 	// Adds snapshot to the list of snapshots. No-op if the snapshot
 	// is already in the list.

--- a/snapshot/pkg/controller/cache/desired_state_of_world.go
+++ b/snapshot/pkg/controller/cache/desired_state_of_world.go
@@ -29,6 +29,9 @@ import (
 	crdv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 )
 
+// DesiredStateOfWorld defines a set of thread-safe operations supported on
+// the snapshot controller's desired state of the world cache. This cache
+// contains all the snapshots that should be created by the snapshot controller.
 type DesiredStateOfWorld interface {
 	// Adds snapshot to the list of snapshots. No-op if the snapshot
 	// is already in the list.

--- a/snapshot/pkg/controller/cache/util.go
+++ b/snapshot/pkg/controller/cache/util.go
@@ -26,10 +26,14 @@ import (
 	"strings"
 )
 
+// MakeSnapshotName makes a full name for a snapshot that includes
+// the namespace and the short name
 func MakeSnapshotName(namespace, name string) string {
 	return namespace + "/" + name
 }
 
+// GetNameAndNameSpaceFromSnapshotName retrieves the namespace and
+// the short name of a snapshot from its full name
 func GetNameAndNameSpaceFromSnapshotName(name string) (string, string, error) {
 	strs := strings.Split(name, "/")
 	if len(strs) != 2 {

--- a/snapshot/pkg/controller/reconciler/reconciler.go
+++ b/snapshot/pkg/controller/reconciler/reconciler.go
@@ -51,7 +51,7 @@ type reconciler struct {
 	disableReconciliationSync bool
 }
 
-// The constructor
+// NewReconciler is the constructor of Reconciler
 func NewReconciler(
 	loopPeriod time.Duration,
 	syncDuration time.Duration,

--- a/snapshot/pkg/controller/snapshot-controller/snapshot-controller.go
+++ b/snapshot/pkg/controller/snapshot-controller/snapshot-controller.go
@@ -54,6 +54,7 @@ const (
 	desiredStateOfWorldPopulatorListSnapshotsRetryDuration time.Duration = 3 * time.Minute
 )
 
+// SnapshotController is a controller that handles snapshot operations
 type SnapshotController interface {
 	Run(stopCh <-chan struct{})
 }
@@ -92,10 +93,11 @@ type snapshotController struct {
 	desiredStateOfWorldPopulator populator.DesiredStateOfWorldPopulator
 }
 
+// NewSnapshotController creates a new SnapshotController
 func NewSnapshotController(client *rest.RESTClient,
 	scheme *runtime.Scheme,
 	clientset kubernetes.Interface,
-	volumePlugins *map[string]volume.VolumePlugin,
+	volumePlugins *map[string]volume.Plugin,
 	syncDuration time.Duration) SnapshotController {
 
 	sc := &snapshotController{

--- a/snapshot/pkg/volume/cinder/processor.go
+++ b/snapshot/pkg/volume/cinder/processor.go
@@ -37,7 +37,7 @@ type cinderPlugin struct {
 	cloud *openstack.OpenStack
 }
 
-var _ volume.VolumePlugin = &cinderPlugin{}
+var _ volume.Plugin = &cinderPlugin{}
 
 // Init inits volume plugin
 func (c *cinderPlugin) Init(cloud cloudprovider.Interface) {
@@ -45,7 +45,7 @@ func (c *cinderPlugin) Init(cloud cloudprovider.Interface) {
 }
 
 // RegisterPlugin creates an uninitialized cinder plugin
-func RegisterPlugin() volume.VolumePlugin {
+func RegisterPlugin() volume.Plugin {
 	return &cinderPlugin{}
 }
 

--- a/snapshot/pkg/volume/interface.go
+++ b/snapshot/pkg/volume/interface.go
@@ -23,7 +23,8 @@ import (
 	"github.com/kubernetes-incubator/external-storage/snapshot/pkg/cloudprovider"
 )
 
-type VolumePlugin interface {
+// Plugin defines functions that should be implemented by the volume plugin
+type Plugin interface {
 	// Init inits volume plugin
 	Init(cloudprovider.Interface)
 	// SnapshotCreate creates a VolumeSnapshot from a PersistentVolumeSpec


### PR DESCRIPTION
This PR fixes the golint errors in all the files
under external-storage/snapshot. A few changes
are highlighted here:
- Renames VolumePlugin to Plugin because it is referred
  by other packages as volume.Plugin.
- Renames aws_ebs to awsebs and gce_pd to gcepd because
  golint says do not use an underscore in package name.
- Renames GCECloud to Cloud because it is referred by
  other packages as gce.Cloud.