### PR TITLE
Add pvc namer interface

### DIFF
--- a/aws/efs/cmd/efs-provisioner/efs-provisioner.go
+++ b/aws/efs/cmd/efs-provisioner/efs-provisioner.go
@@ -297,6 +297,7 @@ func main() {
 		provisionerName,
 		efsProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -377,6 +377,7 @@ func main() {
 		prName,
 		cephFSProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/ceph/rbd/cmd/rbd-provisioner/main.go
+++ b/ceph/rbd/cmd/rbd-provisioner/main.go
@@ -91,6 +91,7 @@ func main() {
 		prName,
 		rbdProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/digitalocean/cmd/digitalocean-provisioner/main.go
+++ b/digitalocean/cmd/digitalocean-provisioner/main.go
@@ -95,6 +95,7 @@ func main() {
 		*provisioner,
 		digitaloceanProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/docs/demo/hostpath-provisioner/hostpath-provisioner.go
+++ b/docs/demo/hostpath-provisioner/hostpath-provisioner.go
@@ -141,6 +141,6 @@ func main() {
 
 	// Start the provision controller which will dynamically provision hostPath
 	// PVs
-	pc := controller.NewProvisionController(clientset, provisionerName, hostPathProvisioner, serverVersion.GitVersion)
+	pc := controller.NewProvisionController(clientset, provisionerName, hostPathProvisioner, serverVersion.GitVersion, controller.NewDefaultNamer())
 	pc.Run(wait.NeverStop)
 }

--- a/flex/cmd/flex-provisioner/main.go
+++ b/flex/cmd/flex-provisioner/main.go
@@ -86,6 +86,7 @@ func main() {
 		*provisioner,
 		flexProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
+++ b/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
@@ -836,6 +836,7 @@ func main() {
 		prName,
 		glusterBlockProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/gluster/glusterfs/cmd/glusterfs-simple-provisioner/main.go
+++ b/gluster/glusterfs/cmd/glusterfs-simple-provisioner/main.go
@@ -78,6 +78,7 @@ func main() {
 		*provisioner,
 		glusterfsProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/iscsi/targetd/cmd/start.go
+++ b/iscsi/targetd/cmd/start.go
@@ -80,7 +80,7 @@ var startcontrollerCmd = &cobra.Command{
 		iscsiProvisioner := provisioner.NewiscsiProvisioner(url)
 		log.Debugln("iscsi provisioner created")
 
-		pc := controller.NewProvisionController(kubernetesClientSet, viper.GetString("provisioner-name"), iscsiProvisioner, serverVersion.GitVersion)
+		pc := controller.NewProvisionController(kubernetesClientSet, viper.GetString("provisioner-name"), iscsiProvisioner, serverVersion.GitVersion, controller.NewDefaultNamer())
 		controller.ResyncPeriod(viper.GetDuration("resync-period"))
 		controller.ExponentialBackOffOnError(viper.GetBool("exponential-backoff-on-error"))
 		controller.FailedProvisionThreshold(viper.GetInt("fail-retry-threshold"))

--- a/lib/controller/namer.go
+++ b/lib/controller/namer.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "k8s.io/api/core/v1"
+
+// Namer interface should implement to get provisioned volume name for claim
+type Namer interface {
+	GetProvisionedVolumeNameForClaim(claim *v1.PersistentVolumeClaim) string
+}
+
+// DefaultNamer for all provider
+type DefaultNamer struct{}
+
+var _ Namer = &DefaultNamer{}
+
+// NewDefaultNamer function for generating default claim name
+func NewDefaultNamer() Namer {
+	return &DefaultNamer{}
+}
+
+// GetProvisionedVolumeNameForClaim returns PV.Name for the provisioned volume.
+// The name must be unique.
+func (n *DefaultNamer) GetProvisionedVolumeNameForClaim(claim *v1.PersistentVolumeClaim) string {
+	return "pvc-" + string(claim.UID)
+}

--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -141,6 +141,6 @@ func main() {
 	}
 	// Start the provision controller which will dynamically provision efs NFS
 	// PVs
-	pc := controller.NewProvisionController(clientset, provisionerName, clientNFSProvisioner, serverVersion.GitVersion)
+	pc := controller.NewProvisionController(clientset, provisionerName, clientNFSProvisioner, serverVersion.GitVersion, controller.NewDefaultNamer())
 	pc.Run(wait.NeverStop)
 }

--- a/nfs/cmd/nfs-provisioner/main.go
+++ b/nfs/cmd/nfs-provisioner/main.go
@@ -132,6 +132,7 @@ func main() {
 		*provisioner,
 		nfsProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -215,7 +215,8 @@ func main() {
 			clientset,
 			provisionerName,
 			openEBSProvisioner,
-			serverVersion.GitVersion)
+			serverVersion.GitVersion,
+			controller.NewDefaultNamer())
 
 		pc.Run(wait.NeverStop)
 	} else {

--- a/openstack/standalone-cinder/cmd/cinder-provisioner/cinder-provisioner.go
+++ b/openstack/standalone-cinder/cmd/cinder-provisioner/cinder-provisioner.go
@@ -80,6 +80,7 @@ func main() {
 		provisioner.ProvisionerName,
 		cinderProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
+++ b/snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go
@@ -264,6 +264,7 @@ func main() {
 		provisionerName,
 		snapshotProvisioner,
 		serverVersion.GitVersion,
+		controller.NewDefaultNamer(),
 	)
 	glog.Infof("starting PV provisioner %s", provisionerName)
 	pc.Run(wait.NeverStop)


### PR DESCRIPTION
For some providers, there have limitations on volume name. e.g. for `Linode`,  maximum length of the volume name is 32 characters (Length of default namer is 40 characters). So, this interface will help those providers to use own namer. 