### PR TITLE
limit provision synchronous operation numbers

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -153,6 +153,8 @@ const (
 	DefaultRetryPeriod = 2 * time.Second
 	// DefaultTermLimit is used when option function TermLimit is omitted
 	DefaultTermLimit = 30 * time.Second
+	// DefaultMaxProvisionOperationCount is used to set the max number of provision running provision Operations at the same time
+	DefaultMaxProvisionOperationCount = 20
 )
 
 var errRuntime = fmt.Errorf("cannot call option functions after controller has Run")
@@ -445,6 +447,10 @@ func (ctrl *ProvisionController) addClaim(obj interface{}) {
 	}
 
 	if ctrl.shouldProvision(claim) {
+		if len(ctrl.leaderElectors) >= DefaultMaxProvisionOperationCount {
+			glog.V(4).Infof("Provisioning opearations reach max %v, waiting until complete...", DefaultMaxProvisionOperationCount)
+			return
+		}
 		ctrl.leaderElectorsMutex.Lock()
 		le, ok := ctrl.leaderElectors[claim.UID]
 		ctrl.leaderElectorsMutex.Unlock()


### PR DESCRIPTION
if there is a huge number of pvc request at the same time, for each pvc, controller will create a leaderElector and spawn a go routine, this will lead to huge map of goroutines in the controller, and cause the provisioner not working.
per my test, the provisioner was stuck when creating 100 PVCs .