### PR TITLE
Fixed flex-provisioner Makefile, so that it builds on osx.

### DIFF
--- a/flex/Makefile
+++ b/flex/Makefile
@@ -12,25 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE = quay.io/kubernetes_incubator/flex-provisioner
+ifeq ($(REGISTRY),)
+	REGISTRY = quay.io/external_storage/
+endif
 
-VERSION := latest
+ifeq ($(VERSION),)
+	VERSION = latest
+endif
+
+IMAGE = $(REGISTRY)flex-provisioner:$(VERSION)
+MUTABLE_IMAGE = $(REGISTRY)deploy/docker/flex-provisioner:latest
 
 all build:
-	GOOS=linux go install -v ./cmd/flex-provisioner
-	GOOS=linux go build ./cmd/flex-provisioner
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o flex-provisioner ./cmd/flex-provisioner
 .PHONY: all build
 
 container: build quick-container
 .PHONY: container
 
 quick-container:
-	cp flex-provisioner deploy/docker/flex-provisioner
-	docker build -t $(IMAGE):$(VERSION) deploy/docker
+	cp flex-provisioner deploy/docker
+	docker build -t $(MUTABLE_IMAGE) deploy/docker
+	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 .PHONY: quick-container
 
 push: container
-	docker push $(IMAGE):$(VERSION)
+	docker push $(IMAGE)
+	docker push $(MUTABLE_IMAGE)
 .PHONY: push
 
 clean:


### PR DESCRIPTION
Make fails on osx with the following error:
```
cd flex; \
	make container
GOOS=linux go install -v ./cmd/flex-provisioner
runtime/internal/sys
go install runtime/internal/sys: mkdir /usr/local/go/pkg/linux_amd64: permission denied
```

This PR updates the Makefile so that the flex provisioner builds on osx.

I removed `GOOS=linux go install -v ./cmd/flex-provisioner`, which I believe is unnecessary and was failing on osx.

I also incorporated a few other Makefile changes that are included in most of the other external-storage provisioners, e.g. the ability to override $REGISTRY and $IMAGE.