### PR TITLE
RBD Provisioner: Support storageClass fsType parameter.

### DIFF
--- a/ceph/rbd/pkg/provision/rbd_util.go
+++ b/ceph/rbd/pkg/provision/rbd_util.go
@@ -76,6 +76,7 @@ func (u *RBDUtil) CreateImage(image string, pOpts *rbdProvisionOptions, options 
 		CephMonitors: pOpts.monitors,
 		RBDImage:     image,
 		RBDPool:      pOpts.pool,
+		FSType:       pOpts.fsType,
 	}, sz, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Support storagClass fsType parameter
- Add some code comments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #560

**Special notes for reviewer**:

cc @wongma7 @rootfs 