### PR TITLE
[cephfs] Added storage class parameters to specify a root path within the backing cephfs and, optionally, use deterministic directory and user names

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -112,7 +112,7 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	if options.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
 	}
-	cluster, adminID, adminSecret, pvc_root, mon, err := p.parseParameters(options.Parameters)
+	cluster, adminID, adminSecret, pvcRoot, mon, err := p.parseParameters(options.Parameters)
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +129,7 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		"CEPH_MON=" + strings.Join(mon[:], ","),
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret,
-		"CEPH_VOLUME_ROOT=" + pvc_root}
+		"CEPH_VOLUME_ROOT=" + pvcRoot}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -220,7 +220,7 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if err != nil {
 		return err
 	}
-	cluster, adminID, adminSecret, pvc_root, mon, err := p.parseParameters(class.Parameters)
+	cluster, adminID, adminSecret, pvcRoot, mon, err := p.parseParameters(class.Parameters)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 		"CEPH_MON=" + strings.Join(mon[:], ","),
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret,
-		"CEPH_VOLUME_ROOT=" + pvc_root}
+		"CEPH_VOLUME_ROOT=" + pvcRoot}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -258,15 +258,15 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 
 func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (string, string, string, string, []string, error) {
 	var (
-		err                                                                            error
-		mon                                                                            []string
-		cluster, adminID, adminSecretName, adminSecretNamespace, adminSecret, pvc_root string
+		err                                                                           error
+		mon                                                                           []string
+		cluster, adminID, adminSecretName, adminSecretNamespace, adminSecret, pvcRoot string
 	)
 
 	adminSecretNamespace = "default"
 	adminID = "admin"
 	cluster = "ceph"
-	pvc_root = "/volumes/kubernetes"
+	pvcRoot = "/volumes/kubernetes"
 
 	for k, v := range parameters {
 		switch strings.ToLower(k) {
@@ -284,7 +284,7 @@ func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (strin
 		case "adminsecretnamespace":
 			adminSecretNamespace = v
 		case "claimroot":
-			pvc_root = v
+			pvcRoot = v
 		default:
 			return "", "", "", "", nil, fmt.Errorf("invalid option %q", k)
 		}
@@ -299,7 +299,7 @@ func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (strin
 	if len(mon) < 1 {
 		return "", "", "", "", nil, fmt.Errorf("missing Ceph monitors")
 	}
-	return cluster, adminID, adminSecret, pvc_root, mon, nil
+	return cluster, adminID, adminSecret, pvcRoot, mon, nil
 }
 
 func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string, error) {

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -112,14 +113,20 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	if options.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
 	}
-	cluster, adminID, adminSecret, pvcRoot, mon, err := p.parseParameters(options.Parameters)
+	cluster, adminID, adminSecret, pvcRoot, mon, deterministicNames, err := p.parseParameters(options.Parameters)
 	if err != nil {
 		return nil, err
 	}
-	// create random share name
-	share := fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
-	// create random user id
-	user := fmt.Sprintf("kubernetes-dynamic-user-%s", uuid.NewUUID())
+	var share, user string
+	if deterministicNames {
+		share = fmt.Sprintf(options.PVC.Name)
+		user = fmt.Sprintf("k8s.%s", options.PVC.Name)
+	} else {
+		// create random share name
+		share = fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
+		// create random user id
+		user = fmt.Sprintf("kubernetes-dynamic-user-%s", uuid.NewUUID())
+	}
 	// provision share
 	// create cmd
 	cmd := exec.Command(provisionCmd, "-n", share, "-u", user)
@@ -220,7 +227,7 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	if err != nil {
 		return err
 	}
-	cluster, adminID, adminSecret, pvcRoot, mon, err := p.parseParameters(class.Parameters)
+	cluster, adminID, adminSecret, pvcRoot, mon, _, err := p.parseParameters(class.Parameters)
 	if err != nil {
 		return err
 	}
@@ -256,17 +263,19 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 	return nil
 }
 
-func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (string, string, string, string, []string, error) {
+func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (string, string, string, string, []string, bool, error) {
 	var (
 		err                                                                           error
 		mon                                                                           []string
 		cluster, adminID, adminSecretName, adminSecretNamespace, adminSecret, pvcRoot string
+		deterministicNames                                                            bool
 	)
 
 	adminSecretNamespace = "default"
 	adminID = "admin"
 	cluster = "ceph"
 	pvcRoot = "/volumes/kubernetes"
+	deterministicNames = false
 
 	for k, v := range parameters {
 		switch strings.ToLower(k) {
@@ -285,21 +294,24 @@ func (p *cephFSProvisioner) parseParameters(parameters map[string]string) (strin
 			adminSecretNamespace = v
 		case "claimroot":
 			pvcRoot = v
+		case "deterministicnames":
+			// On error, strconv.ParseBool() returns false; leave that, as it is a perfectly fine default
+			deterministicNames, _ = strconv.ParseBool(v)
 		default:
-			return "", "", "", "", nil, fmt.Errorf("invalid option %q", k)
+			return "", "", "", "", nil, false, fmt.Errorf("invalid option %q", k)
 		}
 	}
 	// sanity check
 	if adminSecretName == "" {
-		return "", "", "", "", nil, fmt.Errorf("missing Ceph admin secret name")
+		return "", "", "", "", nil, false, fmt.Errorf("missing Ceph admin secret name")
 	}
 	if adminSecret, err = p.parsePVSecret(adminSecretNamespace, adminSecretName); err != nil {
-		return "", "", "", "", nil, fmt.Errorf("failed to get admin secret from [%q/%q]: %v", adminSecretNamespace, adminSecretName, err)
+		return "", "", "", "", nil, false, fmt.Errorf("failed to get admin secret from [%q/%q]: %v", adminSecretNamespace, adminSecretName, err)
 	}
 	if len(mon) < 1 {
-		return "", "", "", "", nil, fmt.Errorf("missing Ceph monitors")
+		return "", "", "", "", nil, false, fmt.Errorf("missing Ceph monitors")
 	}
-	return cluster, adminID, adminSecret, pvcRoot, mon, nil
+	return cluster, adminID, adminSecret, pvcRoot, mon, deterministicNames, nil
 }
 
 func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string, error) {

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -120,7 +120,7 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	var share, user string
 	if deterministicNames {
 		share = fmt.Sprintf(options.PVC.Name)
-		user = fmt.Sprintf("k8s.%s", options.PVC.Name)
+		user = fmt.Sprintf("k8s.%s.%s", options.PVC.Namespace, options.PVC.Name)
 	} else {
 		// create random share name
 		share = fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
@@ -137,6 +137,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret,
 		"CEPH_VOLUME_ROOT=" + pvcRoot}
+	if deterministicNames {
+		cmd.Env = append(cmd.Env, "CEPH_VOLUME_GROUP="+options.PVC.Namespace)
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -42,12 +42,9 @@ class CephFSNativeDriver(object):
 
     def __init__(self, *args, **kwargs):
         self._volume_client = None
-        try:
-            (self.volume_prefix, self.volume_group) = os.path.split(os.environ['CEPH_VOLUME_ROOT'])
-        except KeyError:
-            # Default volume_prefix to None; the CephFSVolumeClient constructor uses a ternary operator on the input argument to default it to /volumes
-            self.volume_prefix = None
-            self.volume_group = VOlUME_GROUP
+        # Default volume_prefix to None; the CephFSVolumeClient constructor uses a ternary operator on the input argument to default it to /volumes
+        self.volume_prefix = os.environ.get('CEPH_VOLUME_ROOT', None)
+        self.volume_group = os.environ.get('CEPH_VOLUME_GROUP', VOlUME_GROUP)
 
     def _create_conf(self, cluster_name, mons):
         """ Create conf using monitors

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -242,7 +242,6 @@ class CephFSNativeDriver(object):
         """
         client_entity = "client.{0}".format(auth_id)
         path = self.volume_client._get_path(volume_path)
-        path = self.volume_client._get_path(volume_path)
         pool_name = self.volume_client._get_ancestor_xattr(path, "ceph.dir.layout.pool")
         namespace = self.volume_client.fs.getxattr(path, "ceph.dir.layout.pool_namespace")
 

--- a/ceph/cephfs/example/class.yaml
+++ b/ceph/cephfs/example/class.yaml
@@ -8,4 +8,5 @@ parameters:
     adminId: admin
     adminSecretName: ceph-secret-admin
     adminSecretNamespace: "kube-system"
+    claimRoot: /volumes/kubernetes
 


### PR DESCRIPTION
Think I got everything covered.  This is tested and working on my local (1.9.4) Kube with some changes to the RBAC stuff.  I'm going to submit those RBAC changes in a separate PR to keep changes compartmentalized.

By the way, I have no idea why that L is lower-case in `VOlUME_GROUP`, but I can change that too if desired :)

This fixes #406.