### PR TITLE
rbd: add access to kube-dns service

### DIFF
--- a/ceph/rbd/deploy/rbac/clusterrole.yaml
+++ b/ceph/rbd/deploy/rbac/clusterrole.yaml
@@ -15,3 +15,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns"]
+    verbs: ["list", "get"]


### PR DESCRIPTION
The rbd-privisioner gets the kube-dns service to pass on the numeric IP
to the provisioning tools in order to avoid outside name resolution. On
a cluster with RBAC this requires appropriate permissions. Add those to
the cluster role (role does not suffice if provisioner is put into other
namespace than kube-system, for example ceph).