### PR TITLE
don't use dash in volume snapshot

### DIFF
--- a/snapshot/examples/aws/snapshot.yaml
+++ b/snapshot/examples/aws/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-demo

--- a/snapshot/examples/aws/snapshot.yaml
+++ b/snapshot/examples/aws/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-demo

--- a/snapshot/examples/gce/snapshot.yaml
+++ b/snapshot/examples/gce/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-1

--- a/snapshot/examples/gce/snapshot.yaml
+++ b/snapshot/examples/gce/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-1

--- a/snapshot/examples/hostpath/README.md
+++ b/snapshot/examples/hostpath/README.md
@@ -42,7 +42,7 @@ Now we have PVC bound to a PV that contains some data. We want to take snapshot 
     kubectl get volumesnapshot,volumesnapshotdata -o yaml
     apiVersion: v1
     items:
-    - apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+    - apiVersion: volumesnapshot.external-storage.k8s.io/v1
       kind: VolumeSnapshot
       metadata:
         labels:
@@ -58,7 +58,7 @@ Now we have PVC bound to a PV that contains some data. We want to take snapshot 
           message: Snapshot created successfully
           status: "True"
           type: Ready
-    - apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+    - apiVersion: volumesnapshot.external-storage.k8s.io/v1
       kind: VolumeSnapshotData
       metadata:
         name: k8s-volume-snapshot-d2209d5a-97a9-11e7-b963-5254000ac840

--- a/snapshot/examples/hostpath/README.md
+++ b/snapshot/examples/hostpath/README.md
@@ -42,7 +42,7 @@ Now we have PVC bound to a PV that contains some data. We want to take snapshot 
     kubectl get volumesnapshot,volumesnapshotdata -o yaml
     apiVersion: v1
     items:
-    - apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+    - apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
       kind: VolumeSnapshot
       metadata:
         labels:
@@ -58,7 +58,7 @@ Now we have PVC bound to a PV that contains some data. We want to take snapshot 
           message: Snapshot created successfully
           status: "True"
           type: Ready
-    - apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+    - apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
       kind: VolumeSnapshotData
       metadata:
         name: k8s-volume-snapshot-d2209d5a-97a9-11e7-b963-5254000ac840

--- a/snapshot/examples/hostpath/snapshot.yaml
+++ b/snapshot/examples/hostpath/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-demo

--- a/snapshot/examples/hostpath/snapshot.yaml
+++ b/snapshot/examples/hostpath/snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-demo

--- a/snapshot/pkg/apis/crd/v1/register.go
+++ b/snapshot/pkg/apis/crd/v1/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GroupName is the group name use in this package.
-const GroupName = "volume-snapshot-data.external-storage.k8s.io"
+const GroupName = "volumesnapshotdata.external-storage.k8s.io"
 
 var (
 	// SchemeBuilder is the new scheme builder

--- a/snapshot/pkg/apis/crd/v1/register.go
+++ b/snapshot/pkg/apis/crd/v1/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GroupName is the group name use in this package.
-const GroupName = "volumesnapshotdata.external-storage.k8s.io"
+const GroupName = "volumesnapshot.external-storage.k8s.io"
 
 var (
 	// SchemeBuilder is the new scheme builder

--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -27,12 +27,12 @@ import (
 const (
 	// VolumeSnapshotDataResourcePlural is "volumesnapshotdatas"
 	VolumeSnapshotDataResourcePlural = "volumesnapshotdatas"
-	// VolumeSnapshotDataResource is "volume-snapshot-data"
-	VolumeSnapshotDataResource = "volume-snapshot-data"
+	// VolumeSnapshotDataResource is "volumesnapshotdata"
+	VolumeSnapshotDataResource = "volumesnapshotdata"
 	// VolumeSnapshotResourcePlural is "volumesnapshots"
 	VolumeSnapshotResourcePlural = "volumesnapshots"
-	// VolumeSnapshotResource is "volume-snapshot"
-	VolumeSnapshotResource = "volume-snapshot"
+	// VolumeSnapshotResource is "volumesnapshot"
+	VolumeSnapshotResource = "volumesnapshot"
 )
 
 // VolumeSnapshotStatus is the status of the VolumeSnapshot

--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -27,12 +27,8 @@ import (
 const (
 	// VolumeSnapshotDataResourcePlural is "volumesnapshotdatas"
 	VolumeSnapshotDataResourcePlural = "volumesnapshotdatas"
-	// VolumeSnapshotDataResource is "volumesnapshotdata"
-	VolumeSnapshotDataResource = "volumesnapshotdata"
 	// VolumeSnapshotResourcePlural is "volumesnapshots"
 	VolumeSnapshotResourcePlural = "volumesnapshots"
-	// VolumeSnapshotResource is "volumesnapshot"
-	VolumeSnapshotResource = "volumesnapshot"
 )
 
 // VolumeSnapshotStatus is the status of the VolumeSnapshot

--- a/snapshot/test/hostpath_files/hostpath-snapshot.yaml
+++ b/snapshot/test/hostpath_files/hostpath-snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
+apiVersion: volumesnapshot.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: hostpath-test-snapshot

--- a/snapshot/test/hostpath_files/hostpath-snapshot.yaml
+++ b/snapshot/test/hostpath_files/hostpath-snapshot.yaml
@@ -1,4 +1,4 @@
-apiVersion: volume-snapshot-data.external-storage.k8s.io/v1
+apiVersion: volumesnapshotdata.external-storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: hostpath-test-snapshot


### PR DESCRIPTION
per findings from @jingxu97, we don't need dash in volume snapshot to use capital letter in VolumeSnapshot object after switching to CRD.
 
@xing-yang @tsmetana PTAL, thanks