### PR TITLE
update rbac api version to v1

### DIFF
--- a/aws/efs/README.md
+++ b/aws/efs/README.md
@@ -173,7 +173,7 @@ https://docs.openshift.org/latest/install_config/persistent_storage/persistent_s
 First a [`StorageClass`](https://kubernetes.io/docs/user-guide/persistent-volumes/#storageclasses) for claims to ask for needs to be created.
 
 ```yaml
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: slow

--- a/aws/efs/deploy/auth/clusterrole.yaml
+++ b/aws/efs/deploy/auth/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: efs-provisioner-runner
 rules:

--- a/aws/efs/deploy/auth/clusterrolebinding.yaml
+++ b/aws/efs/deploy/auth/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: run-efs-provisioner
 subjects:

--- a/aws/efs/deploy/class.yaml
+++ b/aws/efs/deploy/class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: aws-efs
 provisioner: example.com/aws-efs

--- a/aws/efs/deploy/manifest.yaml
+++ b/aws/efs/deploy/manifest.yaml
@@ -50,7 +50,7 @@ spec:
             path: /
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: aws-efs
 provisioner: example.com/aws-efs

--- a/ceph/cephfs/deploy/rbac/clusterrole.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-provisioner
   namespace: cephfs

--- a/ceph/cephfs/deploy/rbac/clusterrolebinding.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cephfs-provisioner
   namespace: cephfs

--- a/ceph/cephfs/deploy/rbac/role.yaml
+++ b/ceph/cephfs/deploy/rbac/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cephfs-provisioner

--- a/ceph/cephfs/deploy/rbac/rolebinding.yaml
+++ b/ceph/cephfs/deploy/rbac/rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cephfs-provisioner

--- a/ceph/rbd/deploy/rbac/clusterrole.yaml
+++ b/ceph/rbd/deploy/rbac/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-provisioner
 rules:

--- a/ceph/rbd/deploy/rbac/clusterrolebinding.yaml
+++ b/ceph/rbd/deploy/rbac/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rbd-provisioner
 subjects:

--- a/ceph/rbd/deploy/rbac/role.yaml
+++ b/ceph/rbd/deploy/rbac/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: rbd-provisioner

--- a/ceph/rbd/deploy/rbac/rolebinding.yaml
+++ b/ceph/rbd/deploy/rbac/rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: rbd-provisioner

--- a/digitalocean/manifests/rbac/clusterrole.yaml
+++ b/digitalocean/manifests/rbac/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: digitalocean-provisioner
   namespace: kube-system

--- a/digitalocean/manifests/rbac/clusterrolebinding.yaml
+++ b/digitalocean/manifests/rbac/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: digitalocean-provisioner
   namespace: kube-system

--- a/digitalocean/manifests/rbac/role.yaml
+++ b/digitalocean/manifests/rbac/role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: digitalocean-provisioner

--- a/digitalocean/manifests/rbac/rolebinding.yaml
+++ b/digitalocean/manifests/rbac/rolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: digitalocean-provisioner

--- a/docs/demo/hostpath-provisioner/README.md
+++ b/docs/demo/hostpath-provisioner/README.md
@@ -290,7 +290,7 @@ Now we create a `StorageClass` & `PersistentVolumeClaim` and see that a `Persist
 
 ```yaml
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: example-hostpath
 provisioner: example.com/hostpath

--- a/docs/demo/hostpath-provisioner/class.yaml
+++ b/docs/demo/hostpath-provisioner/class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: example-hostpath
 provisioner: example.com/hostpath

--- a/flex/examples/sc.yaml
+++ b/flex/examples/sc.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: default-shared 

--- a/iscsi/targetd/README.md
+++ b/iscsi/targetd/README.md
@@ -254,7 +254,7 @@ docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes -
 storage classes should look like the following
 ```
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: iscsi
 provisioner: iscsi

--- a/iscsi/targetd/ansible/roles/deploy-provisioner/templates/iscsi-provisioner-class.yaml.j2
+++ b/iscsi/targetd/ansible/roles/deploy-provisioner/templates/iscsi-provisioner-class.yaml.j2
@@ -1,6 +1,6 @@
 ---
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: {{ storage_class_name }}
 {% if iscsi_provisioner_default_storage_class | bool %}

--- a/iscsi/targetd/kubernetes/iscsi-provisioner-class.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: iscsi-targetd-vg-targetd
 provisioner: iscsi-targetd

--- a/iscsi/targetd/openshift/iscsi-provisioner-class.yaml
+++ b/iscsi/targetd/openshift/iscsi-provisioner-class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: iscsi-targetd-vg-targetd
 provisioner: iscsi-targetd

--- a/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.common.rbac }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-pv-binding
@@ -13,7 +13,7 @@ roleRef:
   name: system:persistent-volume-provisioner
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding

--- a/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/admin_account.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: local-storage-admin
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-pv-binding
@@ -17,7 +17,7 @@ roleRef:
   name: system:persistent-volume-provisioner
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding

--- a/nfs-client/deploy/class.yaml
+++ b/nfs-client/deploy/class.yaml
@@ -1,4 +1,4 @@
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-nfs-storage

--- a/nfs/deploy/kubernetes/class.yaml
+++ b/nfs/deploy/kubernetes/class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: example-nfs
 provisioner: example.com/nfs

--- a/nfs/docs/demo/class.yaml
+++ b/nfs/docs/demo/class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: example-nfs
 provisioner: example.com/nfs

