### PR TITLE
Check for all Digital Ocean Volumes

### DIFF
--- a/digitalocean/cmd/digitalocean-flexplugin/main.go
+++ b/digitalocean/cmd/digitalocean-flexplugin/main.go
@@ -110,14 +110,27 @@ func (c *cloud) findNode(nodeName string) (int, error) {
 }
 
 func (c *cloud) getVolumeByName(volumeName string) (string, error) {
-	volumes, _, err := c.client.Storage.ListVolumes(c.ctx, nil)
-	if err != nil {
-		return "", err
-	}
-	for _, volume := range volumes {
-		if volume.Name == volumeName {
-			return volume.ID, nil
+	opt := &godo.ListVolumeParams{ListOptions: &godo.ListOptions{}}
+	// get all volumes by looping over pages
+	for {
+		volumes, resp, err := c.client.Storage.ListVolumes(c.ctx, opt)
+		if err != nil {
+			return "", err
 		}
+		for _, volume := range volumes {
+			if volume.Name == volumeName {
+				return volume.ID, nil
+			}
+		}
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return "", err
+		}
+		// set the page we want for the next request
+		opt.ListOptions.Page = page + 1
 	}
 	return "", fmt.Errorf("Error: No volume found with volumeName: %s", volumeName)
 }


### PR DESCRIPTION
The flexplugin was not checking for all volumes since the api returns
volumes by page where each page has a limited number of volumes.

This commit alters the getVolumeByName function so that it checks all volumes by continuing to query pages until no results are found.

/area digitalocean