### PR TITLE
explicitly use a versioned core client

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -120,7 +120,7 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		Type: "Opaque",
 	}
 
-	_, err = p.client.Core().Secrets(nameSpace).Create(secret)
+	_, err = p.client.CoreV1().Secrets(nameSpace).Create(secret)
 	if err != nil {
 		glog.Errorf("Cephfs Provisioner: create volume failed, err: %v", err)
 		return nil, fmt.Errorf("failed to create secret")
@@ -204,7 +204,7 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	// Remove dynamic user secret
 	secretName := generateSecretName(user)
 	secretNamespace := volume.Spec.PersistentVolumeSource.CephFS.SecretRef.Namespace
-	err = p.client.Core().Secrets(secretNamespace).Delete(secretName, &metav1.DeleteOptions{})
+	err = p.client.CoreV1().Secrets(secretNamespace).Delete(secretName, &metav1.DeleteOptions{})
 	if err != nil {
 		glog.Errorf("Cephfs Provisioner: delete secret failed, err: %v", err)
 		return fmt.Errorf("failed to delete secret")
@@ -260,7 +260,7 @@ func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string,
 	if p.client == nil {
 		return "", fmt.Errorf("Cannot get kube client")
 	}
-	secrets, err := p.client.Core().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	secrets, err := p.client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -255,7 +255,7 @@ func (p *rbdProvisioner) parsePVSecret(namespace, secretName string) (string, er
 	if p.client == nil {
 		return "", fmt.Errorf("Cannot get kube client")
 	}
-	secrets, err := p.client.Core().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+	secrets, err := p.client.CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
+++ b/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
@@ -317,7 +317,7 @@ func (p *glusterBlockProvisioner) createSecretRef(nameSpace string, secretName s
 
 	secretRef := &v1.LocalObjectReference{}
 	if secret != nil {
-		_, err = p.client.Core().Secrets(nameSpace).Create(secret)
+		_, err = p.client.CoreV1().Secrets(nameSpace).Create(secret)
 		if err != nil && errors.IsAlreadyExists(err) {
 
 			glog.V(1).Infof(" secret: %s already exist in namespace: %s", secret, nameSpace)
@@ -550,7 +550,7 @@ func (p *glusterBlockProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	if volume.Annotations["AccessKey"] != "" && volume.Annotations["AccessKeyNs"] != "" {
-		deleteSecErr := p.client.Core().Secrets(volume.Annotations["AccessKeyNs"]).Delete(volume.Annotations["AccessKey"], nil)
+		deleteSecErr := p.client.CoreV1().Secrets(volume.Annotations["AccessKeyNs"]).Delete(volume.Annotations["AccessKey"], nil)
 
 		if deleteSecErr != nil && errors.IsNotFound(deleteSecErr) {
 			glog.V(1).Infof(" secret [%s] does not exist in namespace [%s]", volume.Annotations["AccessKey"], volume.Annotations["AccessKeyNs"])

--- a/gluster/glusterfs/pkg/volume/exec.go
+++ b/gluster/glusterfs/pkg/volume/exec.go
@@ -91,7 +91,7 @@ func (p *glusterfsProvisioner) ExecuteCommand(
 func (p *glusterfsProvisioner) selectPod(host string,
 	config *ProvisionerConfig) (*v1.Pod, error) {
 
-	podList, err := p.client.Core().
+	podList, err := p.client.CoreV1().
 		Pods(config.Namespace).
 		List(meta_v1.ListOptions{
 			LabelSelector: config.LabelSelector,

--- a/gluster/glusterfs/pkg/volume/provision.go
+++ b/gluster/glusterfs/pkg/volume/provision.go
@@ -49,7 +49,7 @@ func NewGlusterfsProvisioner(config *rest.Config, client kubernetes.Interface) c
 func newGlusterfsProvisionerInternal(config *rest.Config, client kubernetes.Interface) *glusterfsProvisioner {
 	var identity types.UID
 
-	restClient := client.Core().RESTClient()
+	restClient := client.CoreV1().RESTClient()
 	provisioner := &glusterfsProvisioner{
 		config:     config,
 		client:     client,

--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -285,7 +285,7 @@ func NewProvisionController(
 ) *ProvisionController {
 	identity := uuid.NewUUID()
 	broadcaster := record.NewBroadcaster()
-	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: client.Core().Events(v1.NamespaceAll)})
+	broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: client.CoreV1().Events(v1.NamespaceAll)})
 	var eventRecorder record.EventRecorder
 	out, err := exec.Command("hostname").Output()
 	if err != nil {
@@ -330,10 +330,10 @@ func NewProvisionController(
 
 	controller.claimSource = &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return client.Core().PersistentVolumeClaims(v1.NamespaceAll).List(options)
+			return client.CoreV1().PersistentVolumeClaims(v1.NamespaceAll).List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return client.Core().PersistentVolumeClaims(v1.NamespaceAll).Watch(options)
+			return client.CoreV1().PersistentVolumeClaims(v1.NamespaceAll).Watch(options)
 		},
 	}
 	controller.claims, controller.claimController = cache.NewInformer(
@@ -349,10 +349,10 @@ func NewProvisionController(
 
 	controller.volumeSource = &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return client.Core().PersistentVolumes().List(options)
+			return client.CoreV1().PersistentVolumes().List(options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return client.Core().PersistentVolumes().Watch(options)
+			return client.CoreV1().PersistentVolumes().Watch(options)
 		},
 	}
 	controller.volumes, controller.volumeController = cache.NewInformer(
@@ -756,7 +756,7 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 	//  the locks. Check that PV (with deterministic name) hasn't been provisioned
 	//  yet.
 	pvName := ctrl.getProvisionedVolumeNameForClaim(claim)
-	volume, err := ctrl.client.Core().PersistentVolumes().Get(pvName, metav1.GetOptions{})
+	volume, err := ctrl.client.CoreV1().PersistentVolumes().Get(pvName, metav1.GetOptions{})
 	if err == nil && volume != nil {
 		// Volume has been already provisioned, nothing to do.
 		glog.V(4).Infof("provisionClaimOperation [%s]: volume already exists, skipping", claimToClaimKey(claim))
@@ -829,7 +829,7 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 	// Try to create the PV object several times
 	for i := 0; i < ctrl.createProvisionedPVRetryCount; i++ {
 		glog.V(4).Infof("provisionClaimOperation [%s]: trying to save volume %s", claimToClaimKey(claim), volume.Name)
-		if _, err = ctrl.client.Core().PersistentVolumes().Create(volume); err == nil {
+		if _, err = ctrl.client.CoreV1().PersistentVolumes().Create(volume); err == nil {
 			// Save succeeded.
 			glog.Infof("volume %q for claim %q saved", volume.Name, claimToClaimKey(claim))
 			break
@@ -1007,9 +1007,9 @@ func (ctrl *ProvisionController) watchPVC(claim *v1.PersistentVolumeClaim, stopC
 func (ctrl *ProvisionController) getPVCEventWatch(claim *v1.PersistentVolumeClaim, eventType, reason string) (watch.Interface, error) {
 	claimKind := "PersistentVolumeClaim"
 	claimUID := string(claim.UID)
-	fieldSelector := ctrl.client.Core().Events(claim.Namespace).GetFieldSelector(&claim.Name, &claim.Namespace, &claimKind, &claimUID).String() + ",type=" + eventType + ",reason=" + reason
+	fieldSelector := ctrl.client.CoreV1().Events(claim.Namespace).GetFieldSelector(&claim.Name, &claim.Namespace, &claimKind, &claimUID).String() + ",type=" + eventType + ",reason=" + reason
 
-	list, err := ctrl.client.Core().Events(claim.Namespace).List(metav1.ListOptions{
+	list, err := ctrl.client.CoreV1().Events(claim.Namespace).List(metav1.ListOptions{
 		FieldSelector: fieldSelector,
 	})
 	if err != nil {
@@ -1021,7 +1021,7 @@ func (ctrl *ProvisionController) getPVCEventWatch(claim *v1.PersistentVolumeClai
 		resourceVersion = list.Items[len(list.Items)-1].ResourceVersion
 	}
 
-	return ctrl.client.Core().Events(claim.Namespace).Watch(metav1.ListOptions{
+	return ctrl.client.CoreV1().Events(claim.Namespace).Watch(metav1.ListOptions{
 		FieldSelector:   fieldSelector,
 		Watch:           true,
 		ResourceVersion: resourceVersion,
@@ -1035,7 +1035,7 @@ func (ctrl *ProvisionController) deleteVolumeOperation(volume *v1.PersistentVolu
 	// Our check does not have to be as sophisticated as PV controller's, we can
 	// trust that the PV controller has set the PV to Released/Failed and it's
 	// ours to delete
-	newVolume, err := ctrl.client.Core().PersistentVolumes().Get(volume.Name, metav1.GetOptions{})
+	newVolume, err := ctrl.client.CoreV1().PersistentVolumes().Get(volume.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil
 	}
@@ -1061,7 +1061,7 @@ func (ctrl *ProvisionController) deleteVolumeOperation(volume *v1.PersistentVolu
 
 	glog.V(4).Infof("deleteVolumeOperation [%s]: success", volume.Name)
 	// Delete the volume
-	if err = ctrl.client.Core().PersistentVolumes().Delete(volume.Name, nil); err != nil {
+	if err = ctrl.client.CoreV1().PersistentVolumes().Delete(volume.Name, nil); err != nil {
 		// Oops, could not delete the volume and therefore the controller will
 		// try to delete the volume again on next update.
 		glog.Infof("failed to delete volume %q from database: %v", volume.Name, err)

--- a/lib/controller/controller_test.go
+++ b/lib/controller/controller_test.go
@@ -223,7 +223,7 @@ func TestController(t *testing.T) {
 		time.Sleep(2 * resyncPeriod)
 		ctrl.runningOperations.Wait()
 
-		pvList, _ := client.Core().PersistentVolumes().List(metav1.ListOptions{})
+		pvList, _ := client.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
 		if !reflect.DeepEqual(test.expectedVolumes, pvList.Items) {
 			t.Logf("test case: %s", test.name)
 			t.Errorf("expected PVs:\n %v\n but got:\n %v\n", test.expectedVolumes, pvList.Items)

--- a/lib/gidallocator/allocator.go
+++ b/lib/gidallocator/allocator.go
@@ -175,7 +175,7 @@ func (a *Allocator) getGidTable(className string, min int, max int) (*allocator.
 // in a given storage class, and mark them in the table.
 //
 func (a *Allocator) collectGids(className string, gidTable *allocator.MinMaxAllocator) error {
-	pvList, err := a.client.Core().PersistentVolumes().List(metav1.ListOptions{})
+	pvList, err := a.client.CoreV1().PersistentVolumes().List(metav1.ListOptions{})
 	if err != nil {
 		glog.Errorf("failed to get existing persistent volumes")
 		return err

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -44,7 +44,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 	provisionerName := fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
 
 	broadcaster := record.NewBroadcaster()
-	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.Core().RESTClient()).Events("")})
+	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.CoreV1().RESTClient()).Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: provisionerName})
 
 	runtimeConfig := &common.RuntimeConfig{

--- a/local-volume/provisioner/pkg/util/api_util.go
+++ b/local-volume/provisioner/pkg/util/api_util.go
@@ -48,12 +48,12 @@ func NewAPIUtil(client *kubernetes.Clientset) APIUtil {
 
 // CreatePV will create a PersistentVolume
 func (u *apiUtil) CreatePV(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
-	return u.client.Core().PersistentVolumes().Create(pv)
+	return u.client.CoreV1().PersistentVolumes().Create(pv)
 }
 
 // DeletePV will delete a PersistentVolume
 func (u *apiUtil) DeletePV(pvName string) error {
-	return u.client.Core().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
+	return u.client.CoreV1().PersistentVolumes().Delete(pvName, &metav1.DeleteOptions{})
 }
 
 var _ APIUtil = &FakeAPIUtil{}

--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -374,7 +374,7 @@ func (p *nfsProvisioner) getServer() (string, error) {
 	if namespace == "" {
 		return "", fmt.Errorf("service env %s is set but namespace env %s isn't; no way to get the service cluster IP", p.serviceEnv, p.namespaceEnv)
 	}
-	service, err := p.client.Core().Services(namespace).Get(serviceName, metav1.GetOptions{})
+	service, err := p.client.CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("error getting service %s=%s in namespace %s=%s", p.serviceEnv, serviceName, p.namespaceEnv, namespace)
 	}
@@ -391,7 +391,7 @@ func (p *nfsProvisioner) getServer() (string, error) {
 		{111, v1.ProtocolUDP}:   true,
 		{111, v1.ProtocolTCP}:   true,
 	}
-	endpoints, err := p.client.Core().Endpoints(namespace).Get(serviceName, metav1.GetOptions{})
+	endpoints, err := p.client.CoreV1().Endpoints(namespace).Get(serviceName, metav1.GetOptions{})
 	for _, subset := range endpoints.Subsets {
 		// One service can't have multiple nfs-provisioner endpoints. If it had, kubernetes would round-robin
 		// the request which would probably go to the wrong instance.

--- a/nfs/test/e2e/e2e_test.go
+++ b/nfs/test/e2e/e2e_test.go
@@ -75,11 +75,11 @@ func testCreate(client clientset.Interface, claim *v1.PersistentVolumeClaim) *v1
 
 	By("checking the claim")
 	// Get new copy of the claim
-	claim, err = client.Core().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
+	claim, err = client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(claim.Name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Get the bound PV
-	pv, err := client.Core().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
+	pv, err := client.CoreV1().PersistentVolumes().Get(claim.Spec.VolumeName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	// Check sizes
@@ -126,7 +126,7 @@ func testRead(client clientset.Interface, claim *v1.PersistentVolumeClaim) {
 
 func testDelete(client clientset.Interface, claim *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
 	By("deleting the claim")
-	framework.ExpectNoError(client.Core().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil))
+	framework.ExpectNoError(client.CoreV1().PersistentVolumeClaims(claim.Namespace).Delete(claim.Name, nil))
 
 	// Wait for the PV to get deleted too.
 	framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(client, pv.Name, 5*time.Second, 1*time.Minute))


### PR DESCRIPTION
use `client.CoreV1` instead of deprecated `client.Core`