### PR TITLE
Enhance LV provisioner to have option to access API using kubeconfig 

### DIFF
--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 var provisionerConfig common.ProvisionerConfiguration
@@ -42,19 +41,6 @@ func init() {
 	glog.Infof("Configuration parsing has been completed, ready to run...")
 }
 
-func setupClient() *kubernetes.Clientset {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		glog.Fatalf("Error creating InCluster config: %v\n", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		glog.Fatalf("Error creating clientset: %v\n", err)
-	}
-	return clientset
-}
-
 func main() {
 	flag.Set("logtostderr", "true")
 	flag.Parse()
@@ -64,7 +50,7 @@ func main() {
 		glog.Fatalf("MY_NODE_NAME environment variable not set\n")
 	}
 
-	client := setupClient()
+	client := common.SetupClient()
 	node := getNode(client, nodeName)
 
 	glog.Info("Starting controller\n")

--- a/local-volume/provisioner/deployment/kubernetes/provisioner-daemonset.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/provisioner-daemonset.yaml
@@ -22,6 +22,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+      # If you want provisioner to use a kubeconfig file to access API server, instead of the default
+      #  in-cluster config, then specify the following environment variable:
+      # - name: KUBECONFIG
+      #   value: /path/to/kubeconfig
+      
       volumes:
       - name: discovery-vol
         hostPath:

--- a/local-volume/provisioner/pkg/common/common_test.go
+++ b/local-volume/provisioner/pkg/common/common_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func TestSetupClientByKubeConfigEnv(t *testing.T) {
+	oldEnv := os.Getenv(KubeConfigEnv)
+	os.Setenv(KubeConfigEnv, "/etc/foo/config")
+	defer func() { os.Setenv(KubeConfigEnv, oldEnv) }()
+
+	// Mock BuildConfigFromFlags
+	oldBuildConfig := BuildConfigFromFlags
+	defer func() { BuildConfigFromFlags = oldBuildConfig }()
+
+	methodInvoked := false
+	BuildConfigFromFlags = func(masterUrl, kubeconfigPath string) (*rest.Config, error) {
+		methodInvoked = true
+		if kubeconfigPath != "/etc/foo/config" {
+			t.Errorf("Got unexpected oldEnv for config file %s", kubeconfigPath)
+		}
+		return &rest.Config{}, nil
+	}
+
+	SetupClient()
+	if !methodInvoked {
+		t.Errorf("BuildConfigFromFlags not invoked")
+	}
+}
+
+func TestSetupClientByInCluster(t *testing.T) {
+	// Make sure environment variable is unset
+	if oldEnv := os.Getenv(KubeConfigEnv); oldEnv != "" {
+		os.Unsetenv(KubeConfigEnv)
+		defer func() { os.Setenv(KubeConfigEnv, oldEnv) }()
+	}
+
+	// Mock InClusterConfig
+	oldInClusterConfig := InClusterConfig
+	defer func() { InClusterConfig = oldInClusterConfig }()
+
+	methodInvoked := false
+	InClusterConfig = func() (*rest.Config, error) {
+		methodInvoked = true
+		return &rest.Config{}, nil
+	}
+
+	SetupClient()
+	if !methodInvoked {
+		t.Errorf("InClusterConfig not invoked")
+	}
+}


### PR DESCRIPTION
This addresses issue #479 
Apart from the default in-config mechanism of accessing the API server, this change provides the option of using  kubeconfig file to access the API.
