### PR TITLE
Allow docker image for cephfs provisioner to build the provisioner itself

### DIFF
--- a/ceph/cephfs/Dockerfile.release
+++ b/ceph/cephfs/Dockerfile.release
@@ -1,0 +1,33 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang AS build
+
+COPY . /go/src/github.com/kubernetes-incubator/external-storage
+WORKDIR /go/src/github.com/kubernetes-incubator/external-storage/ceph/cephfs
+RUN go build -a -ldflags '-extldflags "-static"' -o /go/bin/cephfs-provisioner cephfs-provisioner.go
+
+
+FROM centos:7
+
+ENV CEPH_VERSION "jewel"
+RUN rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
+  yum install -y epel-release && \
+  yum install -y ceph-common python-cephfs && \
+  yum clean all
+
+COPY --from=build /go/bin/cephfs-provisioner /usr/local/bin/cephfs-provisioner
+COPY ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py /usr/local/bin/cephfs_provisioner
+RUN chmod -v o+x /usr/local/bin/cephfs_provisioner
+


### PR DESCRIPTION
I've added a pre-step to build the cephfs-provisioner binary within docker, so this dockerfile could be used in e.g. quay automated builds.

Due to how vendoring is set up, the context of docker build has to be the root of the repository itself.