### PR TITLE
Expose prometheus metrics for local volume provisioner

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: bad5b8cc5504a88c060c3135c372b906550627273744530f1af8a53eedf50dac
-updated: 2018-03-05T14:22:31.127141222Z
+hash: b7a0a8aabd23b8fb11f8a6104058aa9d6ae16cf8331dd32afe4a6beb3352d47b
+updated: 2018-04-18T10:57:49.549468703Z
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -649,6 +649,10 @@ imports:
   version: 50ae88d24ede7b8bad68e23c805b5d3da5c8abaf
   subpackages:
   - pkg/util/proto
+- name: k8s.io/kube-state-metrics
+  version: 56fd3e93ab8a6a61473b33fc687a54c6a7f28421
+  subpackages:
+  - collectors/testutils
 - name: k8s.io/kubernetes
   version: 48b7bb56341914b85c76700becadc02b8009d9a0
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -61,3 +61,7 @@ import:
 - package: github.com/digitalocean/godo
   version: ^1.1.1
 - package: github.com/miekg/dns
+- package: k8s.io/kube-state-metrics
+  version: 56fd3e93ab8a6a61473b33fc687a54c6a7f28421
+  subpackages:
+  - collectors/testutils

--- a/local-volume/provisioner/README.md
+++ b/local-volume/provisioner/README.md
@@ -48,3 +48,22 @@ The basic components of the provisioner are as follows:
 - Controller: The controller runs a sync loop that coordinates the other components.
   The discovery and deleter run serially to simplify synchronization with the cache
   and create/delete operations.
+
+## Prometheus Metrics
+
+The metrics are exported through the Prometheus golang client on the HTTP
+endpoint `/metrics` on the listening port (default 8080).
+
+| Metric name                                                   | Metric type | Labels                                                                                                                                                                             |
+| ----------                                                    | ----------- | -----------                                                                                                                                                                        |
+| local_volume_provisioner_persistentvolume_discovery_total     | Counter     | `mode`=&lt;persistentvolume-mode&gt;                                                                                                                                               |
+| local_volume_provisioner_persistentvolume_discovery_duration_seconds   | Histogram   | `mode`=&lt;persistentvolume-mode&gt;                                                                                                                                               |
+| local_volume_provisioner_persistentvolume_delete_total        | Counter     | `mode`=&lt;persistentvolume-mode&gt; <br> `type`=&lt;process&#124;job&gt;                                                                                                          |
+| local_volume_provisioner_persistentvolume_delete_failed_total | Counter     | `mode`=&lt;persistentvolume-mode&gt; <br> `type`=&lt;process&#124;job&gt;                                                                                                          |
+| local_volume_provisioner_persistentvolume_delete_duration_seconds      | Histogram   | `mode`=&lt;persistentvolume-mode&gt; <br> `type`=&lt;process&#124;job&gt; <br> `capacity`=&lt;volume-capacity-breakdown-by-500G&gt; <br> `cleanup_command`=&lt;cleanup-command&gt; |
+| local_volume_provisioner_apiserver_requests_total             | Counter     | `method`=&lt;request-method&gt;                                                                                                                                                    |
+| local_volume_provisioner_apiserver_requests_failed_total      | Counter     | `method`=&lt;request-method&gt;                                                                                                                                                    |
+| local_volume_provisioner_apiserver_requests_duration_seconds           | Histogram   | `method`=&lt;request-method&gt;                                                                                                                                                    |
+| local_volume_provisioner_proctable_running                    | Gauge       |                                                                                                                                                                                    |
+| local_volume_provisioner_proctable_failed                     | Gauge       |                                                                                                                                                                                    |
+| local_volume_provisioner_proctable_succeeded                  | Gauge       |                                                                                                                                                                                    |

