### PR TITLE
gluster:block: fix allocation size calculation

### DIFF
--- a/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
+++ b/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
@@ -182,7 +182,7 @@ func (p *glusterBlockProvisioner) Provision(options controller.VolumeOptions) (*
 	// Calculate the size
 	volSize := options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	volSizeBytes := volSize.Value()
-	volszInt := int(util.RoundUpSize(volSizeBytes, 1000*1000*1000))
+	volszInt := int(util.RoundUpToGiB(volSizeBytes))
 
 	// Create gluster block Volume
 	blockVolName := ""

--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -35,6 +35,11 @@ func RoundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
 	return (volumeSizeBytes + allocationUnitBytes - 1) / allocationUnitBytes
 }
 
+// RoundUpToGiB rounds up given quantity upto chunks of GiB
+func RoundUpToGiB(sizeBytes int64) int64 {
+	return RoundUpSize(sizeBytes, GiB)
+}
+
 // AccessModesContains returns whether the requested mode is contained by modes
 func AccessModesContains(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
 	for _, m := range modes {


### PR DESCRIPTION
Heketi interprets sizes as GiB, not GB.