### PR TITLE
flex: Fix file shbang

### DIFF
--- a/flex/deploy/docker/flex-provision.sh
+++ b/flex/deploy/docker/flex-provision.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/sh
 
 # Set this to true to log the call output to /tmp/flex-provisioner.log
 INTERNAL_DEBUG=true


### PR DESCRIPTION
Otherwise:
```
Failed to provision volume with StorageClass "default-shared": fork/exec /opt/storage/flex-provision.sh: exec format error
```