### PR TITLE
[local-volume] Added recommendation for using ID on block vol to README

### DIFF
--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -245,6 +245,13 @@ go run hack/e2e.go -- -v --test --test_args="--ginkgo.focus=\[Feature:LocalPersi
   Additionally, this practice will ensure that if another node with the
   same name is created, that any volumes on that node are unique and not
   mistaken for a volume on another node with the same name.
+* For raw block volumes without a filesystem, use a unique ID as the symlink
+  name. Depending on your environment, the volume's ID in `/dev/disk/by-id/`
+  may contain a unique hardware serial number. Otherwise, a unique ID should be 
+  generated. The uniqueness of the symlink name will ensure that if another 
+  node with the same name is created, that any volumes on that node are 
+  unique and not mistaken for a volume on another node with the same name.
+
 
 ### Deleting/removing the underlying volume
 


### PR DESCRIPTION
Block volume ID's can be found by looking at `ls -l /dev/disk/by-id`. Using these IDs in directory names can help ensure that the related local PVs are unique and not confused with other local PVs, even if the node name is the same.