### PR TITLE
standalone-cinder: Use cinder attach and detach

### DIFF
--- a/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
@@ -28,6 +28,8 @@ type volumeServiceBroker interface {
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
+	attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
@@ -52,6 +54,14 @@ func (vsb *gophercloudBroker) reserveCinderVolume(vs *gophercloud.ServiceClient,
 
 func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
 	return volumeservice.ConnectCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.AttachCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.DetachCinderVolume(vs, volumeID)
 }
 
 func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {


### PR DESCRIPTION
Prior to this patch, provisioned cinder volumes were left in 'attaching'
state in the cinder DB.  This is an interim state that is supposed to
resolve to 'attached' or (in the case of failure) 'available'.  This
patch completes the attachment process on the cinder side so that
volumes will appear attached to cinder.
    
Note that the volume is not really attached to a user until a pod
consumes the PV and the kubelet attaches and mounts the volume.  This
descrepency between k8s and cinder is OK as each system has an
appropriate view of the volume state from its own perspective.
