### PR TITLE
Rename OWNERS assignees: to approvers:

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - wongma7
   - jsafrane

--- a/aws/efs/OWNERS
+++ b/aws/efs/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - wongma7

--- a/ceph/cephfs/OWNERS
+++ b/ceph/cephfs/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - rootfs

--- a/ceph/rbd/OWNERS
+++ b/ceph/rbd/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - rootfs
   - cofyc

--- a/flex/OWNERS
+++ b/flex/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - childsb

--- a/gluster/block/OWNERS
+++ b/gluster/block/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - humblec

--- a/gluster/glusterfs/OWNERS
+++ b/gluster/glusterfs/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - yuanying

--- a/local-volume/provisioner/OWNERS
+++ b/local-volume/provisioner/OWNERS
@@ -1,4 +1,4 @@
-assignees:
+approvers:
   - msau42
   - vishh
   - saad-ali

--- a/nfs-client/OWNERS
+++ b/nfs-client/OWNERS
@@ -1,2 +1,2 @@
-assignees:
+approvers:
   - jackielii

--- a/nfs/OWNERS
+++ b/nfs/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - wongma7
   - jsafrane

--- a/openebs/OWNERS
+++ b/openebs/OWNERS
@@ -1,3 +1,3 @@
-assignees:
+approvers:
   - kmova
   - satyamz


### PR DESCRIPTION
They are effectively the same, assignees is deprecated

ref: kubernetes/test-infra#3851