### PR TITLE
- updated version from v1alpha1 to v1 , else it breaks atleast on k8s…

### DIFF
--- a/nfs/deploy/kubernetes/auth/clusterrole.yaml
+++ b/nfs/deploy/kubernetes/auth/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nfs-provisioner-runner
 rules:

--- a/nfs/deploy/kubernetes/auth/clusterrolebinding.yaml
+++ b/nfs/deploy/kubernetes/auth/clusterrolebinding.yaml
@@ -1,11 +1,13 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: run-nfs-provisioner
+  namespace: default
 subjects:
   - kind: ServiceAccount
     name: nfs-provisioner
     namespace: default
+# update namespace above to your namespace in order to make this work 
 roleRef:
   kind: ClusterRole
   name: nfs-provisioner-runner


### PR DESCRIPTION
updated version for clusterrole and clusterrolebinding from v1alpha1 to v1. It broken on k8s 1.9.3 at least. 

added documentation to update namespace. does not work in custom namespaces otherwise