### PR TITLE
Update gce examples with reduced node role

### DIFF
--- a/local-volume/provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_count.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_count.yaml
@@ -74,6 +74,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding
@@ -84,6 +94,6 @@ subjects:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: system:node
+  name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 

--- a/local-volume/provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_volumes.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/gce/provisioner_generated_gce_ssd_volumes.yaml
@@ -82,6 +82,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: local-storage-provisioner-node-binding
@@ -92,6 +102,6 @@ subjects:
   namespace: default
 roleRef:
   kind: ClusterRole
-  name: system:node
+  name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
For GKE, creating ClusterRole is not allowed by default, so the workaround described [here](https://github.com/kubernetes/kubernetes/issues/43409#issuecomment-287912190) must be done.  I will update GKE documentation separately.

/area local-volume