--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -18,18 +18,32 @@ package main
 
 import (
 	"flag"
+	"log"
+	"net/http"
 	"os"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/controller"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/metrics"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/metrics/collectors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
+var (
+	optListenAddress string
+	optMetricsPath   string
+)
+
 func main() {
+	flag.StringVar(&optListenAddress, "listen-address", ":8080", "address on which to expose metrics")
+	flag.StringVar(&optMetricsPath, "metrics-path", "/metrics", "path under which to expose metrics")
 	flag.Set("logtostderr", "true")
 	flag.Parse()
 
@@ -61,7 +75,8 @@ func main() {
 	node := getNode(client, nodeName)
 
 	glog.Info("Starting controller\n")
-	controller.StartLocalController(client, &common.UserConfig{
+	procTable := deleter.NewProcTable()
+	go controller.StartLocalController(client, procTable, &common.UserConfig{
 		Node:              node,
 		DiscoveryMap:      provisionerConfig.StorageClassConfig,
 		NodeLabelsForPV:   provisionerConfig.NodeLabelsForPV,
@@ -70,6 +85,21 @@ func main() {
 		Namespace:         namespace,
 		JobContainerImage: jobImage,
 	})
+
+	glog.Infof("Starting metrics server at %s\n", optListenAddress)
+	prometheus.MustRegister([]prometheus.Collector{
+		metrics.PersistentVolumeDiscoveryTotal,
+		metrics.PersistentVolumeDiscoveryDurationSeconds,
+		metrics.PersistentVolumeDeleteTotal,
+		metrics.PersistentVolumeDeleteDurationSeconds,
+		metrics.PersistentVolumeDeleteFailedTotal,
+		metrics.APIServerRequestsTotal,
+		metrics.APIServerRequestsFailedTotal,
+		metrics.APIServerRequestsDurationSeconds,
+		collectors.NewProcTableCollector(procTable),
+	}...)
+	http.Handle(optMetricsPath, promhttp.Handler())
+	log.Fatal(http.ListenAndServe(optListenAddress, nil))
 }
 
 func getNode(client *kubernetes.Clientset, name string) *v1.Node {

--- a/local-volume/provisioner/deployment/kubernetes/example/default_example_service.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/example/default_example_service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: local-volume-provisioner
+  namespace: default 
+  labels:
+    app: local-volume-provisioner
+spec:
+  type: ClusterIP
+  selector:
+    app: local-volume-provisioner
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 // StartLocalController starts the sync loop for the local PV discovery and deleter
-func StartLocalController(client *kubernetes.Clientset, config *common.UserConfig) {
+func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable, config *common.UserConfig) {
 	glog.Info("Initializing volume cache\n")
 
 	provisionerName := fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
@@ -74,7 +74,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 		go jobController.Run(stopCh)
 		glog.Infof("Enabling Jobs based cleaning.")
 	}
-	cleanupTracker := &deleter.CleanupStatusTracker{ProcTable: deleter.NewProcTable(), JobController: jobController}
+	cleanupTracker := &deleter.CleanupStatusTracker{ProcTable: ptable, JobController: jobController}
 
 	discoverer, err := discovery.NewDiscoverer(runtimeConfig, cleanupTracker)
 	if err != nil {

--- a/local-volume/provisioner/pkg/metrics/collectors/proc_table_collector.go
+++ b/local-volume/provisioner/pkg/metrics/collectors/proc_table_collector.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	procTableRunning = prometheus.NewDesc(
+		prometheus.BuildFQName("", metrics.LocalVolumeProvisionerSubsystem, "proctable_running"),
+		"Number of running operations in proctable.",
+		[]string{}, nil,
+	)
+	procTableSucceeded = prometheus.NewDesc(
+		prometheus.BuildFQName("", metrics.LocalVolumeProvisionerSubsystem, "proctable_succeeded"),
+		"Number of succeeded operations in proctable.",
+		[]string{}, nil,
+	)
+	procTableFailed = prometheus.NewDesc(
+		prometheus.BuildFQName("", metrics.LocalVolumeProvisionerSubsystem, "proctable_failed"),
+		"Number of failed operations in proctable.",
+		[]string{}, nil,
+	)
+)
+
+type procTableCollector struct {
+	procTable deleter.ProcTable
+}
+
+// NewProcTableCollector creates a process table
+func NewProcTableCollector(procTable deleter.ProcTable) prometheus.Collector {
+	return &procTableCollector{procTable: procTable}
+}
+
+// Describe implements the prometheus.Collector interface.
+func (collector *procTableCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- procTableRunning
+	ch <- procTableSucceeded
+	ch <- procTableFailed
+}
+
+// Collect implements the prometheus.Collector interface.
+func (collector *procTableCollector) Collect(ch chan<- prometheus.Metric) {
+	stats := collector.procTable.Stats()
+	addGauge := func(desc *prometheus.Desc, v float64, lv ...string) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v, lv...)
+	}
+	addGauge(procTableRunning, float64(stats.Running))
+	addGauge(procTableSucceeded, float64(stats.Succeeded))
+	addGauge(procTableFailed, float64(stats.Failed))
+}

--- a/local-volume/provisioner/pkg/metrics/collectors/proc_table_collector_test.go
+++ b/local-volume/provisioner/pkg/metrics/collectors/proc_table_collector_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
+	"k8s.io/kube-state-metrics/collectors/testutils"
+)
+
+func newUint64Pointer(i uint64) *uint64 {
+	return &i
+}
+
+func TestProcTableCollector(t *testing.T) {
+	// Fixed metadata on type and help text. We prepend this to every expected
+	// output so we only have to modify a single place when doing adjustments.
+	const metadata = `
+		# HELP local_volume_provisioner_proctable_succeeded Number of succeeded operations in proctable.
+		# TYPE local_volume_provisioner_proctable_succeeded gauge
+		# HELP local_volume_provisioner_proctable_failed Number of failed operations in proctable.
+		# TYPE local_volume_provisioner_proctable_failed gauge
+		# HELP local_volume_provisioner_proctable_running Number of running operations in proctable.
+		# TYPE local_volume_provisioner_proctable_running gauge
+	`
+
+	var (
+		want = metadata + `
+			local_volume_provisioner_proctable_running 2
+			local_volume_provisioner_proctable_succeeded 2
+			local_volume_provisioner_proctable_failed 1
+			`
+
+		metrics = []string{
+			"local_volume_provisioner_proctable_running",
+			"local_volume_provisioner_proctable_succeeded",
+			"local_volume_provisioner_proctable_failed",
+		}
+	)
+
+	fakeProcTable := deleter.NewFakeProcTable()
+	fakeProcTable.MarkRunning("pv1")
+	fakeProcTable.MarkRunning("pv2")
+	fakeProcTable.MarkRunning("pv3")
+	fakeProcTable.MarkRunning("pv4")
+	fakeProcTable.MarkRunning("pv5")
+	fakeProcTable.MarkSucceeded("pv1")
+	fakeProcTable.MarkFailed("pv2")
+	fakeProcTable.MarkSucceeded("pv3")
+	if err := testutils.GatherAndCompare(&procTableCollector{procTable: fakeProcTable}, want, metrics); err != nil {
+		t.Errorf("unexpected collecting result:\n%s", err)
+	}
+}

--- a/local-volume/provisioner/pkg/metrics/metrics.go
+++ b/local-volume/provisioner/pkg/metrics/metrics.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"math"
+
+	esUtil "github.com/kubernetes-incubator/external-storage/lib/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// LocalVolumeProvisionerSubsystem is prometheus subsystem name.
+	LocalVolumeProvisionerSubsystem = "local_volume_provisioner"
+	// APIServerRequestCreate represents metrics related to create resource request.
+	APIServerRequestCreate = "create"
+	// APIServerRequestDelete represents metrics related to delete resource request.
+	APIServerRequestDelete = "delete"
+	// DeleteTypeProcess represents metrics releated deletion in process.
+	DeleteTypeProcess = "process"
+	// DeleteTypeJob represents metrics releated deletion by job.
+	DeleteTypeJob = "job"
+)
+
+var (
+	// PersistentVolumeDiscoveryTotal is used to collect accumulated count of persistent volumes discoveried.
+	PersistentVolumeDiscoveryTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_discovery_total",
+			Help:      "Total number of persistent volumes discoveried. Broken down by persistent volume mode.",
+		},
+		[]string{"mode"},
+	)
+	// PersistentVolumeDiscoveryDurationSeconds is used to collect latency in seconds to discovery persistent volumes.
+	PersistentVolumeDiscoveryDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_discovery_duration_seconds",
+			Help:      "Latency in seconds to discovery persistent volumes. Broken down by persistent volume mode.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"mode"},
+	)
+	// PersistentVolumeDeleteTotal is used to collect accumulated count of persistent volumes deleted.
+	PersistentVolumeDeleteTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_delete_total",
+			Help:      "Total number of persistent volumes deleteed. Broken down by persistent volume mode, delete type (process or job).",
+		},
+		[]string{"mode", "type"},
+	)
+	// PersistentVolumeDeleteFailedTotal is used to collect accumulated count of persistent volume delete failed attempts.
+	PersistentVolumeDeleteFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_delete_failed_total",
+			Help:      "Total number of persistent volume delete failed attempts. Broken down by persistent volume mode, delete type (process or job).",
+		},
+		[]string{"mode", "type"},
+	)
+	// PersistentVolumeDeleteDurationSeconds is used to collect latency in seconds to delete persistent volumes.
+	PersistentVolumeDeleteDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "persistentvolume_delete_duration_seconds",
+			Help:      "Latency in seconds to delete persistent volumes. Broken down by persistent volume mode, delete type (process or job), capacity and cleanup_command.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"mode", "type", "capacity", "cleanup_command"},
+	)
+	// APIServerRequestsTotal is used to collect accumulated count of apiserver requests.
+	APIServerRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "apiserver_requests_total",
+			Help:      "Total number of apiserver requests. Broken down by method.",
+		},
+		[]string{"method"},
+	)
+	// APIServerRequestsFailedTotal is used to collect accumulated count of apiserver requests failed.
+	APIServerRequestsFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "apiserver_requests_failed_total",
+			Help:      "Total number of apiserver requests failed. Broken down by method.",
+		},
+		[]string{"method"},
+	)
+	// APIServerRequestsDurationSeconds is used to collect latency in seconds of apiserver requests.
+	APIServerRequestsDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: LocalVolumeProvisionerSubsystem,
+			Name:      "apiserver_requests_duration_seconds",
+			Help:      "Latency in seconds of apiserver requests. Broken down by method.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"method"},
+	)
+)
+
+// CapacityBreakDown breaks capacity down into every 500G, e.g.
+//	[0]: 0G
+//	(0, 500G]: 500G
+//	(500G, 1000G]: 1000G
+//	(1000G, 1500G]: 1500G
+func CapacityBreakDown(capacityBytes int64) string {
+	n := int64(math.Ceil(float64(capacityBytes) / float64(500*esUtil.GiB)))
+	return fmt.Sprintf("%dG", n*500)
+}

