### PR TITLE
Snapshot: add some kubernetes deployments and make container target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ flycheck_*.el
 
 # snapshot binaries
 /snapshot/_output
+/snapshot/deploy/docker/controller/snapshot-controller
+/snapshot/deploy/docker/provisioner/snapshot-provisioner

--- a/snapshot/Makefile
+++ b/snapshot/Makefile
@@ -12,16 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all controller clean test
+ifeq ($(REGISTRY),)
+	REGISTRY = quay.io/external_storage/
+endif
+ifeq ($(VERSION),)
+	VERSION = latest
+endif
+IMAGE_CONTROLLER = $(REGISTRY)snapshot-controller:$(VERSION)
+MUTABLE_IMAGE_CONTROLLER = $(REGISTRY)snapshot-controller:latest
+IMAGE_PROVISIONER = $(REGISTRY)snapshot-provisioner:$(VERSION)
+MUTABLE_IMAGE_PROVISIONER = $(REGISTRY)snapshot-provisioner:latest
 
-all: controller
+.PHONY: all controller provisioner clean container container-quick push test
+
+all: controller provisioner
 
 controller:
 	go build -o _output/bin/snapshot-controller cmd/snapshot-controller/snapshot-controller.go
+
+provisioner:
 	go build -o _output/bin/snapshot-provisioner cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
 
 clean:
+	-rm -f deploy/controller/snapshot-controller
+	-rm -f deploy/provisioner/snapshot-provisioner
 	-rm -rf _output
 
 test:
 	go test `go list ./... | grep -v 'vendor'`
+
+container: controller provisioner container-quick
+
+container-quick:
+	cp _output/bin/snapshot-controller deploy/docker/controller
+	cp _output/bin/snapshot-provisioner deploy/docker/provisioner
+	docker build -t $(MUTABLE_IMAGE_CONTROLLER) deploy/docker/controller
+	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
+	docker build -t $(MUTABLE_IMAGE_PROVISIONER) deploy/docker/provisioner
+	docker tag $(MUTABLE_IMAGE_PROVISIONER) $(IMAGE_PROVISIONER)
+
+push: container
+	docker push $(IMAGE_CONTROLLER)
+	docker push $(MUTABLE_IMAGE_CONTROLLER)
+	docker push $(IMAGE_PROVISIONER)
+	docker push $(MUTABLE_IMAGE_PROVISIONER)

--- a/snapshot/deploy/docker/controller/Dockerfile
+++ b/snapshot/deploy/docker/controller/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox:glibc
+COPY snapshot-controller /bin/snapshot-controller
+ENTRYPOINT ["/bin/snapshot-controller"]

--- a/snapshot/deploy/docker/provisioner/Dockerfile
+++ b/snapshot/deploy/docker/provisioner/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox:glibc
+COPY snapshot-provisioner /bin/snapshot-provisioner
+ENTRYPOINT ["/bin/snapshot-provisioner"]

--- a/snapshot/deploy/kubernetes/aws/deployment.yaml
+++ b/snapshot/deploy/kubernetes/aws/deployment.yaml
@@ -1,0 +1,47 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: snapshot-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      serviceAccountName: snapshot-controller-runner
+      containers:
+        - name: snapshot-controller
+          image: snapshot-controller
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - "-cloudprovider aws"
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: awskeys
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: awskeys
+                  key: secret-access-key
+        - name: snapshot-provisioner
+          image: snapshot-provisioner
+          imagePullPolicy: "IfNotPresent"
+          args:
+            - "-cloudprovider aws"
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: awskeys
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: awskeys
+                  key: secret-access-key

--- a/snapshot/deploy/kubernetes/aws/secret.yaml
+++ b/snapshot/deploy/kubernetes/aws/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: awskeys
+type: Opaque
+data:
+  access-key-id: # base64 encoded AWS_ACCESS_KEY_ID
+  secret-access-key: # base64 encoded AWS_SECRET_ACCESS_KEY
+
+

--- a/snapshot/deploy/kubernetes/aws/snapshot-rbac.yaml
+++ b/snapshot/deploy/kubernetes/aws/snapshot-rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller-runner
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: snapshot-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["volume-snapshot-data.external-storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["volume-snapshot-data.external-storage.k8s.io"]
+    resources: ["volumesnapshotdatas"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: snapsot-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snapshot-controller-role
+subjects:
+- kind: ServiceAccount
+  name: snapshot-controller-runner
+  namespace: default
+

--- a/snapshot/deploy/kubernetes/hostpath/deployment.yaml
+++ b/snapshot/deploy/kubernetes/hostpath/deployment.yaml
@@ -1,0 +1,37 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: snapshot-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: snapshot-controller
+    spec:
+      serviceAccountName: snapshot-controller-runner
+      containers:
+        - name: snapshot-controller
+          image: quay.io/external_storage/snapshot-controller
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: hostpath-source
+              mountPath: /test
+        - name: snapshot-provisioner
+          image: quay.io/external_storage/snapshot-provisioner
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: hostpath-source
+              mountPath: /test
+      volumes:
+        - name: tmp
+          hostPath:
+            path: /tmp
+        - name: hostpath-source
+          emptyDir: {}

--- a/snapshot/deploy/kubernetes/hostpath/snapshot-rbac.yaml
+++ b/snapshot/deploy/kubernetes/hostpath/snapshot-rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-controller-runner
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: snapshot-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create", "list", "watch", "delete"]
+  - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["volumesnapshot.external-storage.k8s.io"]
+    resources: ["volumesnapshotdatas"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: snapsot-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snapshot-controller-role
+subjects:
+- kind: ServiceAccount
+  name: snapshot-controller-runner
+  namespace: default
+

--- a/snapshot/pkg/controller/snapshotter/snapshotter.go
+++ b/snapshot/pkg/controller/snapshotter/snapshotter.go
@@ -695,6 +695,9 @@ func (vs *volumeSnapshotter) updateVolumeSnapshotMetadata(snapshot *crdv1.Volume
 		Resource(crdv1.VolumeSnapshotResourcePlural).
 		Namespace(snapshot.Metadata.Namespace).
 		Do().Into(&snapshotObj)
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving VolumeSnapshot %s from API server: %v", snapshot.Metadata.Name, err)
+	}
 
 	// Copy the snapshot object before updating it
 	objCopy, err := vs.scheme.DeepCopy(&snapshotObj)
@@ -718,11 +721,11 @@ func (vs *volumeSnapshotter) updateVolumeSnapshotMetadata(snapshot *crdv1.Volume
 	err = vs.restClient.Put().
 		Name(snapshot.Metadata.Name).
 		Resource(crdv1.VolumeSnapshotResourcePlural).
-		Namespace(snapshotCopy.Metadata.Namespace).
+		Namespace(snapshot.Metadata.Namespace).
 		Body(snapshotCopy).
 		Do().Into(&result)
 	if err != nil {
-		return nil, fmt.Errorf("Error updating snapshot object %s on the API server: %v", snapshot.Metadata.Name, err)
+		return nil, fmt.Errorf("Error updating snapshot object %s/%s on the API server: %v", snapshot.Metadata.Namespace, snapshot.Metadata.Name, err)
 	}
 
 	cloudTags := make(map[string]string)

--- a/snapshot/test/hostpath_files/promote-claim.yaml
+++ b/snapshot/test/hostpath_files/promote-claim.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: snapshot-pv-provisioning-demo
-  namespace: myns
+  namespace: default
   annotations:
     snapshot.alpha.kubernetes.io/snapshot: snapshot-demo
 spec:

--- a/snapshot/test/run_tests.py
+++ b/snapshot/test/run_tests.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import time
 import atexit
+import json
 
 def reap_process(proc):
     proc.terminate()
@@ -33,14 +34,20 @@ if __name__ == '__main__':
     provlog = sys.stdout
 
     argparser = argparse.ArgumentParser(description='Volume Snapshotter test suite')
-    argparser.add_argument('-n', '--no-kubernetes', dest='nokube',
+    argparser.add_argument('-n', '--no-kubernetes', dest='nokube', action='store_true',
                            help='don\'t start the kubernetes daemon')
+    argparser.add_argument('-t', '--tests-only', dest='testsonly', action='store_true',
+                           help='don\'t start anything, just do the tests')
     argparser.add_argument('-k', '--kubelog', dest='kubelog',
                            help='file to log kubernetes messaes to (default stdout)')
     argparser.add_argument('-c', '--ctrllog', dest='ctrllog',
                            help='file to log controller messaes to (default stdout)')
     argparser.add_argument('-p', '--provlog', dest='provlog',
                            help='file to log provisioner messaes to (default stdout)')
+    argparser.add_argument('-d', '--deployment', dest='deployment',
+                           help='path of deployment yaml file; uses containers for test')
+    argparser.add_argument('-r', '--rbac', dest='rbac',
+                           help='path of rbac definitions yaml file for deployment')
     argparser.add_argument('testname', nargs='*',
                            help='name of test class or method (e. g. "Hostpath")')
     args = argparser.parse_args()
@@ -50,50 +57,97 @@ if __name__ == '__main__':
     kubesrcdir = os.getenv('KUBESRCDIR', default=os.path.join(os.getenv('HOME'), 'kubernetes'))
     snaptestcase.kubesrcdir = kubesrcdir
 
+    kubectl = 'kubectl'
+    if not args.testsonly:
+        # find the kubernetes dir an start the cluster (if not disabled on commandline)
+        if not args.nokube:
+            if args.kubelog:
+                kubelog = open(args.kubelog, mode='w')
+            kubectl = os.path.join(kubesrcdir, "cluster/kubectl.sh")
+            kubecmd = os.path.join(kubesrcdir, 'hack/local-up-cluster.sh')
+            # start the cluster
+            kubeoutputdir = os.path.join(kubesrcdir, '_output/local/bin/linux/amd64')
+            print("Starting " + kubecmd)
+            kube = subprocess.Popen([kubecmd + ' -o ' + kubeoutputdir],
+                    shell=True, stdout=kubelog, stderr=kubelog, cwd=kubesrcdir)
+            # give the cluster some time to initialize
+            check = subprocess.Popen([kubectl + ' get nodes'], shell=True)
+            check.wait()
+            check_count = 0
+            while check.returncode != 0 and check_count < 30:
+                time.sleep(1)
+                check = subprocess.Popen([kubectl + ' get nodes'], shell=True)
+                check.wait()
+                check_count = check_count + 1
+            nodes_num = 0
+            check_count = 0
+            while nodes_num == 0 and check_count < 30:
+                time.sleep(1)
+                check_count = check_count + 1
+                check = subprocess.check_output([kubectl + ' get nodes -o json'], shell=True)
+                try:
+                    node_list = json.loads(check.decode("utf-8"))
+                    nodes_num = len(node_list['items'])
+                except Exception as e:
+                    pass
 
-    # find the kubernetes dir an start the cluster (if not disabled on commandline)
-    if not args.nokube:
-        if args.kubelog:
-            kubelog = open(args.kubelog, mode='w')
-        kubecmd = os.path.join(kubesrcdir, 'hack/local-up-cluster.sh')
-        # start the cluster
-        kubeoutputdir = os.path.join(kubesrcdir, '_output/local/bin/linux/amd64')
-        print("Starting " + kubecmd)
-        kube = subprocess.Popen([kubecmd + ' -o ' + kubeoutputdir],
-                shell=True, stdout=kubelog, stderr=kubelog, cwd=kubesrcdir)
-        # give the cluster some time to initialize
-        time.sleep(20)
-        kube.poll()
-        if kube.returncode != None:
-            print("Fatal: Unable to start the kubernetes cluster", file=sys.stderr)
-            sys.exit(1)
-        atexit.register(reap_process, kube)
+            kube.poll()
+            if kube.returncode != None:
+                print("Fatal: Unable to start the kubernetes cluster", file=sys.stderr)
+                sys.exit(1)
+            atexit.register(reap_process, kube)
+        if args.deployment:
+            deployment_file = os.path.abspath(args.deployment)
+            rbac_file = os.path.abspath(args.rbac)
+            new_rbac = subprocess.Popen([kubectl + ' create -f ' + rbac_file],
+                    shell=True, stdout=kubelog, stderr=kubelog)
+            new_rbac.wait()
+            if new_rbac.returncode != 0:
+                print("Error creating the snapshot deployment rbac", file=sys.stderr)
+                sys.exit(1)
+            new_depl = subprocess.Popen([kubectl + ' create -f ' + deployment_file],
+                    shell=True, stdout=kubelog, stderr=kubelog)
+            new_depl.wait()
+            if new_depl.returncode != 0:
+                print("Error creating the snapshot deployment", file=sys.stderr)
+                sys.exit(1)
+            ready_replicas = 0
+            check_count = 0
+            while ready_replicas == 0 and check_count < 30:
+                time.sleep(1)
+                check_count = check_count + 1
+                check = subprocess.check_output([kubectl + ' get deployments -o json'], shell=True)
+                try:
+                    deployment_list = json.loads(check.decode("utf-8"))
+                    if len(deployment_list['items']) > 0:
+                        ready_replicas = deployment_list['items'][0]['status']['readyReplicas']
+                except Exception as e:
+                    pass
 
-    kubeconfig = os.getenv('KUBECONFIG', '/var/run/kubernetes/admin.kubeconfig')
-    # start the controller
-    if args.ctrllog:
-        ctrllog = open(args.ctrllog, mode='w')
-    ctrlcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-controller')
-    ctrl = subprocess.Popen([ctrlcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
-            shell=True, stdout=ctrllog, stderr=ctrllog, cwd=snapsrcdir)
-    time.sleep(10)
-    ctrl.poll()
-    if ctrl.returncode != None:
-        print("Fatal: Unable to start the snapshot controller", file=sys.stderr)
-        sys.exit(1)
-    atexit.register(reap_process, ctrl)
-    # start the provisioner
-    if args.provlog:
-        ctrllog = open(args.provlog, mode='w')
-    provcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-provisioner')
-    prov = subprocess.Popen([provcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
-            shell=True, stdout=provlog, stderr=provlog, cwd=snapsrcdir)
-    time.sleep(10)
-    prov.poll()
-    if prov.returncode != None:
-        print("Fatal: Unable to start the snapshot provisioner", file=sys.stderr)
-        sys.exit(1)
-    atexit.register(reap_process, prov)
+        else:
+            kubeconfig = os.getenv('KUBECONFIG', '/var/run/kubernetes/admin.kubeconfig')
+            # start the controller
+            if args.ctrllog:
+                ctrllog = open(args.ctrllog, mode='w')
+            ctrlcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-controller')
+            ctrl = subprocess.Popen([ctrlcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
+                    shell=True, stdout=ctrllog, stderr=ctrllog, cwd=snapsrcdir)
+            ctrl.wait()
+            if ctrl.returncode != None:
+                print("Fatal: Unable to start the snapshot controller", file=sys.stderr)
+                sys.exit(1)
+            atexit.register(reap_process, ctrl)
+            # start the provisioner
+            if args.provlog:
+                ctrllog = open(args.provlog, mode='w')
+            provcmd = os.path.join(snapsrcdir, '_output/bin/snapshot-provisioner')
+            prov = subprocess.Popen([provcmd + ' -v 10 -alsologtostderr -kubeconfig ' + kubeconfig],
+                    shell=True, stdout=provlog, stderr=provlog, cwd=snapsrcdir)
+            prov.wait()
+            if prov.returncode != None:
+                print("Fatal: Unable to start the snapshot provisioner", file=sys.stderr)
+                sys.exit(1)
+            atexit.register(reap_process, prov)
 
     # Load all files in this directory whose name starts with 'test'
     if args.testname:


### PR DESCRIPTION
This should help using snapshot controller: Makefile in snapshot directory can now create containers and I have added also some deployments for kubernets (HostPath and AWS).

I have bundled a small fix for snapshotter: we ignored error from API server when GETting the VolumeSnapshot. That lead to somewhat mysterious errors.

PTAL.