### PR TITLE
[cephfs] RBAC, security, and deployment improvements

### DIFF
--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -65,7 +65,6 @@ kubectl create -f example/test-pod.yaml
 
 * Kernel CephFS doesn't work with SELinux, setting SELinux label in Pod's securityContext will not work.
 * Kernel CephFS doesn't support quota or capacity, capacity requested by PVC is not enforced or validated.
-* Currently each Ceph user created by the provisioner has `allow r` MDS cap to permit CephFS mount.
 
 ## Acknowledgement
 

--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -22,12 +22,11 @@ make push
 
 See https://kubernetes.io/.
 
-* Create a Ceph admin secret
+* Import the Ceph admin secret to Kubernetes
 
 ```bash
-ceph auth get client.admin 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
 kubectl create ns cephfs
-kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=cephfs
+kubectl create secret generic ceph-secret-admin --from-literal=secret="$(ceph auth get-key client.admin)" --namespace=cephfs
 ```
 
 * Start CephFS provisioner

--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -64,6 +64,19 @@ kubectl create -f example/test-pod.yaml
 
 * Kernel CephFS doesn't work with SELinux, setting SELinux label in Pod's securityContext will not work.
 * Kernel CephFS doesn't support quota or capacity, capacity requested by PVC is not enforced or validated.
+* If you don't set `PROVISIONER_SECRET_NAMESPACE` as in `deploy/rbac/deployment.yaml`, your serviceaccount will need create/delete permissions on secrets cluster-wide; the following changes to deploy/rbac/clusterrole.yaml will get it working:
+```diff
+--- deploy/rbac/clusterrole.yaml
++++ deploy/rbac/clusterrole.yaml
+@@ -16,3 +16,7 @@ rules:
+   - apiGroups: [""]
+     resources: ["events"]
+     verbs: ["list", "watch", "create", "update", "patch"]
++  - apiGroups: [""]
++    resources: ["secrets"]
++    verbs: ["create", "delete"]
++
+```
 
 ## Acknowledgement
 

--- a/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
+++ b/ceph/cephfs/cephfs_provisioner/cephfs_provisioner.py
@@ -120,7 +120,7 @@ class CephFSNativeDriver(object):
         # permissions to access the share
         client_entity = "client.{0}".format(auth_id)
         want_access_level = 'r' if readonly else 'rw'
-        want_mds_cap = 'allow r,allow {0} path={1}'.format(want_access_level, path)
+        want_mds_cap = 'allow {0} path={1}'.format(want_access_level, path)
         want_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
             want_access_level, pool_name, namespace)
 

--- a/ceph/cephfs/deploy/rbac/clusterrole.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrole.yaml
@@ -16,7 +16,4 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["create", "delete"]
 

--- a/ceph/cephfs/deploy/rbac/clusterrole.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrole.yaml
@@ -16,3 +16,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "delete"]
+

--- a/ceph/cephfs/deploy/rbac/deployment.yaml
+++ b/ceph/cephfs/deploy/rbac/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         env:
         - name: PROVISIONER_NAME
           value: ceph.com/cephfs
+        - name: PROVISIONER_SECRET_NAMESPACE
+          value: cephfs
         command:
         - "/usr/local/bin/cephfs-provisioner"
         args:

--- a/ceph/cephfs/example/class.yaml
+++ b/ceph/cephfs/example/class.yaml
@@ -7,5 +7,5 @@ parameters:
     monitors: 172.24.0.6:6789
     adminId: admin
     adminSecretName: ceph-secret-admin
-    adminSecretNamespace: "kube-system"
+    adminSecretNamespace: "cephfs"
 


### PR DESCRIPTION
This does a handful of small things to smooth deployments and improve security

- Fixes up the example RBAC-enabled deployment with configuration in-repo (adds `PROVISIONER_SECRET_NAMESPACE=cephfs` env, which is necessary in lieu of broad clusterwide secret permissions and enabled by #550)
- Adds a note to the README explaining circumstances under which an admin might need to add clusterwide secret permissions, along with how to do it
- Fixes `adminSecretNamespace` parameter in example storage class to match instructions in README
- Simplifies namespace and admin secret generation
- Removed whole-tree read permissions for generated users - it's highly untenable in terms of security.  Testing with Ceph Luminous + Kubernetes 1.9.4 on Fedora kernel 4.15.3, this does not seem to be necessary - I'd be interested to find out how far back one would have to go before it is necessary