--- a/local-volume/provisioner/pkg/metrics/metrics_test.go
+++ b/local-volume/provisioner/pkg/metrics/metrics_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	esUtil "github.com/kubernetes-incubator/external-storage/lib/util"
+)
+
+func TestCapacityBreakDown(t *testing.T) {
+	testcases := []struct {
+		capacityBytes  int64
+		expectedString string
+	}{
+		{
+			0,
+			"0G",
+		},
+		{
+			1,
+			"500G",
+		},
+		{
+			500 * esUtil.GiB,
+			"500G",
+		},
+		{
+			500*esUtil.GiB + 1,
+			"1000G",
+		},
+		{
+			1000*esUtil.GiB + 1,
+			"1500G",
+		},
+	}
+
+	for _, v := range testcases {
+		got := CapacityBreakDown(v.capacityBytes)
+		if got != v.expectedString {
+			t.Errorf("got %s, expected: %s", got, v.expectedString)
+		}
+	}
+}

--- a/vendor/k8s.io/kube-state-metrics/collectors/testutils/testutils.go
+++ b/vendor/k8s.io/kube-state-metrics/collectors/testutils/testutils.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2018 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutils
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// GatherAndCompare retrieves all metrics exposed by a collector and compares it
+// to an expected output in the Prometheus text exposition format.
+// metricNames allows only comparing the given metrics. All are compared if it's nil.
+func GatherAndCompare(c prometheus.Collector, expected string, metricNames []string) error {
+	expected = removeUnusedWhitespace(expected)
+
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %s", err)
+	}
+	metrics, err := reg.Gather()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %s", err)
+	}
+	if metricNames != nil {
+		metrics = filterMetrics(metrics, metricNames)
+	}
+	var tp expfmt.TextParser
+	expectedMetrics, err := tp.TextToMetricFamilies(bytes.NewReader([]byte(expected)))
+	if err != nil {
+		return fmt.Errorf("parsing expected metrics failed: %s", err)
+	}
+
+	if !reflect.DeepEqual(metrics, normalizeMetricFamilies(expectedMetrics)) {
+		// Encode the gathered output to the readbale text format for comparison.
+		var buf1 bytes.Buffer
+		enc := expfmt.NewEncoder(&buf1, expfmt.FmtText)
+		for _, mf := range metrics {
+			if err := enc.Encode(mf); err != nil {
+				return fmt.Errorf("encoding result failed: %s", err)
+			}
+		}
+		// Encode normalized expected metrics again to generate them in the same ordering
+		// the registry does to spot differences more easily.
+		var buf2 bytes.Buffer
+		enc = expfmt.NewEncoder(&buf2, expfmt.FmtText)
+		for _, mf := range normalizeMetricFamilies(expectedMetrics) {
+			if err := enc.Encode(mf); err != nil {
+				return fmt.Errorf("encoding result failed: %s", err)
+			}
+		}
+
+		return fmt.Errorf(`
+metric output does not match expectation; want:
+
+%s
+
+got:
+
+%s
+`, buf2.String(), buf1.String())
+	}
+	return nil
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		drop := true
+		for _, name := range names {
+			if m.GetName() == name {
+				drop = false
+				break
+			}
+		}
+		if !drop {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func removeUnusedWhitespace(s string) string {
+	var (
+		trimmedLine  string
+		trimmedLines []string
+		lines        = strings.Split(s, "\n")
+	)
+
+	for _, l := range lines {
+		trimmedLine = strings.TrimSpace(l)
+
+		if len(trimmedLine) > 0 {
+			trimmedLines = append(trimmedLines, trimmedLine)
+		}
+	}
+
+	// The Prometheus metrics representation parser expects an empty line at the
+	// end otherwise fails with an unexpected EOF error.
+	return strings.Join(trimmedLines, "\n") + "\n"
+}
+
+// The below sorting code is copied form the Prometheus client library modulo the added
+// label pair sorting.
+// https://github.com/prometheus/client_golang/blob/ea6e1db4cb8127eeb0b6954f7320363e5451820f/prometheus/registry.go#L642-L684
+
+// metricSorter is a sortable slice of *dto.Metric.
+type metricSorter []*dto.Metric
+
+func (s metricSorter) Len() int {
+	return len(s)
+}
+
+func (s metricSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s metricSorter) Less(i, j int) bool {
+	sort.Sort(prometheus.LabelPairSorter(s[i].Label))
+	sort.Sort(prometheus.LabelPairSorter(s[j].Label))
+
+	if len(s[i].Label) != len(s[j].Label) {
+		return len(s[i].Label) < len(s[j].Label)
+	}
+
+	for n, lp := range s[i].Label {
+		vi := lp.GetValue()
+		vj := s[j].Label[n].GetValue()
+		if vi != vj {
+			return vi < vj
+		}
+	}
+
+	if s[i].TimestampMs == nil {
+		return false
+	}
+	if s[j].TimestampMs == nil {
+		return true
+	}
+	return s[i].GetTimestampMs() < s[j].GetTimestampMs()
+}
+
+// normalizeMetricFamilies returns a MetricFamily slice with empty
+// MetricFamilies pruned and the remaining MetricFamilies sorted by name within
+// the slice, with the contained Metrics sorted within each MetricFamily.
+func normalizeMetricFamilies(metricFamiliesByName map[string]*dto.MetricFamily) []*dto.MetricFamily {
+	for _, mf := range metricFamiliesByName {
+		sort.Sort(metricSorter(mf.Metric))
+	}
+	names := make([]string, 0, len(metricFamiliesByName))
+	for name, mf := range metricFamiliesByName {
+		if len(mf.Metric) > 0 {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	result := make([]*dto.MetricFamily, 0, len(names))
+	for _, name := range names {
+		result = append(result, metricFamiliesByName[name])
+	}
+	return result
+}


### PR DESCRIPTION
Expose prometheus metrics for local volume provisioner. Then we can monitor its internal, actions running, finished, and latency, etc.