### PR TITLE
Unify uuid package.

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -24,11 +24,11 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/kubernetes-incubator/external-storage/lib/util"
-	"github.com/pborman/uuid"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/api/v1/helper"
 )


### PR DESCRIPTION
Use `k8s.io/apimachinery/pkg/util/uuid` package to generate UUIDs.

This change does not add/remove dependencies, because `k8s.io/apimachinery/pkg/util/uuid` depends on `github.com/pborman/uuid` (https://github.com/kubernetes-incubator/external-storage/blob/master/vendor/k8s.io/apimachinery/pkg/util/uuid/uuid.go#L30).