### PR TITLE
Adding support for volume.beta.kubernetes.io/mount-options for nfs-client from PVC or storage class

### DIFF
--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"errors"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"


### PR DESCRIPTION
The purpose of this update is to gather mount-options annotations from storage-class or from pvc (if authorized). If both are available the one on the storage class will prevail.
The origin of this is a problem of compatibility between nfs version, and we didn't want to update each pv after automatic creation.