### PR TITLE
Set quota size for dynamic provisioned cephfs volume

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -116,13 +116,15 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	if err != nil {
 		return nil, err
 	}
+	capacity := options.PVC.Spec.Resources.Requests[v1.ResourceStorage]
+	volumeSize := capacity.Value()
 	// create random share name
 	share := fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
 	// create random user id
 	user := fmt.Sprintf("kubernetes-dynamic-user-%s", uuid.NewUUID())
 	// provision share
 	// create cmd
-	cmd := exec.Command(provisionCmd, "-n", share, "-u", user)
+	cmd := exec.Command(provisionCmd, "-n", share, "-u", user, "-s", fmt.Sprintf("%d", volumeSize))
 	// set env
 	cmd.Env = []string{
 		"CEPH_CLUSTER_NAME=" + cluster,

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -297,14 +297,17 @@ class CephFSNativeDriver(object):
             self._volume_client = None
 
 def main():
+    usage = "Usage: " + sys.argv[0] + " --remove -n share_name -u ceph_user_id -s volume_size"
+
     create = True
     share = ""
     user = ""
+    size = None
     cephfs = CephFSNativeDriver()
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "rn:u:", ["remove"])
+        opts, args = getopt.getopt(sys.argv[1:], "rn:u:s:", ["remove", "size"])
     except getopt.GetoptError:
-        print "Usage: " + sys.argv[0] + " --remove -n share_name -u ceph_user_id"
+        print usage
         sys.exit(1)
 
     for opt, arg in opts:
@@ -314,13 +317,15 @@ def main():
             user = arg
         elif opt in ("-r", "--remove"):
             create = False
+        elif opt in ("-s", "--size"):
+            size = arg
 
     if share == "" or user == "":
-        print "Usage: " + sys.argv[0] + " --remove -n share_name -u ceph_user_id"
+        print usage
         sys.exit(1)
 
     if create == True:
-        print cephfs.create_share(share, user)    
+        print cephfs.create_share(share, user, size)
     else:
         cephfs.delete_share(share, user)    
         


### PR DESCRIPTION
Kubernetes v1.10 supports using ceph-fuse to mount cephfs volumes, so we can set the volume's quota to PVC's capacity.

Fix: #691 