### PR TITLE
Adding helm chart to deploy provisioner

### DIFF
--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -1,0 +1,45 @@
+# Helm installation procedure 
+
+## Overview
+
+In order to be able to use **helm** to render templates, it has to be installed on a host where a user plans
+to generate templates.
+
+## Helm Installation
+On Linux, run these two commands to download and copy helm binary into /usr/bin directory.
+
+``` console
+export HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
+curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/bin linux-amd64/helm -zxf -
+```
+Provisioner's spec generation process has been tested with helm version 2.7.2.
+
+## Helm verification
+
+Run the following command:
+``` console
+helm version
+```
+
+This output should be generated:
+``` console
+Client: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}
+Error: cannot connect to Tiller
+``` 
+
+The error on the second line of the output can be ignored, as Tiller, helm's deployment engine has not been installed on the 
+kubernetes cluster as it is not required for template generation.
+
+## Provisioner's helm chart
+
+Helm templating is used to generate the provisioner's DaemonSet and ConfigMap specs.
+The generated specs can be further customized as needed (usually not necessary), and then deployed using kubectl.
+
+**helm template** uses 3 sources of information:
+1. Provisioner's chart template located at helm/provisioner/templates/provisioner.yaml
+2. Provisioner's default values.yaml which contains variables used for rendering a template.
+3. (Optional) User's customized values.yaml as a part of helm template command. User's provided
+   values will override default values of Provisioner's values.yaml.
+
+Default values.yaml is located in local-volume/helm/provisioner folder, user should not remove variables from this file but can
+change any values of these variables.

--- a/local-volume/helm/provisioner/Chart.yaml
+++ b/local-volume/helm/provisioner/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+version: 2.0.0
+description: local provisioner chart 
+name: provisioner
+keywords:
+  - storage
+  - local
+engine: gotpl

--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -1,0 +1,87 @@
+{{- $configMapName := .Values.configmap.configMapName }}
+{{- $provisionerNamespace := .Values.common.namespace }}
+{{- $provisionerName := .Values.daemonset.name }}
+{{- $imageFull := .Values.daemonset.image }}
+{{- $imagePullPolicy := .Values.daemonset.imagePullPolicy }}
+{{- $serviceAccount := .Values.daemonset.serviceAccount }}
+{{- $kubeConfigEnv := .Values.daemonset.kubeConfigEnv }}
+{{- $nodeLabels := .Values.daemonset.nodeLabels }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }} 
+  namespace: {{ $provisionerNamespace }} 
+data:
+{{- if $nodeLabels }}
+  nodeLabelsForPV: |
+   {{- range $label := $nodeLabels }}
+    - {{$label}}
+   {{- end }}
+{{- end }}
+  storageClassMap: |
+#
+# Populating entries with user provided disk discovery directories 
+# and mount directories per storage class.
+#
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+      {{ $storageClass }}:     
+          hostDir: {{ $classConfig.hostDir }}
+          mountDir: {{ if $classConfig.mountDir }} {{$classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
+   {{- end}}
+{{- end}}
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ $provisionerName }}
+  namespace: {{ $provisionerNamespace }}
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner 
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: {{$serviceAccount}}
+      containers:
+        - image: "{{ $imageFull }}"
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          name: provisioner 
+          securityContext:
+            privileged: true
+          env:
+{{- if $kubeConfigEnv }}
+            - name: KUBECONFIG
+              value: {{$kubeConfigEnv}}
+{{- end }}
+          volumeMounts:
+            - mountPath: /etc/provisioner/config 
+              name: provisioner-config
+              readOnly: true
+#
+# Populating entries with user provided disk discovery directories 
+#
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+            - mountPath: {{ if $classConfig.mountDir }} {{ $classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
+              name: {{ $storageClass }}
+   {{- end}}
+{{- end}}
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: {{ $configMapName }}
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+        - name: {{ $storageClass }}
+          hostPath:
+            path: {{ $classConfig.hostDir }}
+   {{- end}}
+{{- end}}

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -1,0 +1,49 @@
+common:
+  #
+  # Defines the namespace where provisioner runs
+  #
+  namespace: default
+configmap:
+  #
+  # Defines the name of configmap used by Provisioner
+  #
+  configMapName: "local-provisioner-config"
+  #
+  # Defines storage classes in a format:
+  #
+  #  storageClass:
+  #    - {storage class name}:
+  #        hostDir: "{path on the host where local volume of this storage class are mounted}"
+  #        mountDir: "{Optional path where a local volume will be mounted inside of a container}"
+  #
+  # Note: At least one storage class must be configured
+  storageClass:
+    - fast-disks:
+        hostDir: /mnt/fast-disks
+  #
+daemonset:
+  #
+  # Defines the name of a Provisioner
+  #
+  name: "local-volume-provisioner"
+  #
+  # Defines Provisioner's image name including container registry.
+  #
+  image: quay.io/external_storage/local-volume-provisioner:latest
+  #
+  # Defines Image download policy, see kubernetes documentation for available values.
+  #
+  imagePullPolicy: Always
+  #
+  # Defines a name of the service account which Provisioner will use to communicate with API server.
+  #
+  serviceAccount: local-storage-admin
+  #
+  # If configured KubeConfigEnv will (optionally) specify the location of kubeconfig file on the node.
+  #  kubeConfigEnv: KUBECONFIG
+  #
+  # List of node labels to be copied to the PVs created by the provisioner in a format:
+  #
+  #  nodeLabels:
+  #    - failure-domain.beta.kubernetes.io/zone
+  #    - failure-domain.beta.kubernetes.io/region


### PR DESCRIPTION
Closes: https://github.com/kubernetes-incubator/external-storage/issues/487

This PR adds an alternative method of deploying local volume provisioner by using HELM chart.  Chart.yaml is just a description of the chart, values.yaml contains variables and its values which the user can change, and templates/provisioner.yaml is the template.

by running: 
```
helm template privisioner
```
from local-volume/provisioner/deployment/kubernetes/helm folder, provisioner's confgmap and daemon set will be generated based on values provided in values.yaml.