### PR TITLE
Added OSX to Travis CI for external-storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,24 @@
+os:
+  - osx
+  - linux
+
 language: go
 go:
   - 1.8.3
 services: docker
 
+go_import_path: github.com/kubernetes-incubator/external-storage
+
 env:
-  - TEST_SUITE=local-volume
-  - TEST_SUITE=everything-else
-  - TEST_SUITE=nfs ETCD_VER=v3.0.14 KUBE_VERSION=1.5.4
-  - TEST_SUITE=nfs ETCD_VER=v3.0.17 KUBE_VERSION=1.6.0
+  - TEST_SUITE=osx
+  - TEST_SUITE=linux-local-volume
+  - TEST_SUITE=linux-everything-else
+  - TEST_SUITE=linux-nfs ETCD_VER=v3.0.14 KUBE_VERSION=1.5.4
+  - TEST_SUITE=linux-nfs ETCD_VER=v3.0.17 KUBE_VERSION=1.6.0
+
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then ulimit -n 8192; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then mkdir -p $GOPATH/bin; fi
 
 install: true
 
@@ -19,4 +30,4 @@ deploy:
     script: ./deploy.sh
     on:
       tags: true
-      condition: $TEST_SUITE = local-volume
+      condition: $TEST_SUITE = linux-local-volume

--- a/iscsi/targetd/Dockerfile
+++ b/iscsi/targetd/Dockerfile
@@ -14,5 +14,5 @@
 
 FROM centos:7
 LABEL authors="Raffaele Spazzoli <rspazzol@redhat.com>" 
-ADD iscsi-controller /iscsi-controller
+ADD targetd /iscsi-controller
 ENTRYPOINT ["/iscsi-controller"]

--- a/iscsi/targetd/Makefile
+++ b/iscsi/targetd/Makefile
@@ -44,7 +44,6 @@ container: build quick-container
 .PHONY: container
 
 quick-container:
-	mv targetd iscsi-controller
 	docker build -t $(MUTABLE_IMAGE) .
 	docker tag $(MUTABLE_IMAGE) $(IMAGE)
 .PHONY: quick-container

--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,19 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+# Skip duplicate build and test runs through the CI, that occur because we are now running on osx and linux.
+# Skipping these steps saves time and travis-ci resources.
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        if [ "$TEST_SUITE" != "osx" ]; then
+	        exit 0
+        fi
+fi
+if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+        if [ "$TEST_SUITE" = "osx" ]; then
+	        exit 0
+        fi
+fi
+
 # Install glide, golint, cfssl
 curl https://glide.sh/get | sh
 go get -u github.com/golang/lint/golint
@@ -27,7 +40,17 @@ go get -u github.com/alecthomas/gometalinter
 gometalinter --install
 make verify
 
-if [ "$TEST_SUITE" = "nfs" ]; then
+if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        if [ "$TEST_SUITE" = "osx" ]; then
+                # Presently travis-ci does not support docker on osx.
+                echo '#!/bin/bash' > docker
+                echo 'echo "***docker not currently supported on osx travis-ci, skipping docker commands for osx***"' >> docker
+                chmod u+x docker
+                export PATH=$(pwd):${PATH}
+                make
+                make test
+        fi
+elif [ "$TEST_SUITE" = "linux-nfs" ]; then
 	# Install nfs, cfssl
 	sudo apt-get -qq update
 	sudo apt-get install -y nfs-common
@@ -72,7 +95,7 @@ if [ "$TEST_SUITE" = "nfs" ]; then
 	# Build nfs-provisioner and run tests
 	make nfs
 	make test-nfs-all
-elif [ "$TEST_SUITE" = "everything-else" ]; then
+elif [ "$TEST_SUITE" = "linux-everything-else" ]; then
 	pushd ./lib
 	go test ./controller
 	go test ./allocator
@@ -95,7 +118,7 @@ elif [ "$TEST_SUITE" = "everything-else" ]; then
 	make snapshot
 	make test-snapshot
 	make test-openstack/standalone-cinder
-elif [ "$TEST_SUITE" = "local-volume" ]; then
+elif [ "$TEST_SUITE" = "linux-local-volume" ]; then
 	make local-volume/provisioner
 	make test-local-volume/provisioner
 fi


### PR DESCRIPTION
Added `.travis.yml` changes for testing on OSX in travis-ci. Similarly, added logic in `test.sh` for building and unit testing on OSX. 

After this PR is merged, if someone attempts to checin something that doesn't work on OSX, then the CI will fail and they'll see the errors.

Certain duplicate test are skipped, to keep CI fast and save travis-ci resources. For example, skip linux tests on osx and vice versa.

Note: travis-ci on osx does not support docker, yet. Therefore, a docker alias is created to enable docker commands to execute successfully for OSX build and test.

You can see the successful run of these travis-ci changes here: https://travis-ci.org/ianchakeres/external-storage/builds/356325691

![screen shot 2018-03-21 at 9 38 32 am](https://user-images.githubusercontent.com/4367440/37723459-aaecb04c-2ceb-11e8-9cac-696d6d2be88c.png)