### PR TITLE
Add clone support in gluster file provisioner.

### DIFF
--- a/gluster/file/README.md
+++ b/gluster/file/README.md
@@ -57,6 +57,8 @@ parameters:
     volumetype: "replicate:3"
     volumeoptions: "features.shard enable"
     volumenameprefix: "dept-dev"
+    smartclone: "true"
+    snapfactor: "10"
 ```
 
 * `resturl` : Gluster REST service/Heketi service url which provision gluster File volumes on demand. The general format should be `IPaddress:Port` and this is a mandatory parameter for glusterfile dynamic provisioner. If Heketi service is exposed as a routable service in openshift/kubernetes setup, this can have a format similar to
@@ -96,6 +98,11 @@ For available volume options and its administration refer: ([Administration Guid
 `volumenameprefix_Namespace_PVCname_randomUUID`
 
 Please note that, the value for this parameter cannot contain `_` in storageclass. This is an optional parameter.
+
+* `cloneenabled` : This option allows to create clone of PVCs if pvc is annotated with `k8s.io/CloneRequest`. The new PVC will be clone of pvc specified as the field value of `k8s.io/CloneRequest` annotation. This is an optional parameter and by default
+this option is false/disabled.
+
+* `snapfactor`: Dynamically provisioned volume's thinpool size can be configured with this parameter. The value for the parameter should be in range of 1-100, this value will be taken into account while creating thinpool for the provisioned volume. This is an optional parameter with default value of 1.
 
 Additional Reference:
 

--- a/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
+++ b/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -54,6 +55,12 @@ const (
 	glusterTypeAnn     = "gluster.org/type"
 	heketiVolIDAnn     = "gluster.org/heketi-volume-id"
 	gidAnn             = "pv.beta.kubernetes.io/gid"
+
+	// CloneRequestAnn is an annotation to request that the PVC be provisioned as a clone of the referenced PVC
+	CloneRequestAnn = "k8s.io/CloneRequest"
+
+	// CloneOfAnn is an annotation to indicate that a PVC is a clone of the referenced PVC
+	CloneOfAnn = "k8s.io/CloneOf"
 )
 
 type glusterfileProvisioner struct {
@@ -65,18 +72,19 @@ type glusterfileProvisioner struct {
 }
 
 type provisionerConfig struct {
-	url              string
-	user             string
-	userKey          string
-	secretNamespace  string
-	secretName       string
-	secretValue      string
-	clusterID        string
-	gidMin           int
-	gidMax           int
-	volumeType       gapi.VolumeDurabilityInfo
-	volumeOptions    []string
-	volumeNamePrefix string
+	url                string
+	user               string
+	userKey            string
+	secretNamespace    string
+	secretName         string
+	secretValue        string
+	clusterID          string
+	gidMin             int
+	gidMax             int
+	volumeType         gapi.VolumeDurabilityInfo
+	volumeOptions      []string
+	volumeNamePrefix   string
+	thinPoolSnapFactor float32
 }
 
 //NewglusterfileProvisioner create a new provisioner.
@@ -98,9 +106,40 @@ func (p *glusterfileProvisioner) GetAccessModes() []v1.PersistentVolumeAccessMod
 	}
 }
 
+func (p *glusterfileProvisioner) getPVC(ns string, name string) (*v1.PersistentVolumeClaim, error) {
+	return p.client.CoreV1().PersistentVolumeClaims(ns).Get(name, metav1.GetOptions{})
+}
+
+func (p *glusterfileProvisioner) annotatePVC(ns string, name string, updates map[string]string) error {
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Retrieve the latest version of PVC before attempting update
+		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
+		result, getErr := p.client.CoreV1().PersistentVolumeClaims(ns).Get(name, metav1.GetOptions{})
+		if getErr != nil {
+			panic(fmt.Errorf("Failed to get latest version of PVC: %v", getErr))
+		}
+
+		for k, v := range updates {
+			result.Annotations[k] = v
+		}
+		_, updateErr := p.client.CoreV1().PersistentVolumeClaims(ns).Update(result)
+		return updateErr
+	})
+	if retryErr != nil {
+		glog.Errorf("Update failed: %v", retryErr)
+		return retryErr
+	}
+	return nil
+}
+
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
 
+	sourceVolID := ""
+	volID := ""
+	var glusterfs *v1.GlusterfsVolumeSource
+
+	smartclone := true
 	if options.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
 	}
@@ -114,6 +153,8 @@ func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v
 	gidAllocate := true
 	for k, v := range options.Parameters {
 		switch dstrings.ToLower(k) {
+		case "smartclone":
+			smartclone = dstrings.ToLower(v) == "true"
 		case "gidmin":
 		// Let allocator handle
 		case "gidmax":
@@ -154,11 +195,70 @@ func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v
 	volSizeBytes := volSize.Value()
 	volszInt := int(util.RoundUpToGiB(volSizeBytes))
 
-	glusterfs, sizeGiB, volID, err := p.CreateVolume(gid, cfg, volszInt)
-	if err != nil {
-		glog.Errorf("failed to create volume: %v", err)
-		return nil, fmt.Errorf("failed to create volume: %v", err)
+	if smartclone && (options.PVC.Annotations[CloneRequestAnn] != "") {
+		if sourcePVCRef, ok := options.PVC.Annotations[CloneRequestAnn]; ok {
+			var ns string
+			parts := dstrings.SplitN(sourcePVCRef, "/", 2)
+			if len(parts) < 2 {
+				ns = options.PVC.Namespace
+			} else {
+				ns = parts[0]
+			}
+			sourcePVCName := parts[len(parts)-1]
+			sourcePVC, err := p.getPVC(ns, sourcePVCName)
+			if err != nil {
+				return nil, fmt.Errorf("Unable to get PVC %s/%s", ns, sourcePVCName)
+			}
+			if sourceVolID, ok = sourcePVC.Annotations[heketiVolIDAnn]; ok {
+				glog.Infof("Requesting clone of heketi volumeID %s", sourceVolID)
+				cGlusterfs, sizeGiB, cVolID, createCloneErr := p.createVolumeClone(sourceVolID, cfg)
+				if createCloneErr != nil {
+					glog.Errorf("failed to create clone of %v: %v", sourceVolID, createCloneErr)
+					return nil, fmt.Errorf("failed to create clone of %v: %v", sourceVolID, createCloneErr)
+				}
+				if cGlusterfs != nil {
+					glusterfs = cGlusterfs
+				}
+				volID = cVolID
+				glog.Infof("glusterfs volume source %v with size %d retrieved", cGlusterfs, sizeGiB)
+				err = p.annotateClonedPVC(cVolID, options.PVC, sourceVolID)
+				if err != nil {
+					glog.Errorf("Failed to annotate cloned PVC: %v", err)
+					return nil, fmt.Errorf("failed to annotate cloned PVC %s :%v", options.PVC, err)
+					//todo: cleanup?
+				}
+			} else {
+				return nil, fmt.Errorf("PVC %s/%s missing %s annotation",
+					ns, sourcePVCName, heketiVolIDAnn)
+			}
+		}
+	} else {
+
+		nGlusterfs, sizeGiB, nVolID, createErr := p.CreateVolume(gid, cfg, volszInt)
+		if createErr != nil {
+			glog.Errorf("failed to create volume: %v", createErr)
+			return nil, fmt.Errorf("failed to create volume: %v", createErr)
+		}
+		glog.Infof("glusterfs volume source %v with size %d retrieved", nGlusterfs, sizeGiB)
+		if nGlusterfs != nil {
+			glusterfs = nGlusterfs
+		}
+		volID = nVolID
+		annotations := make(map[string]string, 2)
+		annotations[heketiVolIDAnn] = nVolID
+		annotateErr := p.annotatePVC(options.PVC.Namespace, options.PVC.Name, annotations)
+		if annotateErr != nil {
+			glog.Errorf("annotating PVC %v failed: %v", options.PVC.Name, annotateErr)
+
+		}
+		glog.V(1).Infof("successfully created Gluster File volume %+v with size and volID", glusterfs, sizeGiB, volID)
 	}
+
+	if glusterfs == nil {
+		glog.Errorf("retrieved glusterfs volume source is nil")
+		return nil, fmt.Errorf("retrieved glusterfs volume source is nil")
+	}
+
 	mode := v1.PersistentVolumeFilesystem
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -184,8 +284,71 @@ func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v
 			},
 		},
 	}
-	glog.V(1).Infof("successfully created Gluster File volume %+v with size", pv.Spec.PersistentVolumeSource.Glusterfs, sizeGiB)
+
 	return pv, nil
+}
+
+func (p *glusterfileProvisioner) createVolumeClone(sourceVolID string, config *provisionerConfig) (r *v1.GlusterfsVolumeSource, size int, volID string, err error) {
+	//cloneName := ""
+	if config.url == "" {
+		glog.Errorf("REST server endpoint is empty")
+		return nil, 0, "", fmt.Errorf("failed to create glusterfs REST client, REST URL is empty")
+	}
+
+	cli := gcli.NewClient(config.url, config.user, config.secretValue)
+	if cli == nil {
+		glog.Errorf("failed to create glusterfs REST client")
+		return nil, 0, "", fmt.Errorf("failed to create glusterfs REST client, REST server authentication failed")
+	}
+	cloneReq := &gapi.VolumeCloneRequest{}
+	cloneVolInfo, cloneErr := cli.VolumeClone(sourceVolID, cloneReq)
+	if cloneErr != nil {
+		glog.Errorf("failed to clone of volume %v: %v", sourceVolID, cloneErr)
+		return nil, 0, "", fmt.Errorf("failed to clone of volume %v: %v", sourceVolID, cloneErr)
+	}
+	glog.V(1).Infof("volume with size %d and name %s created", cloneVolInfo.Size, cloneVolInfo.Name)
+
+	volID = cloneVolInfo.Id
+	dynamicHostIps, err := getClusterNodes(cli, cloneVolInfo.Cluster)
+	if err != nil {
+		glog.Errorf("error [%v] when getting cluster nodes for volume %s", err, cloneVolInfo.Name)
+		return nil, 0, "", fmt.Errorf("error [%v] when getting cluster nodes for volume %s", err, cloneVolInfo.Name)
+	}
+
+	epServiceName := dynamicEpSvcPrefix + p.options.PVC.Name
+	epNamespace := p.options.PVC.Namespace
+	endpoint, service, err := p.createEndpointService(epNamespace, epServiceName, dynamicHostIps, p.options.PVC.Name)
+	if err != nil {
+		glog.Errorf("failed to create endpoint/service %v/%v: %v", epNamespace, epServiceName, err)
+		deleteErr := cli.VolumeDelete(cloneVolInfo.Id)
+		if deleteErr != nil {
+			glog.Errorf("error when deleting the volume: %v, manual deletion required", deleteErr)
+		}
+		return nil, 0, "", fmt.Errorf("failed to create endpoint/service %v/%v: %v", epNamespace, epServiceName, err)
+	}
+	glog.V(3).Infof("dynamic endpoint %v and service %v", endpoint, service)
+
+	return &v1.GlusterfsVolumeSource{
+		EndpointsName: endpoint.Name,
+		Path:          cloneVolInfo.Name,
+		ReadOnly:      false,
+	}, cloneVolInfo.Size, cloneVolInfo.Id, nil
+}
+
+func (p *glusterfileProvisioner) annotateClonedPVC(VolID string, pvc *v1.PersistentVolumeClaim, SourceVolID string) error {
+	annotations := make(map[string]string, 2)
+	annotations[heketiVolIDAnn] = VolID
+
+	// Add clone annotation if this is a cloned volume
+	if sourcePVCName, ok := pvc.Annotations[CloneRequestAnn]; ok {
+		if SourceVolID != "" {
+			glog.Infof("Annotating PVC %s/%s as a clone of PVC %s/%s",
+				pvc.Namespace, pvc.Name, pvc.Namespace, sourcePVCName)
+			annotations[CloneOfAnn] = sourcePVCName
+		}
+	}
+	err := p.annotatePVC(pvc.Namespace, pvc.Name, annotations)
+	return err
 }
 
 func (p *glusterfileProvisioner) CreateVolume(gid *int, config *provisionerConfig, sz int) (r *v1.GlusterfsVolumeSource, size int, volID string, err error) {
@@ -215,7 +378,17 @@ func (p *glusterfileProvisioner) CreateVolume(gid *int, config *provisionerConfi
 	}
 
 	gid64 := int64(*gid)
-	volumeReq := &gapi.VolumeCreateRequest{Size: sz, Name: customVolumeName, Clusters: clusterIDs, Gid: gid64, Durability: config.volumeType, GlusterVolumeOptions: p.volumeOptions}
+
+	snaps := struct {
+		Enable bool    `json:"enable"`
+		Factor float32 `json:"factor"`
+	}{
+		true,
+		config.thinPoolSnapFactor,
+	}
+
+	volumeReq := &gapi.VolumeCreateRequest{Size: sz, Name: customVolumeName, Clusters: clusterIDs, Gid: gid64, Durability: p.volumeType, GlusterVolumeOptions: p.volumeOptions, Snapshot: snaps}
+
 	volume, err := cli.VolumeCreate(volumeReq)
 	if err != nil {
 		glog.Errorf("failed to create gluster volume: %v", err)
@@ -588,6 +761,10 @@ func (p *glusterfileProvisioner) parseClassParameters(params map[string]string, 
 	parseVolumeType := ""
 	parseVolumeOptions := ""
 	parseVolumeNamePrefix := ""
+	parseThinPoolSnapFactor := ""
+
+	//thin pool snap factor default to 1.0
+	cfg.thinPoolSnapFactor = float32(1.0)
 
 	for k, v := range params {
 		switch dstrings.ToLower(k) {
@@ -619,8 +796,13 @@ func (p *glusterfileProvisioner) parseClassParameters(params map[string]string, 
 			if len(v) != 0 {
 				parseVolumeNamePrefix = v
 			}
+		case "snapfactor":
+			if len(v) != 0 {
+				parseThinPoolSnapFactor = v
+			}
 		case "gidmin":
 		case "gidmax":
+		case "smartclone":
 		default:
 			return nil, fmt.Errorf("invalid option %q for volume plugin %s", k, provisionerName)
 		}
@@ -703,6 +885,17 @@ func (p *glusterfileProvisioner) parseClassParameters(params map[string]string, 
 			return nil, fmt.Errorf("Storageclass parameter 'volumenameprefix' should not contain '_' in its value")
 		}
 		cfg.volumeNamePrefix = parseVolumeNamePrefix
+	}
+
+	if len(parseThinPoolSnapFactor) != 0 {
+		thinPoolSnapFactor, err := strconv.ParseFloat(parseThinPoolSnapFactor, 32)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert snapfactor value %v to float32: %v", parseThinPoolSnapFactor, err)
+		}
+		if thinPoolSnapFactor < 1.0 || thinPoolSnapFactor > 100.0 {
+			return nil, fmt.Errorf("invalid snapshot factor %v, the value of snapfactor must be between 1 to 100", thinPoolSnapFactor)
+		}
+		cfg.thinPoolSnapFactor = float32(thinPoolSnapFactor)
 	}
 	return &cfg, nil
 }

--- a/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
+++ b/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
@@ -43,18 +43,19 @@ import (
 )
 
 const (
-	provisionerName    = "gluster.org/glusterfile"
-	provisionerNameKey = "PROVISIONER_NAME"
-	descAnn            = "Gluster-external: Dynamically provisioned PV"
-	restStr            = "server"
-	dynamicEpSvcPrefix = "glusterfile-dynamic-"
-	replicaCount       = 3
-	secretKeyName      = "key" // key name used in secret
-	volPrefix          = "vol_"
-	mountStr           = "auto_unmount"
-	glusterTypeAnn     = "gluster.org/type"
-	heketiVolIDAnn     = "gluster.org/heketi-volume-id"
-	gidAnn             = "pv.beta.kubernetes.io/gid"
+	provisionerName           = "gluster.org/glusterfile"
+	provisionerNameKey        = "PROVISIONER_NAME"
+	descAnn                   = "Gluster-external: Dynamically provisioned PV"
+	restStr                   = "server"
+	dynamicEpSvcPrefix        = "glusterfile-dynamic-"
+	replicaCount              = 3
+	secretKeyName             = "key" // key name used in secret
+	volPrefix                 = "vol_"
+	mountStr                  = "auto_unmount"
+	glusterTypeAnn            = "gluster.org/type"
+	heketiVolIDAnn            = "gluster.org/heketi-volume-id"
+	gidAnn                    = "pv.beta.kubernetes.io/gid"
+	defaultThinPoolSnapFactor = float32(1.0) // thin pool snap factor default to 1.0
 
 	// CloneRequestAnn is an annotation to request that the PVC be provisioned as a clone of the referenced PVC
 	CloneRequestAnn = "k8s.io/CloneRequest"
@@ -289,7 +290,7 @@ func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v
 }
 
 func (p *glusterfileProvisioner) createVolumeClone(sourceVolID string, config *provisionerConfig) (r *v1.GlusterfsVolumeSource, size int, volID string, err error) {
-	//cloneName := ""
+
 	if config.url == "" {
 		glog.Errorf("REST server endpoint is empty")
 		return nil, 0, "", fmt.Errorf("failed to create glusterfs REST client, REST URL is empty")
@@ -763,8 +764,7 @@ func (p *glusterfileProvisioner) parseClassParameters(params map[string]string, 
 	parseVolumeNamePrefix := ""
 	parseThinPoolSnapFactor := ""
 
-	//thin pool snap factor default to 1.0
-	cfg.thinPoolSnapFactor = float32(1.0)
+	cfg.thinPoolSnapFactor = defaultThinPoolSnapFactor
 
 	for k, v := range params {
 		switch dstrings.ToLower(k) {

--- a/vendor/github.com/heketi/heketi/client/api/go-client/volume.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/volume.go
@@ -232,3 +232,52 @@ func (c *Client) VolumeDelete(id string) error {
 
 	return nil
 }
+
+func (c *Client) VolumeClone(id string, request *api.VolumeCloneRequest) (*api.VolumeInfoResponse, error) {
+	// Marshal request to JSON
+	buffer, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a request
+	req, err := http.NewRequest("POST", c.host+"/volumes/"+id+"/clone", bytes.NewBuffer(buffer))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Set token
+	err = c.setToken(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send request
+	r, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusAccepted {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Wait for response
+	r, err = c.waitForResponseWithTimer(r, time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode != http.StatusOK {
+		return nil, utils.GetErrorFromResponse(r)
+	}
+
+	// Read JSON response
+	var volume api.VolumeInfoResponse
+	err = utils.GetJsonFromResponse(r, &volume)
+	if err != nil {
+		return nil, err
+	}
+
+	return &volume, nil
+}

--- a/vendor/github.com/heketi/heketi/pkg/glusterfs/api/types.go
+++ b/vendor/github.com/heketi/heketi/pkg/glusterfs/api/types.go
@@ -330,6 +330,17 @@ func (volExpandReq VolumeExpandRequest) Validate() error {
 	)
 }
 
+type VolumeCloneRequest struct {
+       Name string `json:"name,omitempty"`
+}
+
+func (vcr VolumeCloneRequest) Validate() error {
+     return validation.ValidateStruct(&vcr,
+             validation.Field(&vcr.Name, validation.Match(volumeNameRe)),
+     )
+}
+
+
 // BlockVolume
 
 type BlockVolumeCreateRequest struct {


### PR DESCRIPTION
    Add smartclone functionality for external gluster file provisioner.
    
    This patch adds the capability of creating clone volumes in the
    gluster backend based on a PVC annotation. This functionality can
    be controlled by the `smartclone` parameter in the storageclass.
    


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>