### PR TITLE
[local-volume] Set local-volume PV capacity to an easily readable value.

### DIFF
--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -18,6 +18,14 @@ package util
 
 import "k8s.io/api/core/v1"
 
+// Common allocation units
+const (
+	KiB int64 = 1024
+	MiB int64 = 1024 * KiB
+	GiB int64 = 1024 * MiB
+	TiB int64 = 1024 * GiB
+)
+
 // RoundUpSize calculates how many allocation units are needed to accommodate
 // a volume of given size. E.g. when user wants 1500MiB volume, while AWS EBS
 // allocates volumes in gibibyte-sized chunks,

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 
+	esUtil "github.com/kubernetes-incubator/external-storage/lib/util"
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/api/v1/helper"
 )
@@ -177,7 +178,7 @@ func (d *Discoverer) createPV(file, class string, config common.MountConfig, cap
 	pvSpec := common.CreateLocalPVSpec(&common.LocalPVConfig{
 		Name:            pvName,
 		HostPath:        outsidePath,
-		Capacity:        capacityByte,
+		Capacity:        roundDownCapacityPretty(capacityByte),
 		StorageClass:    class,
 		ProvisionerName: d.Name,
 		AffinityAnn:     d.nodeAffinityAnn,
@@ -190,4 +191,21 @@ func (d *Discoverer) createPV(file, class string, config common.MountConfig, cap
 		return
 	}
 	glog.Infof("Created PV %q for volume at %q", pvName, outsidePath)
+}
+
+// Round down the capacity to an easy to read value.
+func roundDownCapacityPretty(capacityBytes int64) int64 {
+
+	easyToReadUnitsBytes := []int64{esUtil.GiB, esUtil.MiB}
+
+	// Round down to the nearest easy to read unit
+	// such that there are at least 10 units at that size.
+	for _, easyToReadUnitBytes := range easyToReadUnitsBytes {
+		// Round down the capacity to the nearest unit.
+		size := capacityBytes / easyToReadUnitBytes
+		if size >= 10 {
+			return size * easyToReadUnitBytes
+		}
+	}
+	return capacityBytes
 }

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -18,12 +18,13 @@ package discovery
 
 import (
 	"fmt"
-	"path/filepath"
-	"testing"
-
+	esUtil "github.com/kubernetes-incubator/external-storage/lib/util"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
+	"path/filepath"
+	"testing"
+
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1/helper"
@@ -240,7 +241,7 @@ func TestDiscoverVolumes_BadVolume(t *testing.T) {
 
 func testSetup(t *testing.T, test *testConfig) *Discoverer {
 	test.cache = cache.NewVolumeCache()
-	test.volUtil = util.NewFakeVolumeUtil(false)
+	test.volUtil = util.NewFakeVolumeUtil(false /*deleteShouldFail*/)
 	test.volUtil.AddNewDirEntries(testMountDir, test.dirLayout)
 	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, test.cache)
 
@@ -352,7 +353,7 @@ func verifyCapacity(t *testing.T, createdPV *v1.PersistentVolume, expectedPV *te
 	if !ok {
 		t.Errorf("Unable to convert resource storage into int64")
 	}
-	if capacityInt != expectedPV.capacity {
+	if roundDownCapacityPretty(capacityInt) != expectedPV.capacity {
 		t.Errorf("Expected capacity %d, got %d", expectedPV.capacity, capacityInt)
 	}
 }
@@ -419,6 +420,34 @@ func verifyPVsNotInCache(t *testing.T, test *testConfig) {
 			if exists {
 				t.Errorf("Expected PV %q to not be in cache", pvName)
 			}
+		}
+	}
+}
+
+func TestRoundDownCapacityPretty(t *testing.T) {
+	var capTests = []struct {
+		n        int64 // input
+		expected int64 // expected result
+	}{
+		{100 * esUtil.KiB, 100 * esUtil.KiB},
+		{10 * esUtil.MiB, 10 * esUtil.MiB},
+		{100 * esUtil.MiB, 100 * esUtil.MiB},
+		{10 * esUtil.GiB, 10 * esUtil.GiB},
+		{10 * esUtil.TiB, 10 * esUtil.TiB},
+		{9*esUtil.GiB + 999*esUtil.MiB, 9*esUtil.GiB + 999*esUtil.MiB},
+		{10*esUtil.GiB + 5, 10 * esUtil.GiB},
+		{10*esUtil.MiB + 5, 10 * esUtil.MiB},
+		{10000*esUtil.MiB - 1, 9999 * esUtil.MiB},
+		{13*esUtil.GiB - 1, 12 * esUtil.GiB},
+		{63*esUtil.MiB - 10, 62 * esUtil.MiB},
+		{12345, 12345},
+		{10000*esUtil.GiB - 1, 9999 * esUtil.GiB},
+		{3*esUtil.TiB + 2*esUtil.GiB + 1*esUtil.MiB, 3*esUtil.TiB + 2*esUtil.GiB},
+	}
+	for _, tt := range capTests {
+		actual := roundDownCapacityPretty(tt.n)
+		if actual != tt.expected {
+			t.Errorf("roundDownCapacityPretty(%d): expected %d, actual %d", tt.n, tt.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
For volumes larger than 10Gi, it will round down to the nearest 1Gi.
For volumes larger than 10Mi, it will round down to the nearest 1Mi.
For volumes smaller than 10Mi, it will provide actual capacity (displayed in Ki).

This PR closes https://github.com/kubernetes-incubator/external-storage/issues/405

