### PR TITLE
[local-volume] Use RBAC to limit permissions of provisioner node-binding to get nodes

### DIFF
--- a/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -14,6 +14,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: {{ .Values.common.namespace }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding
@@ -24,6 +34,6 @@ subjects:
   namespace: {{ .Values.common.namespace }}
 roleRef:
   kind: ClusterRole
-  name: system:node
+  name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -75,7 +75,7 @@ daemonset:
   #
   # Defines Provisioner's image name including container registry.
   #
-  image: quay.io/external_storage/local-volume-provisioner:latest
+  image: quay.io/external_storage/local-volume-provisioner:v2.1.0
   #
   # Defines Image download policy, see kubernetes documentation for available values.
   #

--- a/local-volume/provisioner/deployment/kubernetes/example/default_example_provisioner_generated.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/example/default_example_provisioner_generated.yaml
@@ -62,8 +62,9 @@ spec:
 
 apiVersion: v1
 kind: ServiceAccount
-metadata:  
+metadata:
   name: local-storage-admin
+  namespace: default
 
 ---
 # Source: provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -83,6 +84,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding
@@ -93,6 +104,6 @@ subjects:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: system:node
+  name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reduces the permissions associated with the local-storage-provisioner-node-binding to get nodes, which are the only required operations. This PR updates the helm templates that generate the RBAC elements.

**Which issue(s) this PR fixes** :
Fixes https://github.com/kubernetes-incubator/external-storage/issues/688

**Special notes for your reviewer**:

Here is the generated yaml from this change.

```
# Source: provisioner/templates/provisioner-cluster-role-binding.yaml

apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: local-storage-provisioner-pv-binding
  namespace: default
subjects:
- kind: ServiceAccount
  name: local-storage-admin
  namespace: default
roleRef:
  kind: ClusterRole
  name: system:persistent-volume-provisioner
  apiGroup: rbac.authorization.k8s.io
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: local-storage-provisioner-node-clusterrole
  namespace: default
rules:
- apiGroups: [""]
  resources: ["nodes"]
  verbs: ["get"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: local-storage-provisioner-node-binding
  namespace: default
subjects:
- kind: ServiceAccount
  name: local-storage-admin
  namespace: default
roleRef:
  kind: ClusterRole
  name: local-storage-provisioner-node-clusterrole
  apiGroup: rbac.authorization.k8s.io
```

`default_example_provisioner_generated.yaml` was generated using the following helm command:
```
helm template ./helm/provisioner > /provisioner/deployment/kubernetes/example/default_example_provisioner_generated.yaml
```