### PR TITLE
Fixed openstack/standalone-cinder/pkg/provisioner/provisioner.go:L115 linter error impacting build

### DIFF
--- a/openstack/standalone-cinder/pkg/provisioner/provisioner.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner.go
@@ -112,7 +112,7 @@ func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 
 	mapper, err = p.mb.newVolumeMapperFromConnection(connection)
 	if err != nil {
-		glog.Errorf("Unable to create volume mapper: %f", err)
+		glog.Errorf("Unable to create volume mapper: %v", err)
 		goto ERROR_DISCONNECT
 	}
 


### PR DESCRIPTION
I'm seeing a bunch of failures in CI related to this linter error across multiple PRs:
```
Verifying /home/travis/gopath/src/github.com/kubernetes-incubator/external-storage/repo-infra/verify/go-tools/verify-gometalinter.sh
openstack/standalone-cinder/pkg/provisioner/provisioner.go:115::error: arg err for printf verb %f of wrong type: error (vet)
FAILED   /home/travis/gopath/src/github.com/kubernetes-incubator/external-storage/repo-infra/verify/go-tools/verify-gometalinter.sh	0s
```

For example, https://travis-ci.org/kubernetes-incubator/external-storage/jobs/288716995