### PR TITLE
Breakfix for external-storage CI - ceph/rbd failing to install unsigned packages

### DIFF
--- a/ceph/rbd/Dockerfile
+++ b/ceph/rbd/Dockerfile
@@ -17,7 +17,7 @@ FROM centos:7
 ENV CEPH_VERSION "luminous"
 RUN rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
   yum install -y epel-release && \
-  yum install -y ceph-common
+  yum install -y --nogpgcheck ceph-common
 
 COPY rbd-provisioner /usr/local/bin/rbd-provisioner
 ENTRYPOINT ["/usr/local/bin/rbd-provisioner"]


### PR DESCRIPTION
The external-storage CI is currently failing with the following error:

```
Package libcephfs2-12.2.2-0.el7.x86_64.rpm is not signed
--------------------------------------------------------------------------------
Total                                              3.8 MB/s |  39 MB  00:10     
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
Importing GPG key 0x352C64E5:
 Userid     : "Fedora EPEL (7) <epel@fedoraproject.org>"
 Fingerprint: 91e9 7d7c 4a5e 96f1 7f3e 888f 6a2f aea2 352c 64e5
 Package    : epel-release-7-9.noarch (@extras)
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7
Package ceph-common-12.2.2-0.el7.x86_64.rpm is not signed
The command '/bin/sh -c rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm &&   yum install -y epel-release &&   yum install -y ceph-common' returned a non-zero code: 1
make[1]: *** [quick-container] Error 1
make[1]: Leaving directory `/home/travis/gopath/src/github.com/kubernetes-incubator/external-storage/ceph/rbd'
make: *** [ceph/rbd] Error 2
```

I've added `--nogpgcheck` so that the unsigned ceph-common packages can be installed.
