### PR TITLE
Fixed snapshot Makefile, so that it builds on osx.

### DIFF
--- a/snapshot/Makefile
+++ b/snapshot/Makefile
@@ -51,8 +51,8 @@ container-quick:
 	cp _output/bin/snapshot-controller deploy/docker/controller
 	cp _output/bin/snapshot-provisioner deploy/docker/provisioner
 	# Copy the root CA certificates -- cloudproviders need them
-	cp -R deploy/ca-certificates/* deploy/docker/controller/.
-	cp -R deploy/ca-certificates/* deploy/docker/provisioner/.
+	cp -Rf deploy/ca-certificates/* deploy/docker/controller/.
+	cp -Rf deploy/ca-certificates/* deploy/docker/provisioner/.
 	docker build -t $(MUTABLE_IMAGE_CONTROLLER) deploy/docker/controller
 	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
 	docker build -t $(MUTABLE_IMAGE_PROVISIONER) deploy/docker/provisioner

--- a/snapshot/Makefile
+++ b/snapshot/Makefile
@@ -51,8 +51,8 @@ container-quick:
 	cp _output/bin/snapshot-controller deploy/docker/controller
 	cp _output/bin/snapshot-provisioner deploy/docker/provisioner
 	# Copy the root CA certificates -- cloudproviders need them
-	cp -r --remove-destination deploy/ca-certificates/* deploy/docker/controller/
-	cp -r --remove-destination deploy/ca-certificates/* deploy/docker/provisioner/
+	cp -R deploy/ca-certificates/* deploy/docker/controller/.
+	cp -R deploy/ca-certificates/* deploy/docker/provisioner/.
 	docker build -t $(MUTABLE_IMAGE_CONTROLLER) deploy/docker/controller
 	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
 	docker build -t $(MUTABLE_IMAGE_PROVISIONER) deploy/docker/provisioner

--- a/snapshot/deploy/ca-certificates/etc/pki/ca-trust/source/ca-bundle.legacy.crt
+++ b/snapshot/deploy/ca-certificates/etc/pki/ca-trust/source/ca-bundle.legacy.crt
@@ -1,1 +1,0 @@
-/usr/share/pki/ca-trust-legacy/ca-bundle.legacy.default.crt

--- a/snapshot/deploy/ca-certificates/etc/pki/java/cacerts
+++ b/snapshot/deploy/ca-certificates/etc/pki/java/cacerts
@@ -1,1 +1,0 @@
-/etc/pki/ca-trust/extracted/java/cacerts

--- a/snapshot/deploy/ca-certificates/etc/ssl/certs
+++ b/snapshot/deploy/ca-certificates/etc/ssl/certs
@@ -1,1 +1,0 @@
-../pki/tls/certs


### PR DESCRIPTION
Make fails on osx with the following error:

```
$ make container-quick
cp _output/bin/snapshot-controller deploy/docker/controller
cp _output/bin/snapshot-provisioner deploy/docker/provisioner
# Copy the root CA certificates -- cloudproviders need them
cp -r --remove-destination deploy/ca-certificates/* deploy/docker/controller/
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvXc] source_file ... target_directory
make: *** [container-quick] Error 64
```

This error occurs because osx's `cp` command does not support the `--remove-destination`. 

Additionally, osx `cp` command does not support `-r` and instead it supports `-R` for recursive copy.