### PR TITLE
Check strconv.ParseUint error.

### DIFF
--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -450,7 +450,11 @@ func (p *nfsProvisioner) createDirectory(directory, gid string) error {
 	}
 
 	if gid != "none" {
-		groupID, _ := strconv.ParseUint(gid, 10, 64)
+		groupID, err := strconv.ParseUint(gid, 10, 64)
+		if err != nil {
+			os.RemoveAll(path)
+			return fmt.Errorf("strconv.ParseUint failed with error: %v", err)
+		}
 		cmd := exec.Command("chgrp", strconv.FormatUint(groupID, 10), path)
 		out, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
`strconv.ParseUint` returns 0 and an error if argument is invalid. If we
don't check error, the following `chgrd` will succeed to change the
group of file to 0, and reports no error if the process is
running as root user.