### PR TITLE
Modifed nfs make test target to perform only unit tests.

### DIFF
--- a/nfs/Makefile
+++ b/nfs/Makefile
@@ -40,11 +40,11 @@ push: container
 	docker push $(MUTABLE_IMAGE)
 .PHONY: push
 
-test: test-integration test-e2e
+test-all: test test-e2e
 
-test-integration:
+test:
 	go test `go list ./... | grep -v 'vendor\|test\|demo'`
-.PHONY: test-integration
+.PHONY: test
 
 test-e2e:
 	cd ./test/e2e; glide install -v


### PR DESCRIPTION
At present nfs `make test` attempts to execute unit tests and e2e tests. The e2e tests fail on osx, and here is the initial error:
```
cd nfs; \
	make test
go test `go list ./... | grep -v 'vendor\|test\|demo'`
?   	github.com/kubernetes-incubator/external-storage/nfs/cmd/nfs-provisioner	[no test files]
?   	github.com/kubernetes-incubator/external-storage/nfs/pkg/server	[no test files]
ok  	github.com/kubernetes-incubator/external-storage/nfs/pkg/volume	0.034s
cd ./test/e2e; glide install -v
[INFO]	Downloading dependencies. Please wait...
<snip>
[INFO]	--> Fetching bitbucket.org/ww/goautoneg
[WARN]	Unable to checkout bitbucket.org/ww/goautoneg
[ERROR]	Update failed for bitbucket.org/ww/goautoneg: hg is not installed
[ERROR]	Failed to install: hg is not installed
```

It appears that hg (Mercurial) may be an e2e test dependency that isn't being checked or installed.

To rectify this issue and enable tests to pass on osx, I modified the `test` target to perform only unit tests. I created a new target `test-all` to execute both the unit tests and e2e tests.
