### PR TITLE
Refactor the snapshotter code for more robustness.

### DIFF
--- a/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
+++ b/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
@@ -137,7 +137,6 @@ func (p *snapshotProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 	var snapshotData crdv1.VolumeSnapshotData
 	err = p.crdclient.Get().
 		Resource(crdv1.VolumeSnapshotDataResourcePlural).
-		Namespace(v1.NamespaceDefault).
 		Name(snapshot.Spec.SnapshotDataName).
 		Do().Into(&snapshotData)
 

--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -37,7 +37,7 @@ type VolumeSnapshotStatus struct {
 	// +optional
 	CreationTimestamp metav1.Time `json:"creationTimestamp" protobuf:"bytes,1,opt,name=creationTimestamp"`
 
-	// Representes the latest available observations about the volume snapshot
+	// Represent the latest available observations about the volume snapshot
 	Conditions []VolumeSnapshotCondition `json:"conditions" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/snapshot/pkg/client/client.go
+++ b/snapshot/pkg/client/client.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/glog"
 	crdv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
-	apiv1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -107,7 +106,8 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 // WaitForSnapshotResource waits for the snapshot resource
 func WaitForSnapshotResource(snapshotClient *rest.RESTClient) error {
 	return wait.Poll(100*time.Millisecond, 60*time.Second, func() (bool, error) {
-		_, err := snapshotClient.Get().Namespace(apiv1.NamespaceDefault).Resource(crdv1.VolumeSnapshotDataResourcePlural).DoRaw()
+		_, err := snapshotClient.Get().
+			Resource(crdv1.VolumeSnapshotDataResourcePlural).DoRaw()
 		if err == nil {
 			return true, nil
 		}

--- a/snapshot/pkg/controller/snapshotter/snapshotter_test.go
+++ b/snapshot/pkg/controller/snapshotter/snapshotter_test.go
@@ -429,7 +429,7 @@ func Test_createSnapshotData(t *testing.T) {
 			Type:               crdv1.VolumeSnapshotConditionReady,
 		},
 	}
-	retData, err := vs.createVolumeSnapshotData("default/new-snapshot-test-1", fakeNewVolumeSnapshot(), &snapDataSource, &snapConditions)
+	retData, err := vs.createVolumeSnapshotData("default/new-snapshot-test-1", "fake-pv-1", &snapDataSource, &snapConditions)
 	if err != nil {
 		t.Errorf("Test failed, unexpected error: %v", err)
 	}

--- a/snapshot/pkg/volume/awsebs/processor.go
+++ b/snapshot/pkg/volume/awsebs/processor.go
@@ -214,7 +214,7 @@ func convertAWSStatus(status string) *[]crdv1.VolumeSnapshotCondition {
 			{
 				Type:               crdv1.VolumeSnapshotConditionReady,
 				Status:             v1.ConditionTrue,
-				Message:            "Snapshot created succsessfully and it is ready",
+				Message:            "Snapshot created successfully and it is ready",
 				LastTransitionTime: metav1.Now(),
 			},
 		}

--- a/snapshot/pkg/volume/cinder/processor.go
+++ b/snapshot/pkg/volume/cinder/processor.go
@@ -172,7 +172,7 @@ func (c *cinderPlugin) convertSnapshotStatus(status string) *[]crdv1.VolumeSnaps
 			{
 				Type:               crdv1.VolumeSnapshotConditionReady,
 				Status:             v1.ConditionTrue,
-				Message:            "Snapshot created succsessfully and it is ready",
+				Message:            "Snapshot created successfully and it is ready",
 				LastTransitionTime: metav1.Now(),
 			},
 		}


### PR DESCRIPTION
The main logic in snapshotter is as follows

```
syncSnapshot is the main controller method to decide what to do with a snapshot object. 

Step1. [Check snapshot condition] It first checks the status of this snapshot object from its VolumeSnapshotCondition field.  

- If the condition is Ready or Failed, do nothing
- If the condition is Pending, go to step 3
- If there is no condition recorded yet, check the following

  1. Check if snapshot object metadata has label of “snapshotMetadataTimeStamp”. If no such label, it indicates that snapshot has not yet triggered, return statusNew which will continues with step 2.
  2. If the label exist, check if there is already a VolumeSnapshotData object exist that references the given snapshot. If this object exists, update snapshot object to bind the VolumeSnapshotData with it. Return statusPending which continues with step 3
  3. If no VolumeSnapshotData object, use the metadata information to construct tag and query the cloud whether a snapshot is already taken with the tag. If such snapshot can be found, construct the VolumeSnapshotData object and bind it with VolumeSnapshot object. Return statusPending which continues with step 3.
  4. If no snapshot is found,  return statusNew which will continue with step 2.



Step2. [Take snapshot and Create SnapshotData object to bind]

1. **getPVFromVolumeSnapshot**: From snapshot data object, get PVC name and then retrieve pv object from API server. If failed, return error.
2. **updateVolumeSnapshotMetadata**: Construct tag information with current timestamp and VolumeSnapshot object’s metadata (namespace, name, and uid). Also update the VolumeSnapshot object with the timestamp and pv name (which will be used later). If update failed, return error.
3. **takeSnapshot**: call cloud provider to take the snapshot and attach the tags to the snapshot constructed from above. If it failed, return the error. Otherwise it returns the snapshot data source information and condition.
4. **createVolumeSnapshotData**: The name of the VolumeSnapshotData object is constructed from the UID of the VolumeSnapshot for easy query at later point. If object is constructed and updated to API server successfully, move to the next step. Otherwise, return error.
5. **bindandUpdateVolumeSnapshot**: It updates the VolumeSnapshot object with the VolumeSnapshotData object name and new status.

Step3. [Wait until snapshot is ready or failed] This step creates a loop with exponential backoff time. Inside the loop

1. It queries the cloud provider to describe the snapshot with the status information.
2. It updates the VolumeSnapshot object with the new condition if there is any changes compared with the old condition
3. If the latest status is ready or error, break the loop and return.
```


This PR also includes the changes
1. SnapshotCreate function in gce
2. Remove Namespace for VolumeSnapshotData object