### PR TITLE
Parse out env for DomainName in cinder-provisioner

### DIFF
--- a/openstack/standalone-cinder/pkg/volumeservice/connection.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/connection.go
@@ -91,11 +91,12 @@ func getConfigFromEnv() cinderConfig {
 
 	return cinderConfig{
 		Global: cinderConfigGlobal{
-			AuthURL:  authURL,
-			Username: os.Getenv("OS_USERNAME"),
-			Password: os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
-			TenantID: os.Getenv("OS_TENANT_ID"),
-			Region:   os.Getenv("OS_REGION_NAME"),
+			AuthURL:    authURL,
+			Username:   os.Getenv("OS_USERNAME"),
+			Password:   os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
+			TenantID:   os.Getenv("OS_TENANT_ID"),
+			Region:     os.Getenv("OS_REGION_NAME"),
+			DomainName: os.Getenv("OS_USER_DOMAIN_NAME"),
 		},
 	}
 }


### PR DESCRIPTION
When connecting to a deployment using Keystone V3 we
expect/require the Domain Name or ID. This is in the
openrc file for most deployments (ie RDO) however it's
not read in from env variables in the connection code.

This adds the parsing of OS_USER_DOMAIN_NAME to
cinderConfig to fix this and make the provisioner
usable for deployments using Keystone V3.

Fixes Issue: #436