### PR TITLE
iscsi: Support master and kubeconfig options to run iscsi provisioner locally

### DIFF
--- a/iscsi/targetd/README.md
+++ b/iscsi/targetd/README.md
@@ -241,6 +241,14 @@ oc secret new-basicauth targetd-account --username=admin --password=ciao
 oc create -f https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/iscsi/targetd/openshift/iscsi-provisioner-dc.yaml
 ```
 
+### Start iscsi provisioner as docker container.
+
+Alternatively, you can start a provisioner as a container locally.
+
+```bash
+docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host quay.io/external_storage/iscsi-controller:latest start --kubeconfig=/kube/config --master=http://127.0.0.1:8080 --log-level=debug --targetd-address=192.168.99.100 --targetd-password=ciao --targetd-username=admin
+```
+
 ### Create a storage class
 
 storage classes should look like the following

--- a/iscsi/targetd/cmd/start.go
+++ b/iscsi/targetd/cmd/start.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/kubernetes-incubator/external-storage/iscsi/targetd/provisioner"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var log = logrus.New()
@@ -42,12 +44,18 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		initLog()
-
 		log.Debugln("start called")
-
+		var config *rest.Config
+		var err error
+		master := viper.GetString("master")
+		kubeconfig := viper.GetString("kubeconfig")
 		// creates the in-cluster config
 		log.Debugln("creating in cluster default kube client config")
-		config, err := rest.InClusterConfig()
+		if master != "" || kubeconfig != "" {
+			config, err = clientcmd.BuildConfigFromFlags(master, kubeconfig)
+		} else {
+			config, err = rest.InClusterConfig()
+		}
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -126,6 +134,10 @@ func init() {
 	startcontrollerCmd.Flags().String("default-fs", "xfs", "filesystem to use when not specified")
 	viper.BindPFlag("default-fs", startcontrollerCmd.Flags().Lookup("default-fs"))
 
+	startcontrollerCmd.Flags().String("master", "", "Master URL")
+	viper.BindPFlag("master", startcontrollerCmd.Flags().Lookup("master"))
+	startcontrollerCmd.Flags().String("kubeconfig", "", "Absolute path to the kubeconfig")
+	viper.BindPFlag("kubeconfig", startcontrollerCmd.Flags().Lookup("kubeconfig"))
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command


### PR DESCRIPTION
This patch supports `master` and `kubeconfig` options to run iscsi
provisioner locally.