### PR TITLE
gluster-block: replace ReadWriteMany with ReadWriteOnce in pvc

### DIFF
--- a/gluster/block/examples/glusterblock-mode/claim1.yaml
+++ b/gluster/block/examples/glusterblock-mode/claim1.yaml
@@ -6,7 +6,7 @@ metadata:
     volume.beta.kubernetes.io/storage-class: "glusterblock"
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
This patch replaces ReadWriteMany with ReadWriteOnce in pvc example. Currently gluster-block does not support ReadWriteMany as [GetAccessModes()](https://github.com/kubernetes-incubator/external-storage/blob/8732beaa43a3b00d39e2c9ced21f2d662e6a0969/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go#L153-L158) in glusterblock-provisioner.go.