### PR TITLE
Expose `shouldProvision` to provisioners via new controller interface

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -569,6 +569,12 @@ func (ctrl *ProvisionController) shouldProvision(claim *v1.PersistentVolumeClaim
 		return false
 	}
 
+	if qualifier, ok := ctrl.provisioner.(Qualifier); ok {
+		if !qualifier.ShouldProvision(claim) {
+			return false
+		}
+	}
+
 	// Kubernetes 1.5 provisioning with annStorageProvisioner
 	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.5.0")) {
 		if provisioner, found := claim.Annotations[annStorageProvisioner]; found {

--- a/lib/controller/volume.go
+++ b/lib/controller/volume.go
@@ -38,6 +38,15 @@ type Provisioner interface {
 	Delete(*v1.PersistentVolume) error
 }
 
+// Qualifier is an optional interface implemented by provisioners to determine
+// whether a claim should be provisioned as early as possible (e.g. prior to
+// leader election).
+type Qualifier interface {
+	// ShouldProvision returns whether provisioning for the claim should
+	// be attempted.
+	ShouldProvision(*v1.PersistentVolumeClaim) bool
+}
+
 // IgnoredError is the value for Delete to return to indicate that the call has
 // been ignored and no action taken. In case multiple provisioners are serving
 // the same storage class, provisioners may ignore PVs they are not responsible

--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -176,6 +176,18 @@ type nfsProvisioner struct {
 }
 
 var _ controller.Provisioner = &nfsProvisioner{}
+var _ controller.Qualifier = &nfsProvisioner{}
+
+// ShouldProvision returns whether provisioning should be attempted for the given
+// claim.
+func (p *nfsProvisioner) ShouldProvision(claim *v1.PersistentVolumeClaim) bool {
+	// As long as the export limit has not been reached we're ok to provision
+	ok := p.checkExportLimit()
+	if !ok {
+		glog.Infof("export limit reached. skipping claim %s/%s", claim.Namespace, claim.Name)
+	}
+	return ok
+}
 
 // Provision creates a volume i.e. the storage asset and returns a PV object for
 // the volume.


### PR DESCRIPTION
Added new `controller.Qualifier` interface which is implemented by
any controller that has a `ShouldProvision` method. When implemented,
the provisioner's `ShouldProvision` method is called by lib controller's
`shouldProvision` with a return value of false from the former
resulting in the same from the latter.

This allows provisioners the opportunity to ignore individual claims
prior to attaining leadership for the claim, avoiding uneccessary
election cycles when multiple provisioners are serving the same storage
class.