### PR TITLE
CephFS Provisioner: Make ceph.dir.layout.pool_namespace optional.

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -129,6 +129,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		"CEPH_MON=" + strings.Join(mon[:], ","),
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret}
+	if *disableCephNamespace {
+		cmd.Env = append(cmd.Env, "CEPH_FEATURE_PNAMESPACE_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -232,6 +235,9 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 		"CEPH_MON=" + strings.Join(mon[:], ","),
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret}
+	if *disableCephNamespace {
+		cmd.Env = append(cmd.Env, "CEPH_FEATURE_PNAMESPACE_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -314,10 +320,11 @@ func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string,
 }
 
 var (
-	master          = flag.String("master", "", "Master URL")
-	kubeconfig      = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
-	id              = flag.String("id", "", "Unique provisioner identity")
-	secretNamespace = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
+	master               = flag.String("master", "", "Master URL")
+	kubeconfig           = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
+	id                   = flag.String("id", "", "Unique provisioner identity")
+	secretNamespace      = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
+	disableCephNamespace = flag.Bool("disable-ceph-namespace", false, "Disable Ceph namespace support")
 )
 
 func main() {

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -260,6 +260,11 @@ class CephFSNativeDriver(object):
             namespace = "{0}{1}".format(self.volume_client.pool_ns_prefix, volume_path.volume_id)
             log.info("create_volume: {0}, using rados namespace {1} to isolate data.".format(volume_path, namespace))
             self.volume_client.fs.setxattr(path, 'ceph.dir.layout.pool_namespace', namespace, 0)
+        else:
+            # If `ceph.dir.layout.pool_namespace` is not configured, `ceph.dir.layout.pool` is inherited from ancestor which may change.
+            # Make sure `ceph.dir.layout.pool` is configured on volume path, so we will not have any permission issues in future.
+            pool_name = self.volume_client._get_ancestor_xattr(path, "ceph.dir.layout.pool")
+            self.volume_client.fs.setxattr(path, 'ceph.dir.layout.pool', pool_name, 0)
 
         # Create a volume meta file, if it does not already exist, to store
         # data about auth ids having access to the volume


### PR DESCRIPTION
**What this PR does / why we need it**:

Linux kernel cephfs only support Rados Pool Namespace in 4.8+. See
https://github.com/torvalds/linux/commit/779fe0fb8e1883d5c479ac6bd85fbd237deed1f7.

If security is not critical, we can configure cephfs provisioner not to enforce pool namespace, then we can use it with linux kernels before 4.8.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/kubernetes-incubator/external-storage/issues/345

**Special notes for reviewer**:

cc @wongma7 @rootfs 