### PR TITLE
Use unique name for snapshot to avoid race

### DIFF
--- a/snapshot/pkg/controller/cache/actual_state_of_world.go
+++ b/snapshot/pkg/controller/cache/actual_state_of_world.go
@@ -70,7 +70,7 @@ func (asw *actualStateOfWorld) AddSnapshot(snapshot *crdv1.VolumeSnapshot) error
 	asw.Lock()
 	defer asw.Unlock()
 
-	snapshotName := MakeSnapshotName(snapshot.Metadata.Namespace, snapshot.Metadata.Name)
+	snapshotName := MakeSnapshotName(snapshot)
 	glog.Infof("Adding new snapshot to actual state of world: %s", snapshotName)
 	asw.snapshots[snapshotName] = snapshot
 	return nil

--- a/snapshot/pkg/controller/cache/desired_state_of_world.go
+++ b/snapshot/pkg/controller/cache/desired_state_of_world.go
@@ -72,7 +72,7 @@ func (dsw *desiredStateOfWorld) AddSnapshot(snapshot *crdv1.VolumeSnapshot) erro
 	dsw.Lock()
 	defer dsw.Unlock()
 
-	snapshotName := MakeSnapshotName(snapshot.Metadata.Namespace, snapshot.Metadata.Name)
+	snapshotName := MakeSnapshotName(snapshot)
 	glog.Infof("Adding new snapshot to desired state of world: %s", snapshotName)
 	dsw.snapshots[snapshotName] = snapshot
 	return nil

--- a/snapshot/pkg/controller/cache/util.go
+++ b/snapshot/pkg/controller/cache/util.go
@@ -22,22 +22,11 @@ reference them.
 package cache
 
 import (
-	"fmt"
-	"strings"
+	crdv1 "github.com/kubernetes-incubator/external-storage/snapshot/pkg/apis/crd/v1"
 )
 
 // MakeSnapshotName makes a full name for a snapshot that includes
 // the namespace and the short name
-func MakeSnapshotName(namespace, name string) string {
-	return namespace + "/" + name
-}
-
-// GetNameAndNameSpaceFromSnapshotName retrieves the namespace and
-// the short name of a snapshot from its full name
-func GetNameAndNameSpaceFromSnapshotName(name string) (string, string, error) {
-	strs := strings.Split(name, "/")
-	if len(strs) != 2 {
-		return "", "", fmt.Errorf("invalid snapshot name")
-	}
-	return strs[0], strs[1], nil
+func MakeSnapshotName(snapshot *crdv1.VolumeSnapshot) string {
+	return snapshot.Metadata.Namespace + "/" + snapshot.Metadata.Name + "-" + string(snapshot.Metadata.UID)
 }

--- a/snapshot/pkg/controller/populator/desired_state_of_world_populator.go
+++ b/snapshot/pkg/controller/populator/desired_state_of_world_populator.go
@@ -93,7 +93,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedSnapshots() {
 		}
 		if !exists {
 			glog.V(1).Infof("Removing snapshot %s from dsw because it does not exist in snapshot informer.", snapshotUID)
-			dswp.desiredStateOfWorld.DeleteSnapshot(cache.MakeSnapshotName(snapshot.Metadata.Namespace, snapshot.Metadata.Name))
+			dswp.desiredStateOfWorld.DeleteSnapshot(cache.MakeSnapshotName(snapshot))
 		}
 	}
 }
@@ -102,7 +102,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndAddActiveSnapshots() {
 	for _, obj := range dswp.snapshotStore.List() {
 		snapshot := obj.(*crdv1.VolumeSnapshot)
 
-		snapshotName := cache.MakeSnapshotName(snapshot.Metadata.Namespace, snapshot.Metadata.Name)
+		snapshotName := cache.MakeSnapshotName(snapshot)
 		if !dswp.desiredStateOfWorld.SnapshotExists(snapshotName) {
 			glog.V(1).Infof("Adding snapshot %s to dsw because it exists in snapshot informer.", snapshotName)
 			dswp.desiredStateOfWorld.AddSnapshot(snapshot)

--- a/snapshot/pkg/controller/snapshot-controller/snapshot-controller.go
+++ b/snapshot/pkg/controller/snapshot-controller/snapshot-controller.go
@@ -220,6 +220,6 @@ func (c *snapshotController) onSnapshotDelete(obj interface{}) {
 	// the snapshot itself
 	snapshot := deletedSnapshot.DeepCopy()
 	glog.Infof("[CONTROLLER] OnDelete %s, snapshot name: %s/%s\n", snapshot.Metadata.SelfLink, snapshot.Metadata.Namespace, snapshot.Metadata.Name)
-	c.desiredStateOfWorld.DeleteSnapshot(cache.MakeSnapshotName(snapshot.Metadata.Namespace, snapshot.Metadata.Name))
+	c.desiredStateOfWorld.DeleteSnapshot(cache.MakeSnapshotName(snapshot))
 
 }

--- a/snapshot/pkg/volume/awsebs/processor.go
+++ b/snapshot/pkg/volume/awsebs/processor.go
@@ -106,11 +106,7 @@ func (a *awsEBSPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnaps
 	glog.Infof("FindSnapshot by tags: %#v", *tags)
 
 	// TODO: Implement FindSnapshot
-	return &crdv1.VolumeSnapshotDataSource{
-		AWSElasticBlockStore: &crdv1.AWSElasticBlockStoreVolumeSnapshotSource{
-			SnapshotID: "",
-		},
-	}, nil, nil
+	return nil, nil, fmt.Errorf("Snapshot not found")
 }
 
 func (a *awsEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, pvc *v1.PersistentVolumeClaim, pvName string, parameters map[string]string) (*v1.PersistentVolumeSource, map[string]string, error) {

--- a/snapshot/pkg/volume/cinder/processor.go
+++ b/snapshot/pkg/volume/cinder/processor.go
@@ -217,5 +217,5 @@ func (c *cinderPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSnaps
 		}, c.convertSnapshotStatus(statuses[0]), nil
 	}
 
-	return nil, nil, nil
+	return nil, nil, fmt.Errorf("Snapshot not found")
 }

--- a/snapshot/pkg/volume/gcepd/processor.go
+++ b/snapshot/pkg/volume/gcepd/processor.go
@@ -186,11 +186,7 @@ func (plugin *gcePersistentDiskPlugin) FindSnapshot(tags *map[string]string) (*c
 	glog.Infof("FindSnapshot by tags: %#v", *tags)
 
 	// TODO: Implement FindSnapshot
-	return &crdv1.VolumeSnapshotDataSource{
-		GCEPersistentDiskSnapshot: &crdv1.GCEPersistentDiskSnapshotSource{
-			SnapshotName: "",
-		},
-	}, nil, nil
+	return nil, nil, fmt.Errorf("Snapshot not found")
 }
 
 func (plugin *gcePersistentDiskPlugin) VolumeDelete(pv *v1.PersistentVolume) error {

--- a/snapshot/pkg/volume/gluster/snapshot.go
+++ b/snapshot/pkg/volume/gluster/snapshot.go
@@ -170,11 +170,7 @@ func (h *glusterfsPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSn
 	glog.Infof("FindSnapshot by tags: %#v", *tags)
 
 	// TODO: Implement FindSnapshot
-	return &crdv1.VolumeSnapshotDataSource{
-		GlusterSnapshotVolume: &crdv1.GlusterVolumeSnapshotSource{
-			SnapshotID: "",
-		},
-	}, nil, nil
+	return nil, nil, fmt.Errorf("Snapshot not found")
 }
 
 func (h *glusterfsPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, _ *v1.PersistentVolumeClaim, _ string, _ map[string]string) (*v1.PersistentVolumeSource, map[string]string, error) {

--- a/snapshot/pkg/volume/hostpath/processor.go
+++ b/snapshot/pkg/volume/hostpath/processor.go
@@ -139,11 +139,7 @@ func (h *hostPathPlugin) FindSnapshot(tags *map[string]string) (*crdv1.VolumeSna
 	glog.Infof("FindSnapshot by tags: %#v", *tags)
 
 	// TODO: Implement FindSnapshot
-	return &crdv1.VolumeSnapshotDataSource{
-		HostPath: &crdv1.HostPathVolumeSnapshotSource{
-			Path: "",
-		},
-	}, nil, nil
+	return nil, nil, fmt.Errorf("Snapshot not found")
 }
 
 func (h *hostPathPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, _ *v1.PersistentVolumeClaim, _ string, _ map[string]string) (*v1.PersistentVolumeSource, map[string]string, error) {


### PR DESCRIPTION
Using just the snapshot name can cause a race when objects are being deleted
and created too quickly.

Also cleaned up some code and fixed error return from FindSnapshot() for
the drivers. FindSnapshot() was not being called previously because
GetNameAndNameSpaceFromSnapshotName() was called with the wrong name.

Issue #646