### PR TITLE
[WIP] standalone-cinder: Support cloning via PVC Annotation

### DIFF
--- a/local-volume/bootstrapper/bootstrapper.go
+++ b/local-volume/bootstrapper/bootstrapper.go
@@ -96,9 +96,9 @@ func ensureMountDir(config *common.ProvisionerConfiguration) bool {
 	needsUpdate := false
 	for class, mount := range config.StorageClassConfig {
 		if mount.MountDir == "" {
-			newMoutConfig := mount
-			newMoutConfig.MountDir = generateMountDir(&mount)
-			config.StorageClassConfig[class] = newMoutConfig
+			newMountConfig := mount
+			newMountConfig.MountDir = generateMountDir(&mount)
+			config.StorageClassConfig[class] = newMountConfig
 			needsUpdate = true
 		}
 	}

--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -1,0 +1,45 @@
+# Helm installation procedure 
+
+## Overview
+
+In order to be able to use **helm** to render templates, it has to be installed on a host where a user plans
+to generate templates.
+
+## Helm Installation
+On Linux, run these two commands to download and copy helm binary into /usr/bin directory.
+
+``` console
+export HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
+curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/bin linux-amd64/helm -zxf -
+```
+Provisioner's spec generation process has been tested with helm version 2.7.2.
+
+## Helm verification
+
+Run the following command:
+``` console
+helm version
+```
+
+This output should be generated:
+``` console
+Client: &version.Version{SemVer:"v2.7.2", GitCommit:"8478fb4fc723885b155c924d1c8c410b7a9444e6", GitTreeState:"clean"}
+Error: cannot connect to Tiller
+``` 
+
+The error on the second line of the output can be ignored, as Tiller, helm's deployment engine has not been installed on the 
+kubernetes cluster as it is not required for template generation.
+
+## Provisioner's helm chart
+
+Helm templating is used to generate the provisioner's DaemonSet and ConfigMap specs.
+The generated specs can be further customized as needed (usually not necessary), and then deployed using kubectl.
+
+**helm template** uses 3 sources of information:
+1. Provisioner's chart template located at helm/provisioner/templates/provisioner.yaml
+2. Provisioner's default values.yaml which contains variables used for rendering a template.
+3. (Optional) User's customized values.yaml as a part of helm template command. User's provided
+   values will override default values of Provisioner's values.yaml.
+
+Default values.yaml is located in local-volume/helm/provisioner folder, user should not remove variables from this file but can
+change any values of these variables.

--- a/local-volume/helm/provisioner/Chart.yaml
+++ b/local-volume/helm/provisioner/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+version: 2.0.0
+description: local provisioner chart 
+name: provisioner
+keywords:
+  - storage
+  - local
+engine: gotpl

--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -1,0 +1,87 @@
+{{- $configMapName := .Values.configmap.configMapName }}
+{{- $provisionerNamespace := .Values.common.namespace }}
+{{- $provisionerName := .Values.daemonset.name }}
+{{- $imageFull := .Values.daemonset.image }}
+{{- $imagePullPolicy := .Values.daemonset.imagePullPolicy }}
+{{- $serviceAccount := .Values.daemonset.serviceAccount }}
+{{- $kubeConfigEnv := .Values.daemonset.kubeConfigEnv }}
+{{- $nodeLabels := .Values.daemonset.nodeLabels }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $configMapName }} 
+  namespace: {{ $provisionerNamespace }} 
+data:
+{{- if $nodeLabels }}
+  nodeLabelsForPV: |
+   {{- range $label := $nodeLabels }}
+    - {{$label}}
+   {{- end }}
+{{- end }}
+  storageClassMap: |
+#
+# Populating entries with user provided disk discovery directories 
+# and mount directories per storage class.
+#
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+      {{ $storageClass }}:     
+          hostDir: {{ $classConfig.hostDir }}
+          mountDir: {{ if $classConfig.mountDir }} {{$classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
+   {{- end}}
+{{- end}}
+
+---
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: {{ $provisionerName }}
+  namespace: {{ $provisionerNamespace }}
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner 
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: {{$serviceAccount}}
+      containers:
+        - image: "{{ $imageFull }}"
+          imagePullPolicy: {{ $imagePullPolicy | quote }}
+          name: provisioner 
+          securityContext:
+            privileged: true
+          env:
+{{- if $kubeConfigEnv }}
+            - name: KUBECONFIG
+              value: {{$kubeConfigEnv}}
+{{- end }}
+          volumeMounts:
+            - mountPath: /etc/provisioner/config 
+              name: provisioner-config
+              readOnly: true
+#
+# Populating entries with user provided disk discovery directories 
+#
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+            - mountPath: {{ if $classConfig.mountDir }} {{ $classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
+              name: {{ $storageClass }}
+   {{- end}}
+{{- end}}
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: {{ $configMapName }}
+{{- range $tmp, $val := .Values.configmap.storageClass }}
+   {{- range $storageClass, $classConfig := $val }}
+        - name: {{ $storageClass }}
+          hostPath:
+            path: {{ $classConfig.hostDir }}
+   {{- end}}
+{{- end}}

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -1,0 +1,49 @@
+common:
+  #
+  # Defines the namespace where provisioner runs
+  #
+  namespace: default
+configmap:
+  #
+  # Defines the name of configmap used by Provisioner
+  #
+  configMapName: "local-provisioner-config"
+  #
+  # Defines storage classes in a format:
+  #
+  #  storageClass:
+  #    - {storage class name}:
+  #        hostDir: "{path on the host where local volume of this storage class are mounted}"
+  #        mountDir: "{Optional path where a local volume will be mounted inside of a container}"
+  #
+  # Note: At least one storage class must be configured
+  storageClass:
+    - fast-disks:
+        hostDir: /mnt/fast-disks
+  #
+daemonset:
+  #
+  # Defines the name of a Provisioner
+  #
+  name: "local-volume-provisioner"
+  #
+  # Defines Provisioner's image name including container registry.
+  #
+  image: quay.io/external_storage/local-volume-provisioner:latest
+  #
+  # Defines Image download policy, see kubernetes documentation for available values.
+  #
+  imagePullPolicy: Always
+  #
+  # Defines a name of the service account which Provisioner will use to communicate with API server.
+  #
+  serviceAccount: local-storage-admin
+  #
+  # If configured KubeConfigEnv will (optionally) specify the location of kubeconfig file on the node.
+  #  kubeConfigEnv: KUBECONFIG
+  #
+  # List of node labels to be copied to the PVs created by the provisioner in a format:
+  #
+  #  nodeLabels:
+  #    - failure-domain.beta.kubernetes.io/zone
+  #    - failure-domain.beta.kubernetes.io/region

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -51,10 +51,6 @@ const (
 	// VolumeTypeBlock represents block type volumes
 	VolumeTypeBlock = "block"
 
-	// DefaultHostDir is the default host dir to discover local volumes.
-	DefaultHostDir = "/mnt/disks"
-	// DefaultMountDir is the container mount point for the default host dir.
-	DefaultMountDir = "/local-disks"
 	// DefaultBlockCleanerCommand is the default block device cleaning command
 	DefaultBlockCleanerCommand = "/scripts/quick_reset.sh"
 
@@ -137,7 +133,7 @@ var InClusterConfig = rest.InClusterConfig
 // ProvisionerConfiguration defines Provisioner configuration objects
 // Each configuration key of the struct e.g StorageClassConfig is individually
 // marshaled in VolumeConfigToConfigMapData.
-// TODO Need to find a way to marshal the struct  more efficiently.
+// TODO Need to find a way to marshal the struct more efficiently.
 type ProvisionerConfiguration struct {
 	// StorageClassConfig defines configuration of Provisioner's storage classes
 	StorageClassConfig map[string]MountConfig `json:"storageClassMap" yaml:"storageClassMap"`
@@ -185,7 +181,7 @@ func GetContainerPath(pv *v1.PersistentVolume, config MountConfig) (string, erro
 	return filepath.Join(config.MountDir, relativePath), nil
 }
 
-// GetVolumeConfigFromConfigMap gets volume configuration from given configmap,
+// GetVolumeConfigFromConfigMap gets volume configuration from given configmap.
 func GetVolumeConfigFromConfigMap(client *kubernetes.Clientset, namespace, name string, provisionerConfig *ProvisionerConfiguration) error {
 	configMap, err := client.CoreV1().ConfigMaps(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -193,17 +189,6 @@ func GetVolumeConfigFromConfigMap(client *kubernetes.Clientset, namespace, name 
 	}
 	err = ConfigMapDataToVolumeConfig(configMap.Data, provisionerConfig)
 	return err
-}
-
-// GetDefaultVolumeConfig returns the default volume configuration.
-func GetDefaultVolumeConfig(provisionerConfig *ProvisionerConfiguration) {
-	provisionerConfig.StorageClassConfig = map[string]MountConfig{
-		"local-storage": {
-			HostDir:             DefaultHostDir,
-			MountDir:            DefaultMountDir,
-			BlockCleanerCommand: []string{DefaultBlockCleanerCommand},
-		},
-	}
 }
 
 // VolumeConfigToConfigMapData converts volume config to configmap data.
@@ -225,7 +210,7 @@ func VolumeConfigToConfigMapData(config *ProvisionerConfiguration) (map[string]s
 	return configMapData, nil
 }
 
-// ConfigMapDataToVolumeConfig converts configmap data to volume config
+// ConfigMapDataToVolumeConfig converts configmap data to volume config.
 func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *ProvisionerConfiguration) error {
 	rawYaml := ""
 	for key, val := range data {
@@ -239,10 +224,10 @@ func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *Prov
 	}
 	for class, config := range provisionerConfig.StorageClassConfig {
 		if config.BlockCleanerCommand == nil {
-			// supply a default block cleaner command.
+			// Supply a default block cleaner command.
 			config.BlockCleanerCommand = []string{DefaultBlockCleanerCommand}
 		} else {
-			// Validate that array is non empty
+			// Validate that array is non empty.
 			if len(config.BlockCleanerCommand) < 1 {
 				return fmt.Errorf("Invalid empty block cleaner command for class %v", class)
 			}

--- a/openstack/standalone-cinder/Makefile
+++ b/openstack/standalone-cinder/Makefile
@@ -35,8 +35,7 @@ container: build
 	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 
 test:
-	go test ./pkg/provisioner
-
+	go test -cover ./pkg/provisioner ./pkg/volumeservice
 
 clean:
 	-rm cinder-provisioner

--- a/openstack/standalone-cinder/pkg/provisioner/clusterbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/clusterbroker.go
@@ -31,7 +31,7 @@ type k8sClusterBroker struct {
 	clusterBroker
 }
 
-func (k8sClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
+func (*k8sClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
 	_, err := p.Client.CoreV1().Secrets(ns).Create(secret)
 	if err != nil {
 		glog.Errorf("Failed to create chap secret in namespace %s: %v", ns, err)

--- a/openstack/standalone-cinder/pkg/provisioner/iscsi.go
+++ b/openstack/standalone-cinder/pkg/provisioner/iscsi.go
@@ -25,6 +25,7 @@ import (
 )
 
 const iscsiType = "iscsi"
+const initiatorName = "iqn.2018-01.io.k8s:a13fc3d1cc22"
 
 type iscsiMapper struct {
 	volumeMapper
@@ -39,9 +40,10 @@ func getChapSecretName(connection volumeservice.VolumeConnection, options contro
 }
 
 func (m *iscsiMapper) BuildPVSource(conn volumeservice.VolumeConnection, options controller.VolumeOptions) (*v1.PersistentVolumeSource, error) {
+	initiator := initiatorName[:]
 	ret := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIVolumeSource{
-			// TODO: Need some way to specify the initiator name
+			InitiatorName:   &initiator,
 			TargetPortal:    conn.Data.TargetPortal,
 			IQN:             conn.Data.TargetIqn,
 			Lun:             conn.Data.TargetLun,

--- a/openstack/standalone-cinder/pkg/provisioner/iscsi_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/iscsi_test.go
@@ -195,22 +195,3 @@ func createIscsiConnectionInfo() volumeservice.VolumeConnection {
 		},
 	}
 }
-
-type fakeClusterBroker struct {
-	clusterBroker
-	CreatedSecret *v1.Secret
-	DeletedSecret string
-	Namespace     string
-}
-
-func (cb *fakeClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
-	cb.CreatedSecret = secret
-	cb.Namespace = ns
-	return nil
-}
-
-func (cb *fakeClusterBroker) deleteSecret(p *cinderProvisioner, ns string, secretName string) error {
-	cb.DeletedSecret = secretName
-	cb.Namespace = ns
-	return nil
-}

--- a/openstack/standalone-cinder/pkg/provisioner/mapper.go
+++ b/openstack/standalone-cinder/pkg/provisioner/mapper.go
@@ -73,8 +73,8 @@ func buildPV(m volumeMapper, p *cinderProvisioner, options controller.VolumeOpti
 			Name:      options.PVName,
 			Namespace: options.PVC.Namespace,
 			Annotations: map[string]string{
-				ProvisionerIDAnn: p.Identity,
-				CinderVolumeID:   volumeID,
+				ProvisionerIDAnn:  p.Identity,
+				CinderVolumeIDAnn: volumeID,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{

--- a/openstack/standalone-cinder/pkg/provisioner/mapper_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/mapper_test.go
@@ -167,8 +167,8 @@ var _ = Describe("Mapper", func() {
 
 		It("should yield a valid PV associated with this provisioner", func() {
 			annotations := map[string]string{
-				ProvisionerIDAnn: "identity",
-				CinderVolumeID:   "volumeid",
+				ProvisionerIDAnn:  "identity",
+				CinderVolumeIDAnn: "volumeid",
 			}
 			accessModes := []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce}
 			quantity, parseErr := resource.ParseQuantity("1Gi")

--- a/openstack/standalone-cinder/pkg/provisioner/provisioner.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner.go
@@ -39,8 +39,8 @@ const (
 	// ProvisionerIDAnn is an annotation to identify a particular instance of this provisioner
 	ProvisionerIDAnn = "standaloneCinderProvisionerIdentity"
 
-	// CinderVolumeID is an annotation to store the ID of the associated cinder volume
-	CinderVolumeID = "cinderVolumeId"
+	// CinderVolumeIDAnn is an annotation to store the ID of the associated cinder volume
+	CinderVolumeIDAnn = "cinderVolumeId"
 )
 
 type cinderProvisioner struct {
@@ -215,9 +215,9 @@ func (p *cinderProvisioner) Delete(pv *v1.PersistentVolume) error {
 	// TODO when beta is removed, have to check kube version and pick v1/beta
 	// accordingly: maybe the controller lib should offer a function for that
 
-	volumeID, ok := pv.Annotations[CinderVolumeID]
+	volumeID, ok := pv.Annotations[CinderVolumeIDAnn]
 	if !ok {
-		return errors.New(CinderVolumeID + " annotation not found on PV")
+		return errors.New(CinderVolumeIDAnn + " annotation not found on PV")
 	}
 
 	mapper, err := p.mb.newVolumeMapperFromPV(pv)

--- a/openstack/standalone-cinder/pkg/provisioner/provisioner.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner.go
@@ -142,7 +142,7 @@ func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		goto ERROR_DELETE
 	}
 
-	connection, err = p.vsb.connectCinderVolume(p.VolumeService, volumeID)
+	connection, err = p.vsb.connectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if err != nil {
 		glog.Errorf("Failed to connect volume %s: %v", volumeID, err)
 		goto ERROR_UNRESERVE
@@ -179,7 +179,7 @@ ERROR_DETACH:
 		glog.Errorf("Failed to detach volume %s: %v", volumeID, cleanupErr)
 	}
 ERROR_DISCONNECT:
-	cleanupErr = p.vsb.disconnectCinderVolume(p.VolumeService, volumeID)
+	cleanupErr = p.vsb.disconnectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if cleanupErr != nil {
 		glog.Errorf("Failed to disconnect volume %s: %v", volumeID, cleanupErr)
 	}
@@ -234,7 +234,7 @@ func (p *cinderProvisioner) Delete(pv *v1.PersistentVolume) error {
 		return err
 	}
 
-	err = p.vsb.disconnectCinderVolume(p.VolumeService, volumeID)
+	err = p.vsb.disconnectCinderVolume(p.VolumeService, initiatorName, volumeID)
 	if err != nil {
 		glog.Errorf("Failed to disconnect volume %s: %v", volumeID, err)
 		return err

--- a/openstack/standalone-cinder/pkg/provisioner/provisioner_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner_test.go
@@ -344,7 +344,7 @@ func (vsb *fakeVolumeServiceBroker) reserveCinderVolume(vs *gophercloud.ServiceC
 	return vsb.mightFail.ret("reserveCinderVolume")
 }
 
-func (vsb *fakeVolumeServiceBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
+func (vsb *fakeVolumeServiceBroker) connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error) {
 	if vsb.mightFail.isSet("connectCinderVolume") {
 		return volumeservice.VolumeConnection{}, errors.New("injected error for testing")
 	}
@@ -359,7 +359,7 @@ func (vsb *fakeVolumeServiceBroker) detachCinderVolume(vs *gophercloud.ServiceCl
 	return vsb.mightFail.logRet("detachCinderVolume")
 }
 
-func (vsb *fakeVolumeServiceBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+func (vsb *fakeVolumeServiceBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
 	return vsb.mightFail.logRet("disconnectCinderVolume")
 }
 

--- a/openstack/standalone-cinder/pkg/provisioner/provisioner_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Provisioner", func() {
 
 		Context("when the cinder volume ID annotation is missing from the PV", func() {
 			BeforeEach(func() {
-				delete(pv.Annotations, CinderVolumeID)
+				delete(pv.Annotations, CinderVolumeIDAnn)
 			})
 
 			It("should fail", func() {

--- a/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
@@ -139,3 +139,22 @@ func (m *fakeMapper) AuthSetup(p *cinderProvisioner, options controller.VolumeOp
 func (m *fakeMapper) AuthTeardown(p *cinderProvisioner, pv *v1.PersistentVolume) error {
 	return m.mightFail.ret("AuthTeardown")
 }
+
+type fakeClusterBroker struct {
+	clusterBroker
+	CreatedSecret *v1.Secret
+	DeletedSecret string
+	Namespace     string
+}
+
+func (cb *fakeClusterBroker) createSecret(p *cinderProvisioner, ns string, secret *v1.Secret) error {
+	cb.CreatedSecret = secret
+	cb.Namespace = ns
+	return nil
+}
+
+func (cb *fakeClusterBroker) deleteSecret(p *cinderProvisioner, ns string, secretName string) error {
+	cb.DeletedSecret = secretName
+	cb.Namespace = ns
+	return nil
+}

--- a/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
@@ -61,8 +61,8 @@ func createPersistentVolume() *v1.PersistentVolume {
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				ProvisionerIDAnn: "identity",
-				CinderVolumeID:   "cinderVolumeID",
+				ProvisionerIDAnn:  "identity",
+				CinderVolumeIDAnn: "cinderVolumeID",
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{

--- a/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package provisioner
 
 import (
+	"bytes"
 	"errors"
+
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/kubernetes-incubator/external-storage/openstack/standalone-cinder/pkg/volumeservice"
@@ -79,31 +81,41 @@ func createCinderProvisioner() *cinderProvisioner {
 }
 
 type failureInjector struct {
-	failOn map[string]bool
+	operationLog bytes.Buffer
+	failOn       map[string]bool
 }
 
-func (vsb *failureInjector) set(method string) {
-	if vsb.failOn == nil {
-		vsb.failOn = make(map[string]bool)
+func (fi *failureInjector) set(method string) {
+	if fi.failOn == nil {
+		fi.failOn = make(map[string]bool)
 	}
-	vsb.failOn[method] = true
+	fi.failOn[method] = true
 }
 
-func (vsb *failureInjector) isSet(method string) bool {
-	if vsb.failOn == nil {
+func (fi *failureInjector) isSet(method string) bool {
+	if fi.failOn == nil {
 		return false
 	}
-	value, ok := vsb.failOn[method]
+	value, ok := fi.failOn[method]
 	if !ok {
 		return false
 	}
 	return value
 }
 
-func (vsb *failureInjector) ret(method string) error {
-	if vsb.isSet(method) {
+func (fi *failureInjector) ret(method string) error {
+	if fi.isSet(method) {
 		return errors.New("injected error for testing")
 	}
+	return nil
+}
+
+func (fi *failureInjector) logRet(fn string) error {
+	if fi.isSet(fn) {
+		return errors.New("injected error for testing")
+	}
+	fi.operationLog.WriteString(fn)
+	fi.operationLog.WriteString(".")
 	return nil
 }
 

--- a/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
+++ b/openstack/standalone-cinder/pkg/provisioner/testutils_test.go
@@ -28,31 +28,37 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createVolumeOptions() controller.VolumeOptions {
+func createPVC(name string, size string) *v1.PersistentVolumeClaim {
 	var storageClass = "storageclass"
 
 	capacity, err := resource.ParseQuantity("1Gi")
 	if err != nil {
 		glog.Error("Programmer error, cannot parse quantity string")
-		return controller.VolumeOptions{}
+		return &v1.PersistentVolumeClaim{}
 	}
-
-	return controller.VolumeOptions{
-		PVName: "testpv",
-		PVC: &v1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "testns",
-			},
-			Spec: v1.PersistentVolumeClaimSpec{
-				StorageClassName: &storageClass,
-				AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
-				Resources: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceName(v1.ResourceStorage): capacity,
-					},
+	return &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "testns",
+			Annotations: make(map[string]string),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClass,
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): capacity,
 				},
 			},
 		},
+	}
+}
+
+func createVolumeOptions() controller.VolumeOptions {
+	return controller.VolumeOptions{
+		PVName:                        "testpv",
+		PVC:                           createPVC("curPVC", "1G"),
+		Parameters:                    make(map[string]string),
 		PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
 	}
 }

--- a/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
@@ -28,6 +28,8 @@ type volumeServiceBroker interface {
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
+	attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
@@ -51,6 +53,14 @@ func (vsb *gophercloudBroker) reserveCinderVolume(vs *gophercloud.ServiceClient,
 
 func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
 	return volumeservice.ConnectCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.AttachCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeservice.DetachCinderVolume(vs, volumeID)
 }
 
 func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {

--- a/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
@@ -27,10 +27,10 @@ type volumeServiceBroker interface {
 	createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error)
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
-	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
+	connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error)
 	attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	detachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
-	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error)
@@ -52,8 +52,8 @@ func (vsb *gophercloudBroker) reserveCinderVolume(vs *gophercloud.ServiceClient,
 	return volumeservice.ReserveCinderVolume(vs, volumeID)
 }
 
-func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error) {
-	return volumeservice.ConnectCinderVolume(vs, volumeID)
+func (vsb *gophercloudBroker) connectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (volumeservice.VolumeConnection, error) {
+	return volumeservice.ConnectCinderVolume(vs, initiator, volumeID)
 }
 
 func (vsb *gophercloudBroker) attachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
@@ -64,8 +64,8 @@ func (vsb *gophercloudBroker) detachCinderVolume(vs *gophercloud.ServiceClient, 
 	return volumeservice.DetachCinderVolume(vs, volumeID)
 }
 
-func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
-	return volumeservice.DisconnectCinderVolume(vs, volumeID)
+func (vsb *gophercloudBroker) disconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
+	return volumeservice.DisconnectCinderVolume(vs, initiator, volumeID)
 }
 
 func (vsb *gophercloudBroker) unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {

--- a/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
@@ -33,6 +33,7 @@ type volumeServiceBroker interface {
 	disconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	unreserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
+	getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error)
 }
 
 type gophercloudBroker struct {
@@ -73,4 +74,8 @@ func (vsb *gophercloudBroker) unreserveCinderVolume(vs *gophercloud.ServiceClien
 
 func (vsb *gophercloudBroker) deleteCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 	return volumeservice.DeleteCinderVolume(vs, volumeID)
+}
+
+func (vsb *gophercloudBroker) getCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (*volumes_v2.Volume, error) {
+	return volumeservice.GetCinderVolume(vs, volumeID)
 }

--- a/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
+++ b/openstack/standalone-cinder/pkg/provisioner/vsbroker.go
@@ -18,13 +18,13 @@ package provisioner
 
 import (
 	"github.com/gophercloud/gophercloud"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/kubernetes-incubator/external-storage/openstack/standalone-cinder/pkg/volumeservice"
 )
 
 // volumeServiceBroker provides a mechanism for tests to override calls to cinder with mocks.
 type volumeServiceBroker interface {
-	createCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error)
+	createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error)
 	waitForAvailableCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	reserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error
 	connectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (volumeservice.VolumeConnection, error)
@@ -37,7 +37,7 @@ type gophercloudBroker struct {
 	volumeServiceBroker
 }
 
-func (vsb *gophercloudBroker) createCinderVolume(vs *gophercloud.ServiceClient, options controller.VolumeOptions) (string, error) {
+func (vsb *gophercloudBroker) createCinderVolume(vs *gophercloud.ServiceClient, options volumes_v2.CreateOpts) (string, error) {
 	return volumeservice.CreateCinderVolume(vs, options)
 }
 

--- a/openstack/standalone-cinder/pkg/volumeservice/actions.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/actions.go
@@ -29,7 +29,6 @@ import (
 const attachMountPoint = "/k8s.io/standalone-cinder"
 const attachHostName = "standalone-cinder.k8s.io"
 
-const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
 const pollInterval = 3 * time.Second
 const pollTimeout = 60 * time.Second
 
@@ -97,11 +96,11 @@ func ReserveCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 // ConnectCinderVolume retrieves connection information for a cinder volume.
 // Depending on the type of volume, cinder may perform setup on a storage server
 // such as mapping a LUN to a particular ISCSI initiator.
-func ConnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (VolumeConnection, error) {
+func ConnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) (VolumeConnection, error) {
 	opt := volumeactions.InitializeConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: initiator,
 	}
 	var rcv rcvVolumeConnection
 	err := volumeactions.InitializeConnection(vs, volumeID, &opt).ExtractInto(&rcv)
@@ -130,11 +129,11 @@ func DetachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
 // DisconnectCinderVolume removes a connection to a cinder volume.  Depending on
 // the volume type, this may cause cinder to clean up the connection at a
 // storage server (i.e. remove a LUN mapping).
-func DisconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+func DisconnectCinderVolume(vs *gophercloud.ServiceClient, initiator string, volumeID string) error {
 	opt := volumeactions.TerminateConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: initiator,
 	}
 
 	err := volumeactions.TerminateConnection(vs, volumeID, &opt).Result.Err

--- a/openstack/standalone-cinder/pkg/volumeservice/actions.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/actions.go
@@ -25,6 +25,9 @@ import (
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 )
 
+const attachMountPoint = "/k8s.io/standalone-cinder"
+const attachHostName = "standalone-cinder.k8s.io"
+
 const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
 
 // VolumeConnectionDetails represent the type-specific values for a given
@@ -107,6 +110,20 @@ func ConnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (Volume
 	}
 	glog.V(3).Infof("Received connection info: %v", rcv)
 	return rcv.ConnectionInfo, nil
+}
+
+// AttachCinderVolume marks the volume as attached in the cinder database.
+func AttachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	opts := volumeactions.AttachOpts{
+		MountPoint: attachMountPoint,
+		HostName:   attachHostName,
+		Mode:       volumeactions.ReadWrite,
+	}
+	return volumeactions.Attach(vs, volumeID, opts).ExtractErr()
+}
+
+func DetachCinderVolume(vs *gophercloud.ServiceClient, volumeID string) error {
+	return volumeactions.Detach(vs, volumeID, volumeactions.DetachOpts{}).ExtractErr()
 }
 
 // DisconnectCinderVolume removes a connection to a cinder volume.  Depending on

--- a/openstack/standalone-cinder/pkg/volumeservice/connection.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/connection.go
@@ -29,7 +29,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/noauth"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts"
 	tokens3 "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens"
-	"gopkg.in/gcfg.v1"
+	gcfg "gopkg.in/gcfg.v1"
 
 	"github.com/golang/glog"
 	netutil "k8s.io/apimachinery/pkg/util/net"
@@ -84,20 +84,15 @@ func (cfg cinderConfig) toAuth3Options() tokens3.AuthOptions {
 }
 
 func getConfigFromEnv() cinderConfig {
-	authURL := os.Getenv("OS_AUTH_URL")
-	if authURL == "" {
-		glog.Warning("OS_AUTH_URL missing from environment")
-		return cinderConfig{}
-	}
-
 	return cinderConfig{
 		Global: cinderConfigGlobal{
-			AuthURL:    authURL,
-			Username:   os.Getenv("OS_USERNAME"),
-			Password:   os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
-			TenantID:   os.Getenv("OS_TENANT_ID"),
-			Region:     os.Getenv("OS_REGION_NAME"),
-			DomainName: os.Getenv("OS_USER_DOMAIN_NAME"),
+			AuthURL:        os.Getenv("OS_AUTH_URL"),
+			CinderEndpoint: os.Getenv("OS_CINDER_ENDPOINT"),
+			Username:       os.Getenv("OS_USERNAME"),
+			Password:       os.Getenv("OS_PASSWORD"), // TODO: Replace with secret
+			TenantID:       os.Getenv("OS_TENANT_ID"),
+			Region:         os.Getenv("OS_REGION_NAME"),
+			DomainName:     os.Getenv("OS_USER_DOMAIN_NAME"),
 		},
 	}
 }
@@ -108,7 +103,7 @@ func getConfig(configFilePath string) (cinderConfig, error) {
 		var config cinderConfig
 		configFile, err := os.Open(configFilePath)
 		if err != nil {
-			glog.Fatalf("Couldn't open configuration %s: %#v",
+			glog.Errorf("Couldn't open configuration %s: %#v",
 				configFilePath, err)
 			return cinderConfig{}, err
 		}
@@ -117,7 +112,7 @@ func getConfig(configFilePath string) (cinderConfig, error) {
 
 		err = gcfg.ReadInto(&config, configFile)
 		if err != nil {
-			glog.Fatalf("Couldn't read configuration: %#v", err)
+			glog.Errorf("Couldn't read configuration: %#v", err)
 			return cinderConfig{}, err
 		}
 		return config, nil

--- a/openstack/standalone-cinder/pkg/volumeservice/volumeservice_suite_test.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/volumeservice_suite_test.go
@@ -1,0 +1,13 @@
+package volumeservice_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestVolumeservice(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volumeservice Suite")
+}

--- a/openstack/standalone-cinder/pkg/volumeservice/volumeservice_test.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/volumeservice_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volumeservice
+
+import (
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Volume Service", func() {
+	Describe("Connection configuration parsing", func() {
+		var (
+			config cinderConfig
+			err    error
+		)
+
+		Context("when config file path is empty", func() {
+			BeforeEach(func() {
+				os.Setenv("OS_AUTH_URL", "AUTH_URL")
+				os.Setenv("OS_CINDER_ENDPOINT", "CINDER_ENDPOINT")
+				os.Setenv("OS_USERNAME", "USERNAME")
+				os.Setenv("OS_PASSWORD", "PASSWORD")
+				os.Setenv("OS_TENANT_ID", "TENANT_ID")
+				os.Setenv("OS_REGION_NAME", "REGION_NAME")
+				os.Setenv("OS_USER_DOMAIN_NAME", "USER_DOMAIN_NAME")
+			})
+
+			JustBeforeEach(func() {
+				config, err = getConfig("")
+			})
+
+			It("should take the configuration from the environment", func() {
+				ValidateConfig(config)
+			})
+		})
+
+		Context("when config file path is specified", func() {
+			var (
+				tmpFile string
+			)
+
+			BeforeEach(func() {
+				data := []byte(`
+					[Global]
+					auth-url=AUTH_URL
+					cinder-endpoint=CINDER_ENDPOINT
+					`)
+				file, err := ioutil.TempFile(os.TempDir(), "cinderConfig")
+				Expect(err).To(BeNil())
+				tmpFile = file.Name()
+				err = ioutil.WriteFile(tmpFile, data, 0644)
+				Expect(err).To(BeNil())
+
+			})
+			AfterEach(func() {
+				os.Remove(tmpFile)
+			})
+
+			JustBeforeEach(func() {
+				config, err = getConfig(tmpFile)
+			})
+
+			It("should read the configuration from the file", func() {
+				ValidateConfig(config)
+			})
+
+			Context("when the config file path does not exist", func() {
+				BeforeEach(func() {
+					os.Remove(tmpFile)
+				})
+				It("should fail", func() {
+					Expect(err).NotTo(BeNil())
+				})
+			})
+		})
+	})
+})
+
+func ValidateConfig(config cinderConfig) {
+	Expect(config.Global.AuthURL).To(Equal("AUTH_URL"))
+	Expect(config.Global.CinderEndpoint).To(Equal("CINDER_ENDPOINT"))
+}


### PR DESCRIPTION
This PR enables provisioning new volumes as a clone of an existing
PVC.  To request a clone, the user should add a clone request annotation
to the PVC:

kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: clone-claim
  annotations:
    k8s.io/CloneRequest: default/source-pvc

The provisioner will locate the indicated PVC and determine the
underlying associated cinder volume ID.  The provisioner will use this
ID as the source-vol-id parameter when provisioning the new volume
resulting in a clone at the storage level.

Cloning will only work if the cinder backend supports "smart-cloning".
This means that the clone will complete without the need for cinder to
perform a bit-for-bit copy using the host.  Because of this, the cinder
provisioner will not attempt to clone unless the associated storage
class contains the parameter: "smartclone" to indicate that volumes
provisioned from this storage class can be cloned correctly.

If the provisioner was able to clone the volume it will apply the
'k8s.io/CloneOf' annotation to the PVC.