--- a/snapshot/deploy/kubernetes/aws/snapshot-rbac.yaml
+++ b/snapshot/deploy/kubernetes/aws/snapshot-rbac.yaml
@@ -30,7 +30,7 @@ rules:
     resources: ["volumesnapshotdatas"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: snapsot-controller

--- a/snapshot/deploy/kubernetes/hostpath/snapshot-rbac.yaml
+++ b/snapshot/deploy/kubernetes/hostpath/snapshot-rbac.yaml
@@ -30,7 +30,7 @@ rules:
     resources: ["volumesnapshotdatas"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: snapsot-controller

--- a/snapshot/doc/user-guide.md
+++ b/snapshot/doc/user-guide.md
@@ -149,7 +149,7 @@ rules:
 ```
 Now the cluster role has to be bound to the user 'alice' by creating a ClusterRole binding object.
 ```yaml
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: volumesnapsot-admin

--- a/snapshot/test/hostpath_files/hostpath-class.yaml
+++ b/snapshot/test/hostpath_files/hostpath-class.yaml
@@ -1,5 +1,5 @@
 kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: test-hostpath
 provisioner: example.com/hostpath

--- a/vendor/k8s.io/client-go/CHANGELOG.md
+++ b/vendor/k8s.io/client-go/CHANGELOG.md
@@ -48,7 +48,7 @@ Bug fix: picked up a security fix [kubernetes/kubernetes#53443](https://github.c
 
    * [https://github.com/kubernetes/kubernetes/pull/41901](https://github.com/kubernetes/kubernetes/pull/41901)
 
-* Promoted rbac.authorization.k8s.io/v1 to rbac.authorization.k8s.io/v1
+* Promoted rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1
 
    * [https://github.com/kubernetes/kubernetes/pull/49642](https://github.com/kubernetes/kubernetes/pull/49642)
 

--- a/vendor/k8s.io/client-go/CHANGELOG.md
+++ b/vendor/k8s.io/client-go/CHANGELOG.md
@@ -48,7 +48,7 @@ Bug fix: picked up a security fix [kubernetes/kubernetes#53443](https://github.c
 
    * [https://github.com/kubernetes/kubernetes/pull/41901](https://github.com/kubernetes/kubernetes/pull/41901)
 
-* Promoted rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1
+* Promoted rbac.authorization.k8s.io/v1 to rbac.authorization.k8s.io/v1
 
    * [https://github.com/kubernetes/kubernetes/pull/49642](https://github.com/kubernetes/kubernetes/pull/49642)
 

--- a/vendor/k8s.io/kubernetes/CHANGELOG-1.9.md
+++ b/vendor/k8s.io/kubernetes/CHANGELOG-1.9.md
@@ -1201,7 +1201,7 @@ filename | sha256 hash
 
 ### Action Required
 
-* action required: The `storage.k8s.io/v1` API  and `volume.beta.kubernetes.io/storage-class` annotation are deprecated. They will be removed in a future release. Please use v1 API and field `v1.PersistentVolumeClaim.Spec.StorageClassName`/`v1.PersistentVolume.Spec.StorageClassName` instead. ([#53580](https://github.com/kubernetes/kubernetes/pull/53580), [@xiangpengzhao](https://github.com/xiangpengzhao))
+* action required: The `storage.k8s.io/v1beta1` API  and `volume.beta.kubernetes.io/storage-class` annotation are deprecated. They will be removed in a future release. Please use v1 API and field `v1.PersistentVolumeClaim.Spec.StorageClassName`/`v1.PersistentVolume.Spec.StorageClassName` instead. ([#53580](https://github.com/kubernetes/kubernetes/pull/53580), [@xiangpengzhao](https://github.com/xiangpengzhao))
 * action required: Deprecated flags `--portal-net` and `service-node-ports` of kube-apiserver are removed. ([#52547](https://github.com/kubernetes/kubernetes/pull/52547), [@xiangpengzhao](https://github.com/xiangpengzhao))
 * The `node.kubernetes.io/memory-pressure` taint now respects the configured whitelist.  If you need to use it, you'll have to add it to the whitelist. ([#55251](https://github.com/kubernetes/kubernetes/pull/55251), [@deads2k](https://github.com/deads2k))
 

--- a/vendor/k8s.io/kubernetes/CHANGELOG-1.9.md
+++ b/vendor/k8s.io/kubernetes/CHANGELOG-1.9.md
@@ -1201,7 +1201,7 @@ filename | sha256 hash
 
 ### Action Required
 
-* action required: The `storage.k8s.io/v1beta1` API  and `volume.beta.kubernetes.io/storage-class` annotation are deprecated. They will be removed in a future release. Please use v1 API and field `v1.PersistentVolumeClaim.Spec.StorageClassName`/`v1.PersistentVolume.Spec.StorageClassName` instead. ([#53580](https://github.com/kubernetes/kubernetes/pull/53580), [@xiangpengzhao](https://github.com/xiangpengzhao))
+* action required: The `storage.k8s.io/v1` API  and `volume.beta.kubernetes.io/storage-class` annotation are deprecated. They will be removed in a future release. Please use v1 API and field `v1.PersistentVolumeClaim.Spec.StorageClassName`/`v1.PersistentVolume.Spec.StorageClassName` instead. ([#53580](https://github.com/kubernetes/kubernetes/pull/53580), [@xiangpengzhao](https://github.com/xiangpengzhao))
 * action required: Deprecated flags `--portal-net` and `service-node-ports` of kube-apiserver are removed. ([#52547](https://github.com/kubernetes/kubernetes/pull/52547), [@xiangpengzhao](https://github.com/xiangpengzhao))
 * The `node.kubernetes.io/memory-pressure` taint now respects the configured whitelist.  If you need to use it, you'll have to add it to the whitelist. ([#55251](https://github.com/kubernetes/kubernetes/pull/55251), [@deads2k](https://github.com/deads2k))
 


### PR DESCRIPTION
The v1alpha1 isn't used by current versions of Kubernetes - this should be updated in the example docs