### PR TITLE
Update to allow flex provisioner scripts to specify more volume options

### DIFF
--- a/flex/pkg/volume/delete.go
+++ b/flex/pkg/volume/delete.go
@@ -37,7 +37,7 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	call := p.NewDriverCall(p.execCommand, deleteCmd)
-	call.AppendSpec(volume.Spec.FlexVolume.Options, nil)
+	call.AppendSpec(*volume)
 	output, err := call.Run()
 
 	if err != nil {

--- a/flex/pkg/volume/delete.go
+++ b/flex/pkg/volume/delete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"k8s.io/api/core/v1"
 )
-
+// DeleteOptions serializes parameters for calling delete to the driver.
 type DeleteOptions struct {
 	// volume that is getting deleted
 	Volume *v1.PersistentVolume `json:"volume,omitempty"`

--- a/flex/pkg/volume/delete.go
+++ b/flex/pkg/volume/delete.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"k8s.io/api/core/v1"
 )
+
 // DeleteOptions serializes parameters for calling delete to the driver.
 type DeleteOptions struct {
 	// volume that is getting deleted

--- a/flex/pkg/volume/delete.go
+++ b/flex/pkg/volume/delete.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+type DeleteOptions struct {
+	// volume that is getting deleted
+	Volume *v1.PersistentVolume `json:"volume,omitempty"`
+}
+
 func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	glog.Infof("Delete called for volume:", volume.Name)
 
@@ -37,11 +42,18 @@ func (p *flexProvisioner) Delete(volume *v1.PersistentVolume) error {
 	}
 
 	call := p.NewDriverCall(p.execCommand, deleteCmd)
-	call.AppendSpec(*volume)
+	call.AppendSpec(&DeleteOptions{
+		Volume: volume,
+	})
 	output, err := call.Run()
 
 	if err != nil {
-		glog.Errorf("Failed to delete volume %s, output: %s, error: %s", volume, output.Message, err.Error())
+		outputString := "nil"
+		if output != nil {
+			outputString = output.Message
+		}
+		glog.Errorf("Failed to delete volume %s, output: %s, error: %s", volume, outputString, err.Error())
+
 		return err
 	}
 	return nil

--- a/flex/pkg/volume/driver-call.go
+++ b/flex/pkg/volume/driver-call.go
@@ -31,8 +31,6 @@ const (
 	// Option keys
 	provisionCmd = "provision"
 	deleteCmd    = "delete"
-
-	optionPVorVolumeName = "kubernetes.io/pvOrVolumeName"
 )
 
 // ErrorTimeout defines the time error

--- a/flex/pkg/volume/provision.go
+++ b/flex/pkg/volume/provision.go
@@ -108,7 +108,11 @@ func (p *flexProvisioner) createVolume(volumeOptions *controller.VolumeOptions) 
 	call.AppendSpec(*volumeOptions)
 	output, err := call.Run()
 	if err != nil {
-		glog.Errorf("Failed to create volume %s, output: %s, error: %s", volumeOptions, output.Message, err.Error())
+		outputString := "nil"
+		if output != nil {
+			outputString = output.Message
+		}
+		glog.Errorf("Failed to create volume %s, output: %s, error: %s", volumeOptions, outputString, err.Error())
 		return nil, err
 	}
 	return output, nil

--- a/lib/controller/volume.go
+++ b/lib/controller/volume.go
@@ -64,15 +64,15 @@ func (e *IgnoredError) Error() string {
 // https://github.com/kubernetes/kubernetes/blob/release-1.4/pkg/volume/plugins.go
 type VolumeOptions struct {
 	// Reclamation policy for a persistent volume
-	PersistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy
+	PersistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy,omitempty"`
 	// PV.Name of the appropriate PersistentVolume. Used to generate cloud
 	// volume name.
-	PVName string
+	PVName string `json:"name,omitempty"`
 	// PVC is reference to the claim that lead to provisioning of a new PV.
 	// Provisioners *must* create a PV that would be matched by this PVC,
 	// i.e. with required capacity, accessMode, labels matching PVC.Selector and
 	// so on.
-	PVC *v1.PersistentVolumeClaim
+	PVC *v1.PersistentVolumeClaim `json:"volumeClaim,omitempty"`
 	// Volume provisioning parameters from StorageClass
-	Parameters map[string]string
+	Parameters map[string]string `json:"parameters,omitempty"`
 }


### PR DESCRIPTION
The goal was to allow more range for script provisioners.
1. Different PersistentVolumeSources.

1. All options for flexvolume including the driver

1. Give more info to the Deleter

1. I deleted code that I didn't think was being used



I know that this is a breaking change. I want to use this as opening the conversation on how to accomplish some of these goals.