### PR TITLE
Update cephfs client-side configurations.

### DIFF
--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -53,7 +53,7 @@ class CephFSNativeDriver(object):
             conf = open(conf_path, 'w')
             conf.write("[global]\n")
             conf.write("mon_host = " + mons + "\n")
-            conf.write("auth_cluster_required = cephx\nauth_service_required = cephx\nauth_client_required = cephx\n")
+            conf.write("auth_client_required = cephx,none\n")
             conf.close()
         return conf_path
 


### PR DESCRIPTION
- `auth_cluster_required/auth_service_required` are server-side configurations, removed.
- configure `auth_client_required` to `cephx,none`, local private cephfs cluster may disable cephx (`none`) on server-side for better performance, if `auth_client_required` is `cephx`, cephfs provisioner cannot connect to cluster.

References:
- http://docs.ceph.com/docs/master/rados/configuration/auth-config-ref/