### PR TITLE
Fixed the kubernetes helper import path

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/kubernetes/pkg/api/v1/helper"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
 )
 
 const (


### PR DESCRIPTION
Helpers were moved in https://github.com/kubernetes/kubernetes/commit/3848e0a4789f57f12cadfa88bd5ad586c0341719 about two months ago.