### PR TITLE
Fixed glusterfs-simple-provisioner Makefile, so that it builds on osx.

### DIFF
--- a/gluster/glusterfs/Makefile
+++ b/gluster/glusterfs/Makefile
@@ -22,13 +22,11 @@ IMAGE = $(REGISTRY)glusterfs-simple-provisioner:$(VERSION)
 MUTABLE_IMAGE = $(REGISTRY)glusterfs-simple-provisioner:latest
 
 all build:
-	GOOS=linux go install -v ./cmd/glusterfs-simple-provisioner
-	GOOS=linux CGO_ENABLED=0 go build ./cmd/glusterfs-simple-provisioner
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o glusterfs-simple-provisioner ./cmd/glusterfs-simple-provisioner
 .PHONY: all build
 
 build-mac:
-	GOOS=darwin go install -v ./cmd/glusterfs-simple-provisioner
-	GOOS=darwin go build ./cmd/glusterfs-simple-provisioner
+	CGO_ENABLED=0 GOOS=darwin go build -a -ldflags '-extldflags "-static"' -o glusterfs-simple-provisioner ./cmd/glusterfs-simple-provisioner
 .PHONY: build-mac
 
 container: build quick-container


### PR DESCRIPTION
Make fails on osx with the following error:

```
cd gluster/glusterfs; \
	make container
GOOS=linux go install -v ./cmd/glusterfs-simple-provisioner
runtime/internal/sys
go install runtime/internal/sys: mkdir /usr/local/go/pkg/linux_amd64: permission denied
```

This PR updates the Makefile so that the glusterfs-simple-provisioner builds on osx.

I removed the lines containing `GOOS=linux go install`, which I believe is unnecessary and were failing on osx.

