### PR TITLE
[local-volume] Enable make test of provisioner on darwin to PASS

### DIFF
--- a/local-volume/provisioner/pkg/util/volume_util.go
+++ b/local-volume/provisioner/pkg/util/volume_util.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/volume/util"
-	"unsafe"
 )
 
 // VolumeUtil is an interface for local filesystem operations
@@ -129,25 +128,6 @@ func (u *volumeUtil) DeleteContents(fullPath string) error {
 func (u *volumeUtil) GetFsCapacityByte(fullPath string) (int64, error) {
 	_, capacity, _, _, _, _, err := util.FsInfo(fullPath)
 	return capacity, err
-}
-
-// GetBlockCapacityByte returns  capacity in bytes of a block device.
-// fullPath is the pathname of block device.
-func (u *volumeUtil) GetBlockCapacityByte(fullPath string) (int64, error) {
-	file, err := os.OpenFile(fullPath, os.O_RDONLY, 0)
-	if err != nil {
-		return 0, err
-	}
-	defer file.Close()
-
-	var size int64
-	// Get size of block device into 64 bit int.
-	// Ref: http://www.microhowto.info/howto/get_the_size_of_a_linux_block_special_device_in_c.html
-	if _, _, err := unix.Syscall(unix.SYS_IOCTL, file.Fd(), unix.BLKGETSIZE64, uintptr(unsafe.Pointer(&size))); err != 0 {
-		return 0, err
-	}
-
-	return size, err
 }
 
 var _ VolumeUtil = &FakeVolumeUtil{}

--- a/local-volume/provisioner/pkg/util/volume_util_linux.go
+++ b/local-volume/provisioner/pkg/util/volume_util_linux.go
@@ -1,0 +1,44 @@
+// +build linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+	"unsafe"
+)
+
+// GetBlockCapacityByte returns  capacity in bytes of a block device.
+// fullPath is the pathname of block device.
+func (u *volumeUtil) GetBlockCapacityByte(fullPath string) (int64, error) {
+	file, err := os.OpenFile(fullPath, os.O_RDONLY, 0)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	var size int64
+	// Get size of block device into 64 bit int.
+	// Ref: http://www.microhowto.info/howto/get_the_size_of_a_linux_block_special_device_in_c.html
+	if _, _, err := unix.Syscall(unix.SYS_IOCTL, file.Fd(), unix.BLKGETSIZE64, uintptr(unsafe.Pointer(&size))); err != 0 {
+		return 0, err
+	}
+
+	return size, err
+}

--- a/local-volume/provisioner/pkg/util/volume_util_unsupported.go
+++ b/local-volume/provisioner/pkg/util/volume_util_unsupported.go
@@ -1,0 +1,29 @@
+// +build !linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+)
+
+// GetBlockCapacityByte is defined here for darwin and other platforms
+// so that make test suceeds on them.
+func (u *volumeUtil) GetBlockCapacityByte(fullPath string) (int64, error) {
+	return 0, fmt.Errorf("GetBlockCapacityByte is unsupported in this build")
+}


### PR DESCRIPTION
This PR break outs `GetBlockCapacityByte` for linux and darwin. `GetBlockCapacityByte` contains reference to a constant `unix.BLKGETSIZE64` which is not defined for darwin.

This fact causes `make test` for the provisioner to fail, as stated in https://github.com/kubernetes-incubator/external-storage/issues/410.

This PR enables make test for the provisioner to PASS on darwin (aka mac).

This PR closes https://github.com/kubernetes-incubator/external-storage/issues/410.