### PR TITLE
RBD Provisioner: Add userSecretNamespace parameter.

### DIFF
--- a/ceph/rbd/README.md
+++ b/ceph/rbd/README.md
@@ -41,7 +41,7 @@ kubectl create secret generic ceph-admin-secret --from-file=/tmp/secret --namesp
 ceph osd pool create kube 8 8
 ceph auth add client.kube mon 'allow r' osd 'allow rwx pool=kube'
 ceph auth get client.kube 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
-kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=default
+kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=kube-system
 ```
 
 * Start RBD provisioner

--- a/ceph/rbd/deploy/README.md
+++ b/ceph/rbd/deploy/README.md
@@ -17,6 +17,6 @@ kubectl apply -f ./non-rbac
 ```
 cd $GOPATH/src/github.com/kubernetes-incubator/external-storage/ceph/rbd/deploy
 NAMESPACE=default # change this if you want to deploy it in another namespace
-sed -r -i "s/namespace: [^ ]+/namespace: $NAMESPACE/g" ./rbac/clusterrolebinding.yaml
+sed -r -i "s/namespace: [^ ]+/namespace: $NAMESPACE/g" ./rbac/clusterrolebinding.yaml ./rbac/rolebinding.yaml
 kubectl -n $NAMESPACE apply -f ./rbac
 ```

--- a/ceph/rbd/deploy/rbac/clusterrole.yaml
+++ b/ceph/rbd/deploy/rbac/clusterrole.yaml
@@ -15,6 +15,3 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]

--- a/ceph/rbd/deploy/rbac/role.yaml
+++ b/ceph/rbd/deploy/rbac/role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: rbd-provisioner
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get"]

--- a/ceph/rbd/deploy/rbac/rolebinding.yaml
+++ b/ceph/rbd/deploy/rbac/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: rbd-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rbd-provisioner
+subjects:
+- kind: ServiceAccount
+  name: rbd-provisioner
+  namespace: default

--- a/ceph/rbd/examples/class.yaml
+++ b/ceph/rbd/examples/class.yaml
@@ -10,6 +10,7 @@ parameters:
   adminSecretNamespace: kube-system
   adminSecretName: ceph-admin-secret
   userId: kube
+  userSecretNamespace: kube-system
   userSecretName: ceph-secret
   imageFormat: "2"
   imageFeatures: layering

--- a/ceph/rbd/examples/secrets.yaml
+++ b/ceph/rbd/examples/secrets.yaml
@@ -12,6 +12,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ceph-secret
+  namespace: kube-system
 type: "kubernetes.io/rbd"
 data:
   # ceph auth add client.kube mon 'allow r' osd 'allow rwx pool=kube'


### PR DESCRIPTION
**What this PR does / why we need it**:
 
With https://github.com/kubernetes/kubernetes/commit/1411c2698eeb3cfe8a319fe0cdb1a7155249dc6e, RBD Persistent Volume now can reference secret from non-PVC/POD namespace. So we can support an additional `userSecretNamespace` parameter. With it, administrator do not need
configure use secret for each user (assuming each user may use a separate namespace).

**Special notes for reviewer**:

This requires [k8s.io/api@1.9](https://github.com/kubernetes/api/tree/release-1.9) (v1. RBDPersistentVolumeSource added in 1.9). I will test when dependencies are updated to 1.9.