### PR TITLE
digitalocean: Fix wrong registry

### DIFF
--- a/digitalocean/Makefile
+++ b/digitalocean/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-REGISTRY = quay.io/kubernetes_incubator
+REGISTRY = quay.io/external_storage
 IMAGE_FLEXPLUGIN = $(REGISTRY)/digitalocean-flexplugin
 IMAGE_PROVISONER = $(REGISTRY)/digitalocean-provisioner
 

--- a/digitalocean/manifests/digitalocean-flexplugin-deploy.yaml
+++ b/digitalocean/manifests/digitalocean-flexplugin-deploy.yaml
@@ -22,7 +22,7 @@ spec:
             secretKeyRef:
               key: access-token
               name: digitalocean
-        image: quay.io/kubernetes_incubator/digitalocean-flexplugin
+        image: quay.io/external_storage/digitalocean-flexplugin
         imagePullPolicy: Always
         name: flex-deploy
         resources:

--- a/digitalocean/manifests/digitalocean-provisioner.yaml
+++ b/digitalocean/manifests/digitalocean-provisioner.yaml
@@ -22,7 +22,7 @@ spec:
             secretKeyRef:
               key: access-token
               name: digitalocean
-        image: quay.io/kubernetes_incubator/digitalocean-provisioner
+        image: quay.io/external_storage/digitalocean-provisioner
         imagePullPolicy: Always
         name: digitalocean-provisioner
         resources:


### PR DESCRIPTION
The correct registry is quay.io/external_storage not
quay.io/kubernetes_incubator.

cc @wongma7 