### PR TITLE
Support noauth connections from the environment

### DIFF
--- a/openstack/standalone-cinder/Makefile
+++ b/openstack/standalone-cinder/Makefile
@@ -35,8 +35,7 @@ container: build
 	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 
 test:
-	go test ./pkg/provisioner
-
+	go test -cover ./pkg/provisioner ./pkg/volumeservice
 
 clean:
 	-rm cinder-provisioner

--- a/openstack/standalone-cinder/README.md
+++ b/openstack/standalone-cinder/README.md
@@ -29,9 +29,44 @@ cinder deployment with keystone managing authentication and
 providing the service catalog, and a standalone configuration where
 cinder is accessed directly.
 
-Conventional cinder deployments can be used by supplying a clound
+Cinder deployments can be used by supplying a clound
 config file identical to the one you would use to configure an
-openstack cloud provider.
+openstack cloud provider or by specifying authentication parameters
+in the environment.
+
+```ini
+# Example configuration: keystone auth via cloudconfig
+[Global]
+auth-url=http://keystone-host:5000/v2.0
+username=admin
+password=Passw0rd!
+region=RegionOne
+tenant-id=637b7373213d439d8119285244481456
+```
+
+```ini
+# Example configuration: noauth via cloudconfig
+[Global]
+cinder-endpoint=http://cinder-host:8776/v2
+username=admin
+tenant-name=admin
+```
+
+```sh
+# Example configuration: keystone auth via environment variables
+OS_AUTH_URL=http://keystone-host:5000/v2.0
+OS_USERNAME=admin
+OS_PASSWORD=Passw0rd!
+OS_TENANT_ID=637b7373213d439d8119285244481456
+OS_REGION_NAME=RegionOne
+```
+
+```sh
+# Example configuration: noauth via environment variables
+OS_CINDER_ENDPOINT=http://cinder-host:8776/v2
+OS_USERNAME=admin
+OS_TENANT_NAME=admin
+```
 
 ### Workflows
 | User       | Kubernetes   | Provisioner  | Cinder       |

--- a/openstack/standalone-cinder/pkg/volumeservice/connection.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/connection.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/noauth"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
-	"gopkg.in/gcfg.v1"
+	gcfg "gopkg.in/gcfg.v1"
 
 	"github.com/golang/glog"
 	netutil "k8s.io/apimachinery/pkg/util/net"
@@ -84,20 +84,15 @@ func (cfg cinderConfig) toAuth3Options() tokens3.AuthOptions {
 }
 
 func getConfigFromEnv() cinderConfig {
-	authURL := os.Getenv("OS_AUTH_URL")
-	if authURL == "" {
-		glog.Warning("OS_AUTH_URL missing from environment")
-		return cinderConfig{}
-	}
-
 	return cinderConfig{
 		Global: cinderConfigGlobal{
-			AuthURL:    authURL,
-			Username:   os.Getenv("OS_USERNAME"),
-			Password:   os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
-			TenantID:   os.Getenv("OS_TENANT_ID"),
-			Region:     os.Getenv("OS_REGION_NAME"),
-			DomainName: os.Getenv("OS_USER_DOMAIN_NAME"),
+			AuthURL:        os.Getenv("OS_AUTH_URL"),
+			CinderEndpoint: os.Getenv("OS_CINDER_ENDPOINT"),
+			Username:       os.Getenv("OS_USERNAME"),
+			Password:       os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
+			TenantID:       os.Getenv("OS_TENANT_ID"),
+			Region:         os.Getenv("OS_REGION_NAME"),
+			DomainName:     os.Getenv("OS_USER_DOMAIN_NAME"),
 		},
 	}
 }
@@ -108,7 +103,7 @@ func getConfig(configFilePath string) (cinderConfig, error) {
 		var config cinderConfig
 		configFile, err := os.Open(configFilePath)
 		if err != nil {
-			glog.Fatalf("Couldn't open configuration %s: %#v",
+			glog.Errorf("Couldn't open configuration %s: %#v",
 				configFilePath, err)
 			return cinderConfig{}, err
 		}
@@ -117,7 +112,7 @@ func getConfig(configFilePath string) (cinderConfig, error) {
 
 		err = gcfg.ReadInto(&config, configFile)
 		if err != nil {
-			glog.Fatalf("Couldn't read configuration: %#v", err)
+			glog.Errorf("Couldn't read configuration: %#v", err)
 			return cinderConfig{}, err
 		}
 		return config, nil

--- a/openstack/standalone-cinder/pkg/volumeservice/volumeservice_suite_test.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/volumeservice_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeservice_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVolumeservice(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volumeservice Suite")
+}

--- a/openstack/standalone-cinder/pkg/volumeservice/volumeservice_test.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/volumeservice_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeservice
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const (
+	AuthURL        = "http://keystone-host:5000/v2.0"
+	CinderEndpoint = "http://cinder-host:8776/v2"
+)
+
+var _ = Describe("Volume Service", func() {
+	Describe("Connection configuration parsing", func() {
+		var (
+			config cinderConfig
+			err    error
+		)
+
+		Context("when config file path is empty", func() {
+			BeforeEach(func() {
+				os.Setenv("OS_AUTH_URL", AuthURL)
+				os.Setenv("OS_CINDER_ENDPOINT", CinderEndpoint)
+				os.Setenv("OS_USERNAME", "USERNAME")
+				os.Setenv("OS_PASSWORD", "PASSWORD")
+				os.Setenv("OS_TENANT_ID", "TENANT_ID")
+				os.Setenv("OS_REGION_NAME", "REGION_NAME")
+				os.Setenv("OS_USER_DOMAIN_NAME", "USER_DOMAIN_NAME")
+			})
+
+			JustBeforeEach(func() {
+				config, err = getConfig("")
+			})
+
+			It("should take the configuration from the environment", func() {
+				ValidateConfig(config)
+			})
+		})
+
+		Context("when config file path is specified", func() {
+			var (
+				tmpFile string
+			)
+
+			BeforeEach(func() {
+				var file *os.File
+				data := []byte(fmt.Sprintf(`
+					[Global]
+					auth-url=%s
+					cinder-endpoint=%s
+				`, AuthURL, CinderEndpoint))
+
+				file, err = ioutil.TempFile(os.TempDir(), "cinderConfig")
+				Expect(err).To(BeNil())
+				tmpFile = file.Name()
+				err = ioutil.WriteFile(tmpFile, data, 0644)
+				Expect(err).To(BeNil())
+
+			})
+			AfterEach(func() {
+				os.Remove(tmpFile)
+			})
+
+			JustBeforeEach(func() {
+				config, err = getConfig(tmpFile)
+			})
+
+			It("should read the configuration from the file", func() {
+				ValidateConfig(config)
+			})
+
+			Context("when the config file path does not exist", func() {
+				BeforeEach(func() {
+					os.Remove(tmpFile)
+				})
+				It("should fail", func() {
+					Expect(err).NotTo(BeNil())
+				})
+			})
+		})
+	})
+})
+
+func ValidateConfig(config cinderConfig) {
+	Expect(config.Global.AuthURL).To(Equal(AuthURL))
+	Expect(config.Global.CinderEndpoint).To(Equal(CinderEndpoint))
+}


### PR DESCRIPTION
Noauth support was added by a recent commit but it only worked when used
with the config file approach.  Add support for parsing the environment.
If OS_AUTH_URL is set, we will use a Keystone approach.  If
OS_CINDER_ENDPOINT is set we will use noauth.  Add connection tests to
validate that this is working as intended.

Signed-off-by: Adam Litke <alitke@redhat.com>