### PR TITLE
API version moved from alpha to v1

### DIFF
--- a/nfs/deploy/kubernetes/auth/clusterrole.yaml
+++ b/nfs/deploy/kubernetes/auth/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nfs-provisioner-runner
 rules:

--- a/nfs/deploy/kubernetes/auth/clusterrolebinding.yaml
+++ b/nfs/deploy/kubernetes/auth/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: run-nfs-provisioner
 subjects:


### PR DESCRIPTION
The `rbac.authorization.k8s.io` API moved to v1 so the `yaml` files shall be updated.