### PR TITLE
Snapshot: Hostpath should count with errors in creating the tarball

### DIFF
--- a/snapshot/pkg/volume/hostpath/processor.go
+++ b/snapshot/pkg/volume/hostpath/processor.go
@@ -61,8 +61,12 @@ func (h *hostPathPlugin) SnapshotCreate(pv *v1.PersistentVolume, tags *map[strin
 		return nil, nil, fmt.Errorf("invalid PV spec %v", spec)
 	}
 	path := spec.HostPath.Path
-	if _, err := os.Stat(path); err != nil {
+	finfo, err := os.Stat(path)
+	if err != nil {
 		return nil, nil, fmt.Errorf("Invalid HostPath spec in PV %s: %v", pv.ObjectMeta.Name, err)
+	}
+	if !finfo.IsDir() {
+		return nil, nil, fmt.Errorf("Invalid HostPath spec in PV %s: %s is not a directory", pv.ObjectMeta.Name, spec.HostPath.Path)
 	}
 	file := depot + string(uuid.NewUUID()) + ".tgz"
 	cmdline := []string{"tar", "czf", file, "-C", path, "."}


### PR DESCRIPTION
During my tests I noticed that HostPath plugin tends to create empty snapshots on errors in PV (invalid path for hostpath). This is because tar first creates a file and if something fails it leaves it empty on the disk. The controller re-tries to take a snapshot on error. We should count with these: first check whethere there is really something to "snapshot" and then delete the broken snapshot if tar returned error.