### PR TITLE
Sanpshot: Small fix in the Dockerfiles

### DIFF
--- a/snapshot/deploy/docker/controller/Dockerfile
+++ b/snapshot/deploy/docker/controller/Dockerfile
@@ -15,5 +15,6 @@
 FROM busybox:glibc
 COPY snapshot-controller /bin/snapshot-controller
 # Root CA certificates
-COPY etc usr /
+COPY etc /etc
+COPY usr /usr
 ENTRYPOINT ["/bin/snapshot-controller"]

--- a/snapshot/deploy/docker/provisioner/Dockerfile
+++ b/snapshot/deploy/docker/provisioner/Dockerfile
@@ -15,5 +15,6 @@
 FROM busybox:glibc
 COPY snapshot-provisioner /bin/snapshot-provisioner
 # Root CA certificates
-COPY etc usr /
+COPY etc /etc
+COPY usr /usr
 ENTRYPOINT ["/bin/snapshot-provisioner"]


### PR DESCRIPTION
Now we have the CA certificates in tree: let's copy them to the correct place so the binaries can find them.
@rootfs PTAL