### PR TITLE
clean up docs to reflect only 1.10

### DIFF
--- a/local-volume/CHANGELOG.md
+++ b/local-volume/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [v2.1.0](https://github.com/kubernetes-incubator/external-storage/releases/tag/local-volume-provisioner-v2.1.0)
 The following changes require Kubernetes 1.10 or higher.
 * Add block volumeMode discovery and cleanup.
-* **Important:** PV.NodeAffinity field is used by default. If running against an older K8s version,
+* **Important:** Beta PV.NodeAffinity field is used by default. If running against an older K8s version,
   the `useAlphaAPI` flag must be set in the configMap.
 
 # [v2.0.0](https://github.com/kubernetes-incubator/external-storage/releases/tag/local-volume-provisioner-v2.0.0)
@@ -10,7 +10,7 @@ The following changes require Kubernetes 1.10 or higher.
 * Configmap data is changed from json to yaml syntax.
 * All local volumes must be mount points.  For directory-based volumes, a
   bind-mount must be done in order for the provisioner to discover them. This
-  requires the K8s [mount propgataion feature](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
+  requires the K8s [mount propagation feature](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
   to be enabled.
 * Detected capacity is rounded down to the nearest GB.
 * New option to specify which node labels to add to the PV.

--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -22,9 +22,23 @@ directories by creating and cleaning up PersistentVolumes for each volume.
 * The static provisioner only discovers mount points.  For directory-based local
   volumes, they must be bind-mounted into the discovery directories.
 
+## Version Compatibility
+
+Recommended provisioner versions with Kubernetes versions
+
+| Provisioner version | K8s version   | Reason                    |
+| ------------------- | ------------- | ------------------------- |
+| [2.1.0][3]          | 1.10          | Beta API default, block   |
+| [2.0.0][2]          | 1.8, 1.9      | Mount propagation         |
+| [1.0.1][1]          | 1.7           |                           |
+
+[1]: https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v1.0.1/local-volume
+[2]: https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.0.0/local-volume
+[3]: https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.1.0/local-volume
+
 ## K8s Feature Status
 
-Also see [known issues](KNOWN_ISSUES.md) and [provisioner CHANGELOG](provisioner/CHANGELOG.md).
+Also see [known issues](KNOWN_ISSUES.md) and [CHANGELOG](CHANGELOG.md).
 
 ### 1.10: Beta
 
@@ -54,31 +68,19 @@ Also see [known issues](KNOWN_ISSUES.md) and [provisioner CHANGELOG](provisioner
 ## User Guide
 
 These instructions reflect the latest version of the codebase.  For instructions
-on older versions, please see version links in the [CHANGELOG](provisioner/CHANGELOG.md).
+on older versions, please see version links under
+[Version Compatibility](#version-compatibility).
 
 ### Step 1: Bringing up a cluster with local disks
 
 #### Enabling the alpha feature gates
 
-##### 1.7
-```
-$ export KUBE_FEATURE_GATES="PersistentLocalVolumes=true"
-```
-
-##### 1.8
-```
-$ export KUBE_FEATURE_GATES="PersistentLocalVolumes=true,MountPropagation=true"
-```
-
-##### 1.9
-```
-$ export KUBE_FEATURE_GATES="PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
-```
-
 ##### 1.10+
 
+If raw local block feature is needed,
+```
 $ export KUBE_FEATURE_GATES="BlockVolume=true"
-
+```
 
 #### Option 1: GCE
 
@@ -86,15 +88,6 @@ GCE clusters brought up with kube-up.sh will automatically format and mount the
 requested Local SSDs, so you can deploy the provisioner with the pre-generated
 deployment spec and skip to [step 4](#step-4-create-local-persistent-volume-claim),
 unless you want to customize the provisioner spec or storage classes.
-
-##### Pre-1.9
-
-``` console
-$ NODE_LOCAL_SSDS=<n> cluster/kube-up.sh
-$ kubectl create -f provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_count.yaml
-```
-
-##### 1.9+
 
 ``` console
 $ NODE_LOCAL_SSDS_EXT=<n>,<scsi|nvme>,fs cluster/kube-up.sh
@@ -105,31 +98,13 @@ $ kubectl create -f provisioner/deployment/kubernetes/gce/provisioner_generated_
 #### Option 2: GKE
 
 GKE clusters will automatically format and mount the
-requested Local SSDs, so you can deploy the provisioner with the pre-generated
-deployment spec and skip to [step 4](#step-4-create-local-persistent-volume-claim),
-unless you want to customize the provisioner spec or storage classes.
+requested Local SSDs. Please see
+[GKE documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/local-ssd)
+for instructions for how to create a cluster with Local SSDs.
 
-##### Using local-ssd-count option
+Then skip to [step 4](#step-4-create-local-persistent-volume-claim).
 
-``` console
-# --enable-kubernetes-alpha flag is not needed from K8s 1.10+
-$ gcloud container cluster create ... --local-ssd-count=<n> --enable-kubernetes-alpha
-$ gcloud container node-pools create ... --local-ssd-count=<n>
-
-# If running K8s 1.9+, also create the StorageClasses
-$ kubectl create -f provisioner/deployment/kubernetes/gce/class-local-ssds.yaml
-$ kubectl create -f provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_count.yaml
-```
-
-##### Using local-ssd-volumes option (available via whitelist only)
-
-``` console
-# --enable-kubernetes-alpha flag is not needed from K8s 1.10+
-$ gcloud alpha container cluster create ... --local-ssd-volumes="count=<n>,type=<scsi|nvme>,format=fs" --enable-kubernetes-alpha
-$ gcloud alpha container node-pools create ... --local-ssd-volumes="count=<n>,type=<scsi|nvme>,format=fs"
-$ kubectl create -f provisioner/deployment/kubernetes/gce/class-local-ssds.yaml
-$ kubectl create -f provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_volumes.yaml
-```
+**Note:** The raw block feature is only supported on GKE Kubernetes alpha clusters.
 
 #### Option 3: Baremetal environments
 
@@ -176,115 +151,69 @@ $ kubectl create -f provisioner/deployment/kubernetes/example/default_example_st
 
 #### Option 1: Using the local volume static provisioner
 
-**Important:** Running provisioner v2.1.0 or later against a Kubernetes cluster prior
-to v1.10 requires setting the `useAlphaAPI` configMap parameter to use the alpha API.
+1. Generate Provisioner's ServiceAccount, Roles, DaemonSet, and ConfigMap spec, and customize it.
 
-1. Generate Provisioner's ServiceAccount, Roles, DaemonSet and ConfigMap spec, and customize it.
-This step uses helm templates to generate the specs.  See the [helm README](helm) for setup instructions.
-To generate the provisioner's specs using the [default values](helm/provisioner/values.yaml), run:
+    This step uses helm templates to generate the specs.  See the [helm README](helm) for setup instructions.
+    To generate the provisioner's specs using the [default values](helm/provisioner/values.yaml), run:
 
-``` console
-helm template ./helm/provisioner > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
-```
+    ``` console
+    helm template ./helm/provisioner > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+    ```
 
-You can also provide a custom values file instead:
+    You can also provide a custom values file instead:
 
-``` console
-helm template ./helm/provisioner --values custom-values.yaml > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
-```
+    ``` console
+    helm template ./helm/provisioner --values custom-values.yaml > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+    ```
 
-In order to generate the environment specific provisioner's spec, **--set engine={gcepre19,gcepost19,gke,baremetal}** parameter
-can be used in helm template command. Example for GKE environment, the command line will look like:
+2. Deploy Provisioner
 
-``` console
-helm template ./helm/provisioner --set engine=gke > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
-```
-Parameter **--set engine=** canbe used in conjunction with custom vlues.yaml file in the same command line.
+    Once a user is satisfied with the content of Provisioner's yaml file, **kubectl** can be used
+    to create Provisioner's DaemonSet and ConfigMap.
 
-Note: By default, common.rbac is set to "true" which generates the necessary ServiceAccount, ClusterRole and ClusterRoleBinding for an RBAC(Role Based Access Control) enabled kubernetes cluster. If your cluster does not use RBAC, you should add --set common.rbac=false when running your helm install command, such as:
-
-``` console
-helm template ./helm/provisioner --set common.rbac=false > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
-```
-
-2. Deploy Provisioner 
-Once a user is satisfied with the content of Provisioner's yaml file, **kubectl** can be used
-to create Provisioner's DaemonSet and ConfigMap.
-
-``` console
-$ kubectl create -f ./provisioner/deployment/kubernetes/provisioner_generated.yaml 
-```
+    ``` console
+    $ kubectl create -f ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+    ```
 
 3. Check discovered local volumes
-Once launched, the external static provisioner will discover and create local-volume PVs.
 
-For example, if the directory `/mnt/disks/` contained one directory `/mnt/disks/vol1` then the following
-local-volume PV would be created by the static provisioner:
+    Once launched, the external static provisioner will discover and create local-volume PVs.
 
-```
-$ kubectl get pv
-NAME                CAPACITY    ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS    REASON    AGE
-local-pv-ce05be60   1024220Ki   RWO           Delete          Available             local-storage             26s
+    For example, if the directory `/mnt/disks/` contained one directory `/mnt/disks/vol1` then the following
+    local-volume PV would be created by the static provisioner:
 
-$ kubectl describe pv local-pv-ce05be60 
-Name:		local-pv-ce05be60
-Labels:		<none>
-Annotations:	pv.kubernetes.io/provisioned-by=local-volume-provisioner-minikube-18f57fb2-a186-11e7-b543-080027d51893
-StorageClass:	local-fast
-Status:		Available
-Claim:		
-Reclaim Policy:	Delete
-Access Modes:	RWO
-Capacity:	1024220Ki
-NodeAffinity:
-  Required Terms:
-      Term 0:  kubernetes.io/hostname in [my-node]
-Message:	
-Source:
-    Type:	LocalVolume (a persistent volume backed by local storage on a node)
-    Path:	/mnt/disks/vol1
-Events:		<none>
-```
+    ```
+    $ kubectl get pv
+    NAME                CAPACITY    ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     STORAGECLASS    REASON    AGE
+    local-pv-ce05be60   1024220Ki   RWO           Delete          Available             local-storage             26s
 
-The PV described above can be claimed and bound to a PVC by referencing the `local-fast` storageClassName.
+    $ kubectl describe pv local-pv-ce05be60 
+    Name:		local-pv-ce05be60
+    Labels:		<none>
+    Annotations:	pv.kubernetes.io/provisioned-by=local-volume-provisioner-minikube-18f57fb2-a186-11e7-b543-080027d51893
+    StorageClass:	local-fast
+    Status:		Available
+    Claim:		
+    Reclaim Policy:	Delete
+    Access Modes:	RWO
+    Capacity:	1024220Ki
+    NodeAffinity:
+      Required Terms:
+          Term 0:  kubernetes.io/hostname in [my-node]
+    Message:	
+    Source:
+        Type:	LocalVolume (a persistent volume backed by local storage on a node)
+        Path:	/mnt/disks/vol1
+    Events:		<none>
+    ```
+
+    The PV described above can be claimed and bound to a PVC by referencing the `local-fast` storageClassName.
 
 #### Option 2: Manually create local persistent volume
 
-If you don't use the external provisioner, then you have to create the local PVs
-manually. Note that with manual PV creation, the volume has to be manually
-reclaimed when deleted. Example PV:
+See [Kubernetes documentation](https://kubernetes.io/docs/concepts/storage/volumes/#local)
+for an example PersistentVolume spec.
 
-``` yaml
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: example-local-pv
-spec:
-  capacity:
-    storage: 5Gi
-  accessModes:
-  - ReadWriteOnce
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: local-storage
-  local:
-    path: /mnt/disks/vol1
-  nodeAffinity:
-    required:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: kubernetes.io/hostname
-          operator: In
-          values: my-node
-```
-Please replace the following elements to reflect your configuration:
-
-  * "my-node" with the name of kubernetes node that is hosting this
-    local storage disk
-  * "5Gi" with the required size of storage volume, same as specified in PVC
-  * "local-storage" with the name of storage class to associate with
-     this local volume
-  * "/mnt/disks/vol1" with the path to the mount point of local volumes
- 
 ### Step 4: Create local persistent volume claim
 
 ``` yaml

--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -43,3 +43,22 @@ The generated specs can be further customized as needed (usually not necessary),
 
 Default values.yaml is located in local-volume/helm/provisioner folder, user should not remove variables from this file but can
 change any values of these variables.
+
+## Advanced options
+
+### Set engine
+In order to generate the environment specific provisioner's spec, **--set engine={gcepre19,gcepost19,gke,baremetal}** parameter
+can be used in helm template command. Example for GKE environment, the command line will look like:
+
+``` console
+helm template ./helm/provisioner --set engine=gke > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+```
+Parameter **--set engine=** can be used in conjunction with custom values.yaml file in the same command line.
+
+### Generating RBAC (Role Based Access Control) specs
+By default, common.rbac is set to "true" which generates the necessary ServiceAccount, ClusterRole, and ClusterRoleBinding
+for an RBAC enabled kubernetes cluster. If your cluster does not use RBAC, you should add --set common.rbac=false when
+running your helm install command, such as:
+
+``` console
+helm template ./helm/provisioner --set common.rbac=false > ./provisioner/deployment/kubernetes/provisioner_generated.yaml


### PR DESCRIPTION
The README is becoming too complicated and messy trying to document older releases.  Instead, recommend provisioner versions to use with specific K8s releases, and cleanup the README.  Instructions for older provisioner versions can still be obtained by looking at the corresponding tags for older releases.

Fixes #689