### PR TITLE
[local-volume] Mention that several feature-gates are required for k8s pre-1.10

### DIFF
--- a/local-volume/README.md
+++ b/local-volume/README.md
@@ -88,6 +88,10 @@ If raw local block feature is needed,
 $ export KUBE_FEATURE_GATES="BlockVolume=true"
 ```
 
+Note: Kubernetes versions prior to 1.10 require [several additional
+feature-gates](https://github.com/kubernetes-incubator/external-storage/tree/local-volume-provisioner-v2.0.0/local-volume#enabling-the-alpha-feature-gates) 
+be enabled on all Kubernetes components, because the persistent lcoal volumes and other features were in alpha.
+
 #### Option 1: GCE
 
 GCE clusters brought up with kube-up.sh will automatically format and mount the


### PR DESCRIPTION
This update to the documentation will help people running k8s 1.8 & k8s 1.9, who might have missed the fact that additional feature-gates are required pre-1.10.