### PR TITLE
PVs created for local volume should have option to inherit node labels

### DIFF
--- a/local-volume/bootstrapper/README.md
+++ b/local-volume/bootstrapper/README.md
@@ -63,6 +63,33 @@ data:
 
 An example of using the bootstraper is included [here](../README.md).
 
+### PV Label Config (optional)
+
+One can (optionally) also configure the provisioner to copy certain labels from the node to the PVs of
+the local volumes on that node. For example in the config below, the admin has chosen to copy the labels
+failure-domain.beta.kubernetes.io/zone and failure-domain.beta.kubernetes.io/region from the node to the
+PVs as those zone and region labels are quite applicable to the local volume PVs of that node.
+
+```yaml
+kind: ConfigMap
+metadata:
+  name: local-volume-config
+  namespace: kube-system
+data:
+  nodeLabelsForPV: |
+    - failure-domain.beta.kubernetes.io/zone
+    - failure-domain.beta.kubernetes.io/region
+  storageClassMap: |
+    local-fast: 
+       hostDir: "/mnt/ssds"
+       mountDir: "/local-ssds"
+    local-slow:
+       hostDir: "/mnt/hdds"
+       mountDir: "/local-hdds"
+    local-storage:
+      hostDir: "/mnt/disks"
+```
+
 ### Command line options
 
 To see all options, compile bootstrapper and use `-h` option, below is a curated

--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -69,8 +69,9 @@ func main() {
 
 	glog.Info("Starting controller\n")
 	controller.StartLocalController(client, &common.UserConfig{
-		Node:         node,
-		DiscoveryMap: provisionerConfig.StorageClassConfig,
+		Node:            node,
+		DiscoveryMap:    provisionerConfig.StorageClassConfig,
+		NodeLabelsForPV: provisionerConfig.NodeLabelsForPV,
 	})
 }
 


### PR DESCRIPTION
As described  in #409 these changes allow a configurable list of node labels to be inherited by the local volume PVs. cc @msau42 @ianchakeres 