### PR TITLE
iscsi: Use centos image for the base image

### DIFF
--- a/iscsi/targetd/Dockerfile
+++ b/iscsi/targetd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/rhel7-atomic:latest
+FROM centos:7
 LABEL authors="Raffaele Spazzoli <rspazzol@redhat.com>" 
 ADD iscsi-controller /iscsi-controller
 ENTRYPOINT ["/iscsi-controller"]


### PR DESCRIPTION
This patch replace rhel7-atmoic base image with centos7 in Dockerfile.