### PR TITLE
Fixed nfs-provisioner Makefile, so that it builds and unit tests pass on osx.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,11 @@ test-nfs:
 	make test
 .PHONY: test-nfs
 
+test-nfs-all:
+	cd nfs; \
+	make test-all
+.PHONY: test-nfs-all
+
 clean-nfs:
 	cd nfs; \
 	make clean

--- a/nfs/Makefile
+++ b/nfs/Makefile
@@ -22,7 +22,6 @@ IMAGE = $(REGISTRY)nfs-provisioner:$(VERSION)
 MUTABLE_IMAGE = $(REGISTRY)nfs-provisioner:latest
 
 all build:
-	GOOS=linux go install -v ./cmd/nfs-provisioner
 	GOOS=linux go build ./cmd/nfs-provisioner
 .PHONY: all build
 
@@ -40,11 +39,11 @@ push: container
 	docker push $(MUTABLE_IMAGE)
 .PHONY: push
 
-test: test-integration test-e2e
+test-all: test test-e2e
 
-test-integration:
+test:
 	go test `go list ./... | grep -v 'vendor\|test\|demo'`
-.PHONY: test-integration
+.PHONY: test
 
 test-e2e:
 	cd ./test/e2e; glide install -v

--- a/test.sh
+++ b/test.sh
@@ -71,7 +71,7 @@ if [ "$TEST_SUITE" = "nfs" ]; then
 
 	# Build nfs-provisioner and run tests
 	make nfs
-	make test-nfs
+	make test-nfs-all
 elif [ "$TEST_SUITE" = "everything-else" ]; then
 	pushd ./lib
 	go test ./controller


### PR DESCRIPTION
There are multiple issues being addressed in this PR.

1) problems with nfs-provisioner build on osx.
2) problems with nfs-provisioner tests on osx.

Details below:
1) Make fails on osx with the following error:

```
cd nfs; \
	make container
GOOS=linux go install -v ./cmd/nfs-provisioner
runtime/internal/sys
go install runtime/internal/sys: mkdir /usr/local/go/pkg/linux_amd64: permission denied
make[1]: *** [build] Error 1
make: *** [nfs] Error 2
```
This PR updates the Makefile so that the nfs-provisioner builds on osx.

I removed `go install` from the `build` target, which I believe is unnecessary and was failing on osx.

2) At present nfs `make test` attempts to execute unit tests and e2e tests. The e2e tests fail on osx, and here is the initial error:
```
cd nfs; \
	make test
go test `go list ./... | grep -v 'vendor\|test\|demo'`
?   	github.com/kubernetes-incubator/external-storage/nfs/cmd/nfs-provisioner	[no test files]
?   	github.com/kubernetes-incubator/external-storage/nfs/pkg/server	[no test files]
ok  	github.com/kubernetes-incubator/external-storage/nfs/pkg/volume	0.034s
cd ./test/e2e; glide install -v
[INFO]	Downloading dependencies. Please wait...
<snip>
[INFO]	--> Fetching bitbucket.org/ww/goautoneg
[WARN]	Unable to checkout bitbucket.org/ww/goautoneg
[ERROR]	Update failed for bitbucket.org/ww/goautoneg: hg is not installed
[ERROR]	Failed to install: hg is not installed
```

It appears that hg (Mercurial) may be an e2e test dependency that isn't being checked or installed.

To rectify this issue and enable tests to pass on osx, I modified the `test` target to perform only unit tests. I created a new target `test-all` to execute both the unit tests and e2e tests.

This new target is called from `test.sh` which is used in the travis CI pipeline.