### PR TITLE
Specify unit string when sending gluster-block command when operating on gluster-block mode.

### DIFF
--- a/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
+++ b/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
@@ -361,7 +361,7 @@ func (p *glusterBlockProvisioner) createVolume(volSizeInt int, blockVol string, 
 		// Execute gluster-block command.
 		cmd := exec.Command(
 			config.opMode, "create", config.blockModeArgs["glustervol"]+"/"+blockVol,
-			"ha", haCountStr, config.blockModeArgs["hosts"], sizeStr, "--json")
+			"ha", haCountStr, config.blockModeArgs["hosts"], sizeStr+"GB", "--json")
 
 		out, cmdErr := cmd.CombinedOutput()
 		if cmdErr != nil {


### PR DESCRIPTION

Issue# https://github.com/kubernetes-incubator/external-storage/issues/404
Signed-off-by: Humble Chirammal <hchiramm@redhat.com>