### PR TITLE
[local-volume] Check that discovered directories are mountpoints before creating local PV.

### DIFF
--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -19,6 +19,7 @@ package common
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path"
 	"strings"
 
@@ -35,7 +36,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
-	"os"
+	"k8s.io/kubernetes/pkg/util/mount"
 	"path/filepath"
 )
 
@@ -112,6 +113,8 @@ type RuntimeConfig struct {
 	Recorder record.EventRecorder
 	// Disable block device discovery and management if true
 	BlockDisabled bool
+	// Mounter used to verify mountpoints
+	Mounter mount.Interface
 }
 
 // LocalPVConfig defines the parameters for creating a local PV

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/util/mount"
 )
 
 // StartLocalController starts the sync loop for the local PV discovery and deleter
@@ -55,6 +56,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 		Name:          provisionerName,
 		Recorder:      recorder,
 		BlockDisabled: true, // TODO: Block discovery currently disabled.
+		Mounter:       mount.New("" /* default mount path */),
 	}
 
 	populator := populator.NewPopulator(runtimeConfig)


### PR DESCRIPTION
This PR checks whether discovered directories are actual mountpoints before creating local PVs.

This PR is part of a fix for https://github.com/kubernetes-incubator/external-storage/issues/370 & https://github.com/kubernetes-incubator/external-storage/issues/482. In a subsequent PR, I intend to provide instructions for enabling mount propagation in Kubernetes 1.8+ to fix these two issues.

 