### PR TITLE
Local volume dynamic provisioning

### DIFF
--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -3,12 +3,21 @@
 {{- range $tmp, $val := $classPath }}
    {{- range $storageClass, $classConfig := $val }}
 {{ $storageClass }}:
+   {{- if $classConfig.hostDir }}
    hostDir: {{ $classConfig.hostDir }}
    mountDir: {{ if $classConfig.mountDir }} {{$classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
+   {{- end }}
    {{- if $classConfig.blockCleanerCommand }}
    blockCleanerCommand:
    {{- range $tmp, $val := $classConfig.blockCleanerCommand }}
      - "{{ $val -}}"{{- end}}
+   {{- end }}
+   {{- if $classConfig.volumeMode }}
+   volumeMode: {{ $classConfig.volumeMode }}
+   {{- end }}
+   {{- if $classConfig.lvmVolumeGroup }}
+   lvm:
+     volumeGroup: {{ $classConfig.lvmVolumeGroup }}
    {{- end }}
 {{- end}}
 {{- end}}
@@ -61,6 +70,7 @@ data:
 {{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configStorageClass" (.Values.configmap.gcePost19.storageClass) | indent 4 }} {{ end }}
 {{- if eq ( $engine | lower ) "gke" }} {{ include "configStorageClass" (.Values.configmap.gke.storageClass) | indent 4 }} {{ end }}
 {{- if eq ( $engine | lower ) "baremetal" }} {{ include "configStorageClass" (.Values.configmap.baremetal.storageClass) | indent 4 }} {{ end }}
+{{- if .Values.common.dynamic }} {{ include "configStorageClass" (.Values.configmap.lvm.storageClass) | indent 4 }} {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -109,6 +119,10 @@ spec:
 {{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configVolumeMounts" (.Values.configmap.gcePost19.storageClass) | indent 12 }} {{ end }}
 {{- if eq ( $engine | lower ) "gke" }} {{ include "configVolumeMounts" (.Values.configmap.gke.storageClass) | indent 12 }} {{ end }}
 {{- if eq ( $engine | lower ) "baremetal" }} {{ include "configVolumeMounts" (.Values.configmap.baremetal.storageClass) | indent 12 }} {{ end }}
+{{- if .Values.common.dynamic }}
+            - mountPath:  /dev
+              name: lvm-root
+{{- end }}
       volumes:
         - name: provisioner-config
           configMap:
@@ -117,3 +131,8 @@ spec:
 {{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configVolumes" (.Values.configmap.gcePost19.storageClass) | indent 8 }} {{ end }}
 {{- if eq ( $engine | lower ) "gke" }} {{ include "configVolumes" (.Values.configmap.gke.storageClass) | indent 8 }} {{ end }}
 {{- if eq ( $engine | lower ) "baremetal" }} {{ include "configVolumes" (.Values.configmap.baremetal.storageClass) | indent 8 }} {{ end }}
+{{- if .Values.common.dynamic }}
+        - name: lvm-root
+          hostPath:
+            path: /dev
+{{- end }}

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -7,6 +7,10 @@ common:
   # Defines the namespace where provisioner runs
   #
   namespace: default
+  #
+  # Defines whether to enbale dynamic provisioning.
+  #
+  dynamic: true
 configmap:
   #
   # Defines the name of configmap used by Provisioner
@@ -19,8 +23,10 @@ configmap:
   #    - {storage class name}:
   #        hostDir: "{path on the host where local volume of this storage class are mounted}"
   #        mountDir: "{Optional path where a local volume will be mounted inside of a container}"
+  #        volumeMode: "{Optional field to specify intended volume mode of created pvs}"
+  #        lvmVolumeGroup: "{Optional field to specify input lvm volume group for dynamic provisioning}"
   #
-  # Note: At least one storage class must be configuredi, baremetal is used as default if no
+  # Note: At least one storage class must be configured, baremetal is used as default if no
   # explicit environment is specified in helm template command line.
   baremetal:
     storageClass:
@@ -66,6 +72,15 @@ configmap:
           hostDir: "/mnt/disks"
           blockCleanerCommand:
             - "/scripts/quick_reset.sh"
+  #
+  # Storage classes for LVM (dynamic provisioning)
+  lvm:
+    storageClass:
+      - dynamic-lvm:
+          lvmVolumeGroup: vg1
+          blockCleanerCommand:
+            - "/scripts/dd_zero.sh"
+            - "1"
   #
 daemonset:
   #

--- a/local-volume/provisioner/deployment/docker/Dockerfile
+++ b/local-volume/provisioner/deployment/docker/Dockerfile
@@ -17,7 +17,10 @@ FROM centos:7
 RUN yum update -y && \
     yum install -y e2fsprogs && \
     yum install -y hdparm && \
+    yum install -y lvm2 && \
     yum clean all
+
+RUN sed -i.save -e "s#udev_sync = 1#udev_sync = 0#" -e "s#udev_rules = 1#udev_rules = 0#" -e "s#use_lvmetad = 1#use_lvmetad = 0#" /etc/lvm/lvm.conf
 
 ADD local-volume-provisioner /local-provisioner
 ADD scripts /scripts

--- a/local-volume/provisioner/deployment/kubernetes/example/default_example_provisioner_generated.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/example/default_example_provisioner_generated.yaml
@@ -13,7 +13,13 @@ data:
        mountDir:  /mnt/fast-disks 
        blockCleanerCommand:
          - "/scripts/shred.sh"
-         - "2" 
+         - "2"
+    dynamic-lvm:
+       blockCleanerCommand:
+         - "/scripts/dd_zero.sh"
+         - "1"
+       lvm:
+         volumeGroup: vg1
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
@@ -49,14 +55,19 @@ spec:
               readOnly: true             
             - mountPath:  /mnt/fast-disks 
               name: fast-disks
-              mountPropagation: "HostToContainer" 
+              mountPropagation: "HostToContainer"
+            - mountPath:  /dev
+              name: lvm-root
       volumes:
         - name: provisioner-config
           configMap:
             name: local-provisioner-config         
         - name: fast-disks
           hostPath:
-            path: /mnt/fast-disks 
+            path: /mnt/fast-disks
+        - name: lvm-root
+          hostPath:
+            path: /dev
 
 ---
 # Source: provisioner/templates/provisioner-service-account.yaml

--- a/local-volume/provisioner/pkg/capacityreconciler/reconciler.go
+++ b/local-volume/provisioner/pkg/capacityreconciler/reconciler.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityreconciler
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
+
+	storage "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const defaultRetryCount = 3
+const defaultRetryWaitDuration = 2 * time.Second
+
+// The minimum size of provisioned volumes is default to 1Gi
+var defaultMinVolumeSize = resource.MustParse("1Gi")
+
+type capacityGetFuncType func(string) int64
+
+type CapacityReconciler struct {
+	*common.RuntimeConfig
+	capacityGetFunc capacityGetFuncType
+}
+
+func NewReconciler(config *common.RuntimeConfig, capacityGetFunc capacityGetFuncType) *CapacityReconciler {
+	return &CapacityReconciler{
+		RuntimeConfig:   config,
+		capacityGetFunc: capacityGetFunc,
+	}
+}
+
+func (r *CapacityReconciler) Reconcile() {
+	tickerPeriod := time.Second
+	// In case the provisioners on different nodes start in rapid succession,
+	// Let the worker wait for a random portion of tickerPeriod before reconciling.
+	time.Sleep(time.Duration(rand.Float64() * float64(tickerPeriod)))
+	go wait.Until(r.reconcileWorker, 120*time.Second, wait.NeverStop)
+}
+
+func (r *CapacityReconciler) reconcileWorker() {
+	nodeHostName, found := r.Node.Labels[common.NodeLabelKey]
+	if !found {
+		glog.Errorf("Node does not have expected label %s", common.NodeLabelKey)
+		return
+	}
+	for className := range r.ProvisionSourceMap {
+		// Return true if need to retry
+		workFunc := func() bool {
+			// Size in GiB
+			actualSize := r.capacityGetFunc(className) / (1024 * 1024 * 1024)
+			actualCapacity := resource.MustParse(fmt.Sprintf("%dGi", actualSize))
+			class, err := r.APIUtil.GetStorageClass(className)
+			if err != nil {
+				glog.Errorf("Failed to get storage class %q: %v", className, err)
+				return true
+			}
+			classStatus := class.Status
+			if classStatus == nil || classStatus.Capacity == nil {
+				classStatus = &storage.StorageClassStatus{
+					Capacity: &storage.StorageClassCapacity{
+						MinVolumeSize: defaultMinVolumeSize,
+						TopologyKeys:  []string{common.NodeLabelKey},
+						Capacities:    make(map[string]resource.Quantity),
+					},
+				}
+				class.Status = classStatus
+			}
+			if len(classStatus.Capacity.TopologyKeys) != 1 ||
+				classStatus.Capacity.TopologyKeys[0] != common.NodeLabelKey {
+				glog.Errorf("Topology Key in storage class %q is not %q, but %v", className, common.NodeLabelKey, classStatus.Capacity.TopologyKeys)
+				// TODO: Should we modify the topology key if not match?
+				return false
+			}
+			recordedCapacity, ok := classStatus.Capacity.Capacities[nodeHostName]
+			if ok {
+				if recordedCapacity.Cmp(actualCapacity) == 0 {
+					// Skip if capacity not changed
+					return false
+				}
+			}
+
+			classStatus.Capacity.Capacities[nodeHostName] = actualCapacity
+			if _, err := r.APIUtil.UpdateStorageClassStatus(class); err != nil {
+				glog.Errorf("Failed to update storage class %q: %v", className, err)
+				return true
+			}
+			return false
+		}
+		for i := 0; i <= defaultRetryCount; i++ {
+			if shouldRetry := workFunc(); !shouldRetry {
+				glog.Infof("Capacity reconcile of storage class %q finished", className)
+				return
+			}
+			time.Sleep(defaultRetryWaitDuration)
+		}
+	}
+}

--- a/local-volume/provisioner/pkg/capacityreconciler/reconciler_test.go
+++ b/local-volume/provisioner/pkg/capacityreconciler/reconciler_test.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacityreconciler
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
+
+	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	testNodeName = "test-node"
+	testClass    = "sc1"
+	capacity1Gi  = 1 * 1024 * 1024 * 1024
+	capacity2Gi  = 2 * 1024 * 1024 * 1024
+)
+
+type testConfig struct {
+	// Pre-installed storage classes
+	classes map[string]*storagev1.StorageClass
+	// Classes after update
+	expectedClasses map[string]*storagev1.StorageClass
+	// True if testing api failure
+	apiShouldFail bool
+	// The rest are set during setup
+	apiUtil *util.FakeAPIUtil
+}
+
+var testNode = &v1.Node{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: testNodeName,
+		Labels: map[string]string{
+			common.NodeLabelKey: testNodeName,
+		},
+	},
+}
+
+var scMapping = map[string]common.ProvisionSourceConfig{
+	testClass: {
+		Fake: &common.FakeSource{
+			Capacity: capacity2Gi,
+			RootPath: "dir1",
+		},
+	},
+}
+
+func getCapacity(className string) int64 {
+	sc, exist := scMapping[className]
+	if !exist {
+		return 0
+	}
+	return sc.Fake.Capacity
+}
+
+func makeClass(name, topologyKey string, size int64) *storagev1.StorageClass {
+	class := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if topologyKey != "" {
+		size := *resource.NewQuantity(size, resource.BinarySI)
+		class.Status = &storagev1.StorageClassStatus{
+			Capacity: &storagev1.StorageClassCapacity{
+				MinVolumeSize: defaultMinVolumeSize,
+				TopologyKeys:  []string{topologyKey},
+				Capacities:    map[string]resource.Quantity{testNodeName: size},
+			},
+		}
+	}
+	return class
+}
+
+func testSetup(t *testing.T, test *testConfig) *CapacityReconciler {
+	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, cache.NewVolumeCache(), test.classes)
+
+	userConfig := &common.UserConfig{
+		Node:               testNode,
+		ProvisionSourceMap: scMapping,
+	}
+	runConfig := &common.RuntimeConfig{
+		UserConfig: userConfig,
+		APIUtil:    test.apiUtil,
+	}
+	return NewReconciler(runConfig, getCapacity)
+}
+
+func TestReconcileCapacity_Changed(t *testing.T) {
+	test := &testConfig{
+		classes: map[string]*storagev1.StorageClass{
+			testClass: makeClass(testClass, common.NodeLabelKey, capacity1Gi),
+		},
+		expectedClasses: map[string]*storagev1.StorageClass{
+			// Should update capacity with capacity reported by the backend
+			testClass: makeClass(testClass, common.NodeLabelKey, capacity2Gi),
+		},
+		apiShouldFail: false,
+	}
+	s := testSetup(t, test)
+	s.reconcileWorker()
+
+	verifyStorageClass(t, test)
+}
+
+func TestReconcileCapacity_Initialized(t *testing.T) {
+	test := &testConfig{
+		classes: map[string]*storagev1.StorageClass{
+			testClass: makeClass(testClass, "", 0),
+		},
+		expectedClasses: map[string]*storagev1.StorageClass{
+			// Should init capacity with capacity reported by the backend
+			testClass: makeClass(testClass, common.NodeLabelKey, capacity2Gi),
+		},
+		apiShouldFail: false,
+	}
+	s := testSetup(t, test)
+	s.reconcileWorker()
+
+	verifyStorageClass(t, test)
+}
+
+func TestReconcileCapacity_InvalidTokpologyKey(t *testing.T) {
+	test := &testConfig{
+		classes: map[string]*storagev1.StorageClass{
+			testClass: makeClass(testClass, "invalid-key", 0),
+		},
+		expectedClasses: map[string]*storagev1.StorageClass{
+			// Should skip if key not equal to "kubernetes.io/hostname"
+			testClass: makeClass(testClass, "invalid-key", 0),
+		},
+		apiShouldFail: false,
+	}
+	s := testSetup(t, test)
+	s.reconcileWorker()
+
+	verifyStorageClass(t, test)
+}
+
+func TestReconcileCapacity_UpdateClassFails(t *testing.T) {
+	test := &testConfig{
+		classes: map[string]*storagev1.StorageClass{
+			testClass: makeClass(testClass, common.NodeLabelKey, capacity1Gi),
+		},
+		expectedClasses: map[string]*storagev1.StorageClass{
+			// Capacity not changed if failed to update class object
+			testClass: makeClass(testClass, common.NodeLabelKey, capacity1Gi),
+		},
+		apiShouldFail: true,
+	}
+	s := testSetup(t, test)
+	s.reconcileWorker()
+
+	verifyStorageClass(t, test)
+}
+
+func verifyStorageClass(t *testing.T, test *testConfig) {
+	for name, expectedClass := range test.expectedClasses {
+		storedClass, err := test.apiUtil.GetStorageClass(name)
+		if err != nil {
+			t.Errorf("Could not get storage class %s: %v", name, err)
+		}
+		storedCapacity, initialized := getClassCapacity(storedClass)
+		expectedCapacity, expectInitialized := getClassCapacity(expectedClass)
+		if initialized != expectInitialized ||
+			storedCapacity.Cmp(expectedCapacity) != 0 {
+			t.Errorf("Expected class %v, got %v", expectedClass, storedClass)
+		}
+	}
+}
+
+func getClassCapacity(class *storagev1.StorageClass) (resource.Quantity, bool) {
+	if class.Status == nil || class.Status.Capacity == nil {
+		return resource.MustParse("0"), false
+	}
+	return class.Status.Capacity.Capacities[testNodeName], true
+}

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
@@ -51,6 +52,9 @@ const (
 
 	// DefaultBlockCleanerCommand is the default block device cleaning command
 	DefaultBlockCleanerCommand = "/scripts/quick_reset.sh"
+
+	// DefaultVolumeMode is the default volume mode of discovered volumes
+	DefaultVolumeMode = "Filesystem"
 
 	// EventVolumeFailedDelete copied from k8s.io/kubernetes/pkg/controller/volume/events
 	EventVolumeFailedDelete = "VolumeFailedDelete"
@@ -73,14 +77,22 @@ const (
 
 	// NodeNameLabel is the name of the label that holds the nodename
 	NodeNameLabel = "kubernetes.io/hostname"
+
+	// TODO: make the paths configurable if needed
+	LvmRootPath    = "/dev"
+	LvmMountedPath = "/dev"
 )
 
 // UserConfig stores all the user-defined parameters to the provisioner
 type UserConfig struct {
 	// Node object for this node
 	Node *v1.Node
-	// key = storageclass, value = mount configuration for the storageclass
-	DiscoveryMap map[string]MountConfig
+	// Name of the provisioner
+	ProvisionerName string
+	// key = storageclass, value = discovery configuration for the storageclass
+	DiscoveryMap map[string]DiscoveryConfig
+	// key = storageclass, value = provision source configuration for the storageclass
+	ProvisionSourceMap map[string]ProvisionSourceConfig
 	// Labels and their values that are added to PVs created by the provisioner
 	NodeLabelsForPV []string
 	// UseAlphaAPI shows if we need to use alpha API
@@ -93,21 +105,66 @@ type UserConfig struct {
 	JobContainerImage string
 }
 
-// MountConfig stores a configuration for discoverying a specific storageclass
-type MountConfig struct {
+// StorageClassConfig stores a configuration for discoverying and provisioning a specific storageclass
+type StorageClassConfig struct {
 	// The hostpath directory
 	HostDir string `json:"hostDir" yaml:"hostDir"`
 	// The mount point of the hostpath volume
 	MountDir string `json:"mountDir" yaml:"mountDir"`
 	// The type of block cleaner to use
 	BlockCleanerCommand []string `json:"blockCleanerCommand" yaml:"blockCleanerCommand"`
+	// Intended volume mode of discovered volumes
+	VolumeMode string `json:"volumeMode" yaml:"volumeMode"`
+	// Configuration for dynamically provisioning with lvm
+	Lvm LvmSource `json:"lvm" yaml:"lvm"`
+
+	// placeholder for other potential sources
+}
+
+// LvmSource stores source of provisioning for LVM
+type LvmSource struct {
+	// Volume group name of the source
+	VolumeGroup string `json:"volumeGroup" yaml:"volumeGroup"`
+}
+
+// Used for test
+type FakeSource struct {
+	Capacity int64
+	RootPath string
+}
+
+// MountConfig stores a pair of mounted paths, along with potential cleanup commands.
+type MountConfig struct {
+	// The hostpath directory
+	HostDir string
+	// The mount point of the hostpath volume
+	MountDir string
+	// The type of block cleaner to use
+	BlockCleanerCommand []string
+}
+
+// DiscoveryConfig stores a configuration for discoverying a specific storageclass
+type DiscoveryConfig struct {
+	*MountConfig
+	// Intended volume mode of discovered volumes
+	VolumeMode v1.PersistentVolumeMode
+}
+
+// ProvisionSourceConfig stores a configuration for provisioning a specific storageclass
+type ProvisionSourceConfig struct {
+	*MountConfig
+	// Source of provisioning for LVM
+	Lvm *LvmSource
+
+	Fake *FakeSource
+	// placeholder for other potential sources
 }
 
 // RuntimeConfig stores all the objects that the provisioner needs to run
 type RuntimeConfig struct {
 	*UserConfig
-	// Unique name of this provisioner
-	Name string
+	// Unique tag of this provisioner
+	Tag string
 	// K8s API client
 	Client *kubernetes.Clientset
 	// Cache to store PVs managed by this provisioner
@@ -122,20 +179,26 @@ type RuntimeConfig struct {
 	BlockDisabled bool
 	// Mounter used to verify mountpoints
 	Mounter mount.Interface
+	// Queue to trigger dynamic provision
+	ProvisionQueue *workqueue.Type
 }
 
 // LocalPVConfig defines the parameters for creating a local PV
 type LocalPVConfig struct {
-	Name            string
-	HostPath        string
-	Capacity        int64
-	StorageClass    string
-	ProvisionerName string
-	UseAlphaAPI     bool
-	AffinityAnn     string
-	NodeAffinity    *v1.VolumeNodeAffinity
-	VolumeMode      v1.PersistentVolumeMode
-	Labels          map[string]string
+	Name           string
+	HostPath       string
+	Capacity       int64
+	StorageClass   string
+	ProvisionerTag string
+	UseAlphaAPI    bool
+	AffinityAnn    string
+	NodeAffinity   *v1.VolumeNodeAffinity
+	VolumeMode     v1.PersistentVolumeMode
+	Labels         map[string]string
+	AccessModes    []v1.PersistentVolumeAccessMode
+	ReclaimPolicy  v1.PersistentVolumeReclaimPolicy
+	AdditionalAnn  map[string]string
+	ClaimRef       *v1.ObjectReference
 }
 
 // BuildConfigFromFlags being defined to enable mocking during unit testing
@@ -150,7 +213,7 @@ var InClusterConfig = rest.InClusterConfig
 // TODO Need to find a way to marshal the struct more efficiently.
 type ProvisionerConfiguration struct {
 	// StorageClassConfig defines configuration of Provisioner's storage classes
-	StorageClassConfig map[string]MountConfig `json:"storageClassMap" yaml:"storageClassMap"`
+	StorageClassConfig map[string]StorageClassConfig `json:"storageClassMap" yaml:"storageClassMap"`
 	// NodeLabelsForPV contains a list of node labels to be copied to the PVs created by the provisioner
 	// +optional
 	NodeLabelsForPV []string `json:"nodeLabelsForPV" yaml:"nodeLabelsForPV"`
@@ -169,11 +232,11 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 			Name:   config.Name,
 			Labels: config.Labels,
 			Annotations: map[string]string{
-				AnnProvisionedBy: config.ProvisionerName,
+				AnnProvisionedBy: config.ProvisionerTag,
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+			PersistentVolumeReclaimPolicy: config.ReclaimPolicy,
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): *resource.NewQuantity(int64(config.Capacity), resource.BinarySI),
 			},
@@ -182,11 +245,10 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 					Path: config.HostPath,
 				},
 			},
-			AccessModes: []v1.PersistentVolumeAccessMode{
-				v1.ReadWriteOnce,
-			},
+			AccessModes:      config.AccessModes,
 			StorageClassName: config.StorageClass,
 			VolumeMode:       &config.VolumeMode,
+			ClaimRef:         config.ClaimRef,
 		},
 	}
 	if config.UseAlphaAPI {
@@ -194,6 +256,11 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 	} else {
 		pv.Spec.NodeAffinity = config.NodeAffinity
 	}
+
+	for key, value := range config.AdditionalAnn {
+		pv.Annotations[key] = value
+	}
+
 	return pv
 }
 
@@ -254,6 +321,7 @@ func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *Prov
 		return fmt.Errorf("fail to Unmarshal yaml due to: %#v", err)
 	}
 	for class, config := range provisionerConfig.StorageClassConfig {
+		// Initialize BlockCleanerCommand
 		if config.BlockCleanerCommand == nil {
 			// Supply a default block cleaner command.
 			config.BlockCleanerCommand = []string{DefaultBlockCleanerCommand}
@@ -263,15 +331,29 @@ func ConfigMapDataToVolumeConfig(data map[string]string, provisionerConfig *Prov
 				return fmt.Errorf("Invalid empty block cleaner command for class %v", class)
 			}
 		}
+		// Initialize VolumeMode
+		if config.VolumeMode == "" {
+			config.VolumeMode = DefaultVolumeMode
+		} else {
+			mode := v1.PersistentVolumeMode(config.VolumeMode)
+			if mode != v1.PersistentVolumeBlock && mode != v1.PersistentVolumeFilesystem {
+				return fmt.Errorf("Storage Class %v is misconfigured, invalid volume mode: %s", class, config.VolumeMode)
+			}
+		}
 		if config.MountDir == "" || config.HostDir == "" {
-			return fmt.Errorf("Storage Class %v is misconfigured, missing HostDir or MountDir parameter", class)
+			if config.Lvm.VolumeGroup == "" {
+				// The config item is for static discovery
+				return fmt.Errorf("Storage Class %v is misconfigured, missing HostDir or MountDir parameter", class)
+			}
 		}
 		provisionerConfig.StorageClassConfig[class] = config
-		glog.Infof("StorageClass %q configured with MountDir %q, HostDir %q, BlockCleanerCommand %q",
+		glog.Infof("StorageClass %q configured with MountDir %q, HostDir %q, BlockCleanerCommand %q, VolumeMode %q, LVM config %v",
 			class,
 			config.MountDir,
 			config.HostDir,
-			config.BlockCleanerCommand)
+			config.BlockCleanerCommand,
+			config.VolumeMode,
+			config.Lvm)
 	}
 	return nil
 }
@@ -307,6 +389,50 @@ func LoadProvisionerConfigs(configPath string, provisionerConfig *ProvisionerCon
 		}
 	}
 	return ConfigMapDataToVolumeConfig(data, provisionerConfig)
+}
+
+// GetDiscoveryConfigsFromProvisionerConfigs generate a DiscoveryConfig map from ProvisionerConfiguration for volume discovery.
+func GetDiscoveryConfigsFromProvisionerConfigs(provisionerConfig *ProvisionerConfiguration) map[string]DiscoveryConfig {
+	discoveryConfigs := make(map[string]DiscoveryConfig)
+	for class, config := range provisionerConfig.StorageClassConfig {
+		if config.Lvm.VolumeGroup != "" {
+			// Skip config items for dynamically provision
+			continue
+		}
+		discoveryConfig := DiscoveryConfig{
+			MountConfig: &MountConfig{
+				MountDir:            config.MountDir,
+				HostDir:             config.HostDir,
+				BlockCleanerCommand: config.BlockCleanerCommand,
+			},
+			VolumeMode: v1.PersistentVolumeMode(config.VolumeMode),
+		}
+		discoveryConfigs[class] = discoveryConfig
+	}
+	return discoveryConfigs
+}
+
+// GetStorageSourceConfigsFromProvisionerConfigs generate a storage source config map from ProvisionerConfiguration
+// for volume provisioning.
+func GetStorageSourceConfigsFromProvisionerConfigs(provisionerConfig *ProvisionerConfiguration) map[string]ProvisionSourceConfig {
+	sourceConfigs := make(map[string]ProvisionSourceConfig)
+	for class, config := range provisionerConfig.StorageClassConfig {
+		if config.Lvm.VolumeGroup != "" {
+			sourceConfig := ProvisionSourceConfig{
+				Lvm: &LvmSource{
+					VolumeGroup: config.Lvm.VolumeGroup,
+				},
+				MountConfig: &MountConfig{
+					MountDir:            LvmMountedPath,
+					HostDir:             LvmRootPath,
+					BlockCleanerCommand: config.BlockCleanerCommand,
+				},
+			}
+			sourceConfigs[class] = sourceConfig
+		}
+
+	}
+	return sourceConfigs
 }
 
 // SetupClient created client using either in-cluster configuration or if KUBECONFIG environment variable is specified then using that config.

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -46,6 +46,13 @@ import (
 const (
 	// AnnProvisionedBy is the external provisioner annotation in PV object
 	AnnProvisionedBy = "pv.kubernetes.io/provisioned-by"
+	// AnnSelectedNode is added to a PVC that has been triggered by scheduler to
+	// be dynamically provisioned. Its value is the name of the selected node.
+	AnnSelectedNode = "volume.alpha.kubernetes.io/selected-node"
+	// This annotation is added to a PVC that is supposed to be dynamically
+	// provisioned. Its value is name of volume plugin that is supposed to provision
+	// a volume for this PVC.
+	AnnStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 	// NodeLabelKey is the label key that this provisioner uses for PV node affinity
 	// hostname is not the best choice, but it's what pod and node affinity also use
 	NodeLabelKey = apis.LabelHostname

--- a/local-volume/provisioner/pkg/common/common_test.go
+++ b/local-volume/provisioner/pkg/common/common_test.go
@@ -80,7 +80,7 @@ func TestLoadProvisionerConfigs(t *testing.T) {
 		os.RemoveAll(tmpConfigPath)
 	}()
 	provisionerConfig := &ProvisionerConfiguration{
-		StorageClassConfig: make(map[string]MountConfig),
+		StorageClassConfig: make(map[string]StorageClassConfig),
 	}
 	err = LoadProvisionerConfigs(tmpConfigPath, provisionerConfig)
 	if err != nil {

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -41,11 +41,11 @@ import (
 func StartLocalController(client *kubernetes.Clientset, config *common.UserConfig) {
 	glog.Info("Initializing volume cache\n")
 
-	provisionerName := fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
+	provisionerTag := fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.CoreV1().RESTClient()).Events("")})
-	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: provisionerName})
+	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: provisionerTag})
 
 	runtimeConfig := &common.RuntimeConfig{
 		UserConfig: config,
@@ -53,7 +53,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 		VolUtil:    util.NewVolumeUtil(),
 		APIUtil:    util.NewAPIUtil(client),
 		Client:     client,
-		Name:       provisionerName,
+		Tag:        provisionerTag,
 		Recorder:   recorder,
 		Mounter:    mount.New("" /* default mount path */),
 	}

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/discovery"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/populator"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/provisioningmanager"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
 
 	"k8s.io/api/core/v1"
@@ -82,6 +83,12 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 	if err != nil {
 		glog.Fatalf("Error starting discoverer: %v", err)
 	}
+
+	dynamicProvisioningManager, err := provisioningmanager.NewManager(runtimeConfig)
+	if err != nil {
+		glog.Fatalf("Error starting dynamic provisioning manager: %v", err)
+	}
+	dynamicProvisioningManager.Start()
 
 	deleter := deleter.NewDeleter(runtimeConfig, cleanupTracker)
 

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -48,14 +49,15 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: provisionerTag})
 
 	runtimeConfig := &common.RuntimeConfig{
-		UserConfig: config,
-		Cache:      cache.NewVolumeCache(),
-		VolUtil:    util.NewVolumeUtil(),
-		APIUtil:    util.NewAPIUtil(client),
-		Client:     client,
-		Tag:        provisionerTag,
-		Recorder:   recorder,
-		Mounter:    mount.New("" /* default mount path */),
+		UserConfig:     config,
+		Cache:          cache.NewVolumeCache(),
+		VolUtil:        util.NewVolumeUtil(),
+		APIUtil:        util.NewAPIUtil(client),
+		Client:         client,
+		Tag:            provisionerTag,
+		Recorder:       recorder,
+		Mounter:        mount.New("" /* default mount path */),
+		ProvisionQueue: workqueue.NewNamed("claimsToProvision"),
 	}
 
 	populator := populator.NewPopulator(runtimeConfig)

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/capacityreconciler"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/deleter"
 	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/discovery"
@@ -91,6 +92,9 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 	dynamicProvisioningManager.Start()
 
 	deleter := deleter.NewDeleter(runtimeConfig, cleanupTracker, dynamicProvisioningManager.DeleteLocalVolume)
+
+	capacityReconciler := capacityreconciler.NewReconciler(runtimeConfig, dynamicProvisioningManager.GetCapacity)
+	capacityReconciler.Reconcile()
 
 	glog.Info("Controller started\n")
 	for {

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -90,7 +90,7 @@ func StartLocalController(client *kubernetes.Clientset, config *common.UserConfi
 	}
 	dynamicProvisioningManager.Start()
 
-	deleter := deleter.NewDeleter(runtimeConfig, cleanupTracker)
+	deleter := deleter.NewDeleter(runtimeConfig, cleanupTracker, dynamicProvisioningManager.DeleteLocalVolume)
 
 	glog.Info("Controller started\n")
 	for {

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -91,7 +91,7 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 		return fmt.Errorf("Unknown storage class name %s", pv.Spec.StorageClassName)
 	}
 
-	mountPath, err := common.GetContainerPath(pv, config)
+	mountPath, err := common.GetContainerPath(pv, *config.MountConfig)
 	if err != nil {
 		return err
 	}
@@ -137,10 +137,10 @@ func (d *Deleter) deletePV(pv *v1.PersistentVolume) error {
 
 	if runjob {
 		// If we are dealing with block volumes and using jobs based cleaning for it.
-		return d.runJob(pv, mountPath, config)
+		return d.runJob(pv, mountPath, *config.MountConfig)
 	}
 
-	return d.runProcess(pv, volMode, mountPath, config)
+	return d.runProcess(pv, volMode, mountPath, *config.MountConfig)
 }
 
 func (d *Deleter) runProcess(pv *v1.PersistentVolume, volMode v1.PersistentVolumeMode, mountPath string,

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -481,11 +481,13 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail, config.cache)
 
 	userConfig := &common.UserConfig{
-		DiscoveryMap: map[string]common.MountConfig{
+		DiscoveryMap: map[string]common.DiscoveryConfig{
 			testStorageClass: {
-				HostDir:             testHostDir,
-				MountDir:            testMountDir,
-				BlockCleanerCommand: cleanupCmd,
+				MountConfig: &common.MountConfig{
+					HostDir:             testHostDir,
+					MountDir:            testMountDir,
+					BlockCleanerCommand: cleanupCmd,
+				},
 			},
 		},
 		Node:              &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: "somehost.acme.com"}},

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -431,7 +431,7 @@ func testSetupForJobCleaning(t *testing.T, config *testConfig, cleanupCmd []stri
 
 func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForCleaning bool) *Deleter {
 	config.cache = cache.NewVolumeCache()
-	config.apiUtil = util.NewFakeAPIUtil(false, config.cache)
+	config.apiUtil = util.NewFakeAPIUtil(false, config.cache, nil)
 	config.procTable = NewFakeProcTable()
 	config.jobControl = NewFakeJobController()
 	config.volUtil = util.NewFakeVolumeUtil(config.volDeleteShouldFail, map[string][]*util.FakeDirEntry{})
@@ -478,7 +478,7 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 	// Update volume util
 	config.volUtil.AddNewDirEntries(testMountDir, newVols)
 
-	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail, config.cache)
+	config.apiUtil = util.NewFakeAPIUtil(config.apiShouldFail, config.cache, nil)
 
 	userConfig := &common.UserConfig{
 		DiscoveryMap: map[string]common.DiscoveryConfig{

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -114,7 +114,7 @@ func (d *Discoverer) discoverVolumesAtPath(class string, config common.Discovery
 
 	for _, file := range files {
 		filePath := filepath.Join(config.MountDir, file)
-		volMode, err := d.getVolumeMode(filePath)
+		volMode, err := common.GetVolumeMode(d.VolUtil, filePath)
 		if err != nil {
 			glog.Error(err)
 			continue
@@ -170,28 +170,6 @@ func (d *Discoverer) discoverVolumesAtPath(class string, config common.Discovery
 
 		d.createPV(file, class, config, capacityByte)
 	}
-}
-
-func (d *Discoverer) getVolumeMode(fullPath string) (v1.PersistentVolumeMode, error) {
-	isdir, errdir := d.VolUtil.IsDir(fullPath)
-	if isdir {
-		return v1.PersistentVolumeFilesystem, nil
-	}
-	// check for Block before returning errdir
-	isblk, errblk := d.VolUtil.IsBlock(fullPath)
-	if isblk {
-		return v1.PersistentVolumeBlock, nil
-	}
-
-	if errdir == nil && errblk == nil {
-		return "", fmt.Errorf("Skipping file %q: not a directory nor block device", fullPath)
-	}
-
-	// report the first error found
-	if errdir != nil {
-		return "", fmt.Errorf("Directory check for %q failed: %s", fullPath, errdir)
-	}
-	return "", fmt.Errorf("Block device check for %q failed: %s", fullPath, errblk)
 }
 
 func generatePVName(file, node, class string) string {

--- a/local-volume/provisioner/pkg/discovery/discovery.go
+++ b/local-volume/provisioner/pkg/discovery/discovery.go
@@ -55,7 +55,7 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 	}
 
 	if config.UseAlphaAPI {
-		nodeAffinity, err := generateNodeAffinity(config.Node)
+		nodeAffinity, err := common.GenerateNodeAffinity(config.Node)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to generate node affinity: %v", err)
 		}
@@ -71,7 +71,7 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 			nodeAffinityAnn: tmpAnnotations[v1.AlphaStorageNodeAffinityAnnotation]}, nil
 	}
 
-	volumeNodeAffinity, err := generateVolumeNodeAffinity(config.Node)
+	volumeNodeAffinity, err := common.GenerateVolumeNodeAffinity(config.Node)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to generate volume node affinity: %v", err)
 	}
@@ -81,58 +81,6 @@ func NewDiscoverer(config *common.RuntimeConfig, cleanupTracker *deleter.Cleanup
 		Labels:         labelMap,
 		CleanupTracker: cleanupTracker,
 		nodeAffinity:   volumeNodeAffinity}, nil
-}
-
-func generateNodeAffinity(node *v1.Node) (*v1.NodeAffinity, error) {
-	if node.Labels == nil {
-		return nil, fmt.Errorf("Node does not have labels")
-	}
-	nodeValue, found := node.Labels[common.NodeLabelKey]
-	if !found {
-		return nil, fmt.Errorf("Node does not have expected label %s", common.NodeLabelKey)
-	}
-
-	return &v1.NodeAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-			NodeSelectorTerms: []v1.NodeSelectorTerm{
-				{
-					MatchExpressions: []v1.NodeSelectorRequirement{
-						{
-							Key:      common.NodeLabelKey,
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{nodeValue},
-						},
-					},
-				},
-			},
-		},
-	}, nil
-}
-
-func generateVolumeNodeAffinity(node *v1.Node) (*v1.VolumeNodeAffinity, error) {
-	if node.Labels == nil {
-		return nil, fmt.Errorf("Node does not have labels")
-	}
-	nodeValue, found := node.Labels[common.NodeLabelKey]
-	if !found {
-		return nil, fmt.Errorf("Node does not have expected label %s", common.NodeLabelKey)
-	}
-
-	return &v1.VolumeNodeAffinity{
-		Required: &v1.NodeSelector{
-			NodeSelectorTerms: []v1.NodeSelectorTerm{
-				{
-					MatchExpressions: []v1.NodeSelectorRequirement{
-						{
-							Key:      common.NodeLabelKey,
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{nodeValue},
-						},
-					},
-				},
-			},
-		},
-	}, nil
 }
 
 // DiscoverLocalVolumes reads the configured discovery paths, and creates PVs for the new volumes

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -287,7 +287,7 @@ func testSetup(t *testing.T, test *testConfig, useAlphaAPI bool) *Discoverer {
 	test.cache = cache.NewVolumeCache()
 	test.volUtil = util.NewFakeVolumeUtil(false /*deleteShouldFail*/, map[string][]*util.FakeDirEntry{})
 	test.volUtil.AddNewDirEntries(testMountDir, test.dirLayout)
-	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, test.cache)
+	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, test.cache, nil)
 	test.cleanupTracker = &deleter.CleanupStatusTracker{ProcTable: deleter.NewProcTable(),
 		JobController: deleter.NewFakeJobController()}
 

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -35,10 +35,10 @@ import (
 )
 
 const (
-	testHostDir         = "/mnt/disks"
-	testMountDir        = "/discoveryPath"
-	testNodeName        = "test-node"
-	testProvisionerName = "test-provisioner"
+	testHostDir        = "/mnt/disks"
+	testMountDir       = "/discoveryPath"
+	testNodeName       = "test-node"
+	testProvisionerTag = "test-provisioner"
 )
 
 var nodeLabels = map[string]string{
@@ -65,14 +65,18 @@ var testNode = &v1.Node{
 	},
 }
 
-var scMapping = map[string]common.MountConfig{
+var scMapping = map[string]common.DiscoveryConfig{
 	"sc1": {
-		HostDir:  testHostDir + "/dir1",
-		MountDir: testMountDir + "/dir1",
+		MountConfig: &common.MountConfig{
+			HostDir:  testHostDir + "/dir1",
+			MountDir: testMountDir + "/dir1",
+		},
 	},
 	"sc2": {
-		HostDir:  testHostDir + "/dir2",
-		MountDir: testMountDir + "/dir2",
+		MountConfig: &common.MountConfig{
+			HostDir:  testHostDir + "/dir2",
+			MountDir: testMountDir + "/dir2",
+		},
 	},
 }
 
@@ -297,6 +301,9 @@ func testSetup(t *testing.T, test *testConfig, useAlphaAPI bool) *Discoverer {
 			{Path: "/discoveryPath/dir2"},
 			{Path: "/discoveryPath/dir1/mount3"},
 			{Path: "/discoveryPath/dir1/mount4"},
+			{Path: "/discoveryPath/dir1/symlink2", Device: "device1"},
+			{Path: "/discoveryPath/dir2/symlink2", Device: "device2"},
+			{Path: "/discoveryPath/dir1/symlink3", Device: "device3"},
 		},
 	}
 
@@ -311,7 +318,7 @@ func testSetup(t *testing.T, test *testConfig, useAlphaAPI bool) *Discoverer {
 		Cache:      test.cache,
 		VolUtil:    test.volUtil,
 		APIUtil:    test.apiUtil,
-		Name:       testProvisionerName,
+		Tag:        testProvisionerTag,
 		Mounter:    fm,
 	}
 	d, err := NewDiscoverer(runConfig, test.cleanupTracker)
@@ -400,13 +407,13 @@ func verifyProvisionerName(t *testing.T, pv *v1.PersistentVolume) {
 		t.Errorf("Annotations not set")
 		return
 	}
-	name, found := pv.Annotations[common.AnnProvisionedBy]
+	tag, found := pv.Annotations[common.AnnProvisionedBy]
 	if !found {
 		t.Errorf("Provisioned by annotations not set")
 		return
 	}
-	if name != testProvisionerName {
-		t.Errorf("Provisioned name is %q, expected %q", name, testProvisionerName)
+	if tag != testProvisionerTag {
+		t.Errorf("Provisioned name is %q, expected %q", tag, testProvisionerTag)
 	}
 }
 

--- a/local-volume/provisioner/pkg/populator/populator.go
+++ b/local-volume/provisioner/pkg/populator/populator.go
@@ -102,11 +102,11 @@ func (p *Populator) handlePVUpdate(pv *v1.PersistentVolume) {
 		p.Cache.UpdatePV(pv)
 	} else {
 		if pv.Annotations != nil {
-			provisioner, found := pv.Annotations[common.AnnProvisionedBy]
+			provisionerTag, found := pv.Annotations[common.AnnProvisionedBy]
 			if !found {
 				return
 			}
-			if provisioner == p.Name {
+			if provisionerTag == p.Tag {
 				// This PV was created by this provisioner
 				p.Cache.AddPV(pv)
 			}

--- a/local-volume/provisioner/pkg/provisioningmanager/backend/backend.go
+++ b/local-volume/provisioner/pkg/provisioningmanager/backend/backend.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+// Local Volume configuration Information
+type LocalVolumeReq struct {
+	// Volume name
+	VolumeName string
+
+	// Size in GiB
+	SizeGB int
+}
+
+// Created Local Volume's detail Information
+type LocalVolumeInfo struct {
+	// Volume name
+	VolumeName string
+
+	// Size in GiB
+	SizeGB int
+
+	// Volume Path
+	VolumePath string
+}
+
+// StorageBackend is used to de-couple local provisioning manager and backend storage.
+type StorageBackend interface {
+	CreateLocalVolume(volReq *LocalVolumeReq) (*LocalVolumeInfo, error)
+	DeleteLocalVolume(volName string) error
+	GetCapacity() (int64, error)
+}
+
+type FakeBackend struct {
+	Capacity int64
+	RootPath string
+}
+
+func NewFakeBackend(capacity int64, rootPath string) *FakeBackend {
+	return &FakeBackend{
+		Capacity: capacity,
+		RootPath: rootPath,
+	}
+}
+
+func (w *FakeBackend) CreateLocalVolume(volReq *LocalVolumeReq) (*LocalVolumeInfo, error) {
+	return &LocalVolumeInfo{
+		VolumeName: volReq.VolumeName,
+		VolumePath: w.RootPath + "/" + volReq.VolumeName,
+		SizeGB:     volReq.SizeGB,
+	}, nil
+}
+
+func (w *FakeBackend) DeleteLocalVolume(volName string) error {
+	return nil
+}
+
+func (w *FakeBackend) GetCapacity() (int64, error) {
+	return w.Capacity, nil
+}

--- a/local-volume/provisioner/pkg/provisioningmanager/backend/lvmbackend.go
+++ b/local-volume/provisioner/pkg/provisioningmanager/backend/lvmbackend.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+type LvmBackend struct {
+	volumeGroup string
+	rootPath    string
+}
+
+func NewLvmBackend(volumeGroup, rootPath string) *LvmBackend {
+	return &LvmBackend{
+		volumeGroup: volumeGroup,
+		rootPath:    rootPath,
+	}
+}
+
+func (w *LvmBackend) CreateLocalVolume(volReq *LocalVolumeReq) (*LocalVolumeInfo, error) {
+	_, err := createLv(volReq.VolumeName, volReq.SizeGB, w.volumeGroup)
+	if err != nil {
+		return nil, err
+	}
+	return &LocalVolumeInfo{
+		VolumeName: volReq.VolumeName,
+		SizeGB:     volReq.SizeGB,
+		VolumePath: getLvPath(w.rootPath, w.volumeGroup, volReq.VolumeName),
+	}, nil
+}
+
+func (w *LvmBackend) DeleteLocalVolume(volName string) error {
+	_, err := deleteLv(w.rootPath, w.volumeGroup, volName)
+	return err
+}
+
+func (w *LvmBackend) GetCapacity() (int64, error) {
+	return getVgSize(w.volumeGroup)
+}

--- a/local-volume/provisioner/pkg/provisioningmanager/backend/lvmhelper.go
+++ b/local-volume/provisioner/pkg/provisioningmanager/backend/lvmhelper.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backend
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+const defaultRetryCount = 2
+const defaultRetryWaitDuration = 5 * time.Second
+const invalidInt64 int64 = -1
+
+func getVgSize(vgName string) (size int64, err error) {
+	output, err := runCmdWithRetries("vgs", vgName, "--nosuffix", "--units", "b", "--noheading", "-o", "size")
+	if err != nil {
+		return
+	}
+
+	float64Value, err := strconv.ParseFloat(strings.TrimSpace(output), 64)
+	if err != nil {
+		return
+	}
+	if float64Value < 0 || float64Value > math.MaxInt64 {
+		err = fmt.Errorf("volume size overflow")
+		return
+	}
+	// roundup
+	size = int64(float64Value)
+	return
+}
+
+func createLv(lvName string, sizeInGB int, vgName string) (output string, err error) {
+	output, err = runCmdWithRetries("lvcreate", "--name", lvName, "--size", strconv.Itoa(sizeInGB)+"G", vgName)
+	return
+}
+
+func deleteLv(rootPath string, vgName string, lvName string) (output string, err error) {
+	output, err = runCmdWithRetries("lvremove", "-f", getLvPath(rootPath, vgName, lvName))
+	return
+}
+
+func getLvPath(rootPath, vgName, lvName string) string {
+	return rootPath + "/" + vgName + "/" + lvName
+}
+
+// TODO: isTransientError should be different with command
+func runCmdWithRetries(name string, args ...string) (ret string, err error) {
+	var errMsg string
+	for i := 0; i <= defaultRetryCount; i++ {
+		ret, errMsg, err = runCmd(name, args...)
+		if err != nil {
+			if !isTransientError() {
+				break
+			}
+			glog.Warningf("the %dth time command[%s, %s] running error: %v, Stderr: %v", i+1, name, args, err, errMsg)
+			time.Sleep(defaultRetryWaitDuration)
+			continue
+		}
+		glog.V(2).Infof("the command output: %s", ret)
+		break
+	}
+	return ret, err
+}
+
+func runCmd(name string, args ...string) (string, string, error) {
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	return out.String(), errOut.String(), err
+}
+
+func isTransientError() bool {
+	return true
+}

--- a/local-volume/provisioner/pkg/provisioningmanager/manager.go
+++ b/local-volume/provisioner/pkg/provisioningmanager/manager.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioningmanager
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/provisioningmanager/backend"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/scheme"
+	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+const defaultRetryCount = 3
+const defaultRetryWaitDuration = 2 * time.Second
+
+type DynamicProvisioningManager struct {
+	*common.RuntimeConfig
+	storageBackends map[string]backend.StorageBackend
+	labels          map[string]string
+	nodeAffinityAnn string
+	nodeAffinity    *v1.VolumeNodeAffinity
+}
+
+// NewManager create a DynamicProvisioningManager instance that will accept volume claims
+// that are expected to be provisioned, and create PVs and backend volumes accordingly
+func NewManager(config *common.RuntimeConfig) (*DynamicProvisioningManager, error) {
+	// Initialize the backends
+	backends := make(map[string]backend.StorageBackend)
+	for class, source := range config.ProvisionSourceMap {
+		if source.Lvm != nil {
+			backends[class] = backend.NewLvmBackend(source.Lvm.VolumeGroup, source.MountConfig.HostDir)
+		}
+		if source.Fake != nil {
+			backends[class] = backend.NewFakeBackend(source.Fake.Capacity, source.Fake.RootPath)
+		}
+		// TODO: initialize backends from other sources
+	}
+
+	// Generate labels that will be used on the provisioned PVs
+	labelMap := make(map[string]string)
+	for _, labelName := range config.NodeLabelsForPV {
+		labelVal, ok := config.Node.Labels[labelName]
+		if ok {
+			labelMap[labelName] = labelVal
+		}
+	}
+
+	manager := &DynamicProvisioningManager{
+		RuntimeConfig:   config,
+		storageBackends: backends,
+		labels:          labelMap,
+	}
+
+	// Generate node affinity information,
+	if config.UseAlphaAPI {
+		nodeAffinity, err := common.GenerateNodeAffinity(config.Node)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate node affinity: %v", err)
+		}
+		tmpAnnotations := map[string]string{}
+		err = helper.StorageNodeAffinityToAlphaAnnotation(tmpAnnotations, nodeAffinity)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert node affinity to alpha annotation: %v", err)
+		}
+		manager.nodeAffinityAnn = tmpAnnotations[v1.AlphaStorageNodeAffinityAnnotation]
+	} else {
+		volumeNodeAffinity, err := common.GenerateVolumeNodeAffinity(config.Node)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate volume node affinity: %v", err)
+		}
+		manager.nodeAffinity = volumeNodeAffinity
+	}
+
+	return manager, nil
+}
+
+// Start starts provisioning service
+func (m *DynamicProvisioningManager) Start() {
+	go wait.Until(m.volumeProvisionWorker, time.Second, wait.NeverStop)
+}
+
+func (m *DynamicProvisioningManager) volumeProvisionWorker() {
+	workFunc := func() bool {
+		keyObj, quit := m.ProvisionQueue.Get()
+		if quit {
+			return true
+		}
+		defer m.ProvisionQueue.Done(keyObj)
+
+		claim, ok := keyObj.(*v1.PersistentVolumeClaim)
+		if !ok {
+			glog.Errorf("Object is not a *v1.PersistentVolumeClaim")
+			return false
+		}
+
+		pvName := getProvisionedVolumeNameForClaim(claim)
+		pv, exists := m.Cache.GetPV(pvName)
+		if exists {
+			if pv.Spec.ClaimRef == nil ||
+				pv.Spec.ClaimRef.Name != claim.Name ||
+				pv.Spec.ClaimRef.Namespace != claim.Namespace {
+				glog.Errorf("PV %q already exist, but not bound to claim %q", pvName, getClaimName(claim))
+			}
+			return false
+		}
+
+		if err := m.CreateLocalVolume(claim); err != nil {
+			glog.Errorf("Error creating volumes for claim %q: %v", getClaimName(claim), err)
+			// Signal back to the scheduler to retry dynamic provisioning
+			// by removing the "annSelectedNode" annotation
+			annotations := claim.Annotations
+			delete(annotations, common.AnnSelectedNode)
+			delete(annotations, common.AnnProvisionedTopology)
+			claim.Annotations = annotations
+			for i := 0; i <= defaultRetryCount; i++ {
+				if _, err := m.APIUtil.UpdatePVC(claim); err == nil {
+					break
+				}
+				glog.Errorf("Failed to update claim %q: %v", getClaimName(claim), err)
+				time.Sleep(defaultRetryWaitDuration)
+			}
+
+			return false
+		}
+		return false
+	}
+	for {
+		if quit := workFunc(); quit {
+			glog.Infof("Provision worker queue shutting down")
+			return
+		}
+	}
+}
+
+// CreateLocalVolume create volume basing on given claim,
+// along with a PV object that is pre-bound to the claim
+func (m *DynamicProvisioningManager) CreateLocalVolume(claim *v1.PersistentVolumeClaim) error {
+	// If annProvisionerTopology was not set, then it means
+	// the scheduler made a decision not taking into account
+	// capacity.
+	// Do not try provisioning if the capacity in StorageClass
+	// has not been initialized.
+	// TODO: Double check the value of the annotation if needed
+	if _, ok := claim.Annotations[common.AnnProvisionedTopology]; !ok {
+		return fmt.Errorf("capacity not reported yet, skip creating volumes for claim %q", getClaimName(claim))
+	}
+
+	className := helper.GetPersistentVolumeClaimClass(claim)
+	storageBackend, ok := m.storageBackends[className]
+	if !ok {
+		// Backend does not exist, return error
+		// This should not happen
+		return fmt.Errorf("cannot handle volume creation of storage class %s", className)
+	}
+
+	class, err := m.APIUtil.GetStorageClass(className)
+	if err != nil {
+		glog.Errorf("Failed to get storage class %q: %v", className, err)
+		return err
+	}
+
+	capacity := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	sizeBytes := capacity.Value()
+	// Convert to GiB with rounding up
+	sizeGB := int(util.RoundUpToGiB(sizeBytes))
+
+	// Create local volume
+	volName := getProvisionedVolumeNameForClaim(claim)
+	volReq := &backend.LocalVolumeReq{
+		VolumeName: volName,
+		SizeGB:     sizeGB,
+	}
+
+	// Prepare a claimRef to the claim early (to fail before a volume is
+	// provisioned)
+	claimRef, err := ref.GetReference(scheme.Scheme, claim)
+	if err != nil {
+		glog.Errorf("Unexpected error getting claim reference to claim %q: %v", getClaimName(claim), err)
+		return nil
+	}
+
+	volInfo, err := storageBackend.CreateLocalVolume(volReq)
+	if err != nil {
+		return err
+	}
+
+	localPVConfig := &common.LocalPVConfig{
+		Name:           volName,
+		HostPath:       volInfo.VolumePath,
+		Capacity:       int64(sizeGB * (1024 * 1024 * 1024)),
+		StorageClass:   className,
+		ProvisionerTag: m.Tag,
+		Labels:         m.labels,
+		AccessModes:    claim.Spec.AccessModes,
+		ReclaimPolicy:  *class.ReclaimPolicy,
+		ClaimRef:       claimRef,
+		AdditionalAnn: map[string]string{
+			common.AnnProvisionedTopology: claim.Annotations[common.AnnProvisionedTopology],
+		},
+	}
+
+	if claim.Spec.VolumeMode == nil {
+		// Default to filesystem
+		localPVConfig.VolumeMode = v1.PersistentVolumeFilesystem
+	} else {
+		localPVConfig.VolumeMode = *claim.Spec.VolumeMode
+	}
+
+	if m.UseAlphaAPI {
+		localPVConfig.UseAlphaAPI = true
+		localPVConfig.AffinityAnn = m.nodeAffinityAnn
+	} else {
+		localPVConfig.NodeAffinity = m.nodeAffinity
+	}
+
+	pvSpec := common.CreateLocalPVSpec(localPVConfig)
+
+	for trial := 0; trial <= defaultRetryCount; trial++ {
+		_, err := m.APIUtil.CreatePV(pvSpec)
+		if err == nil {
+			break
+		}
+		// Recycle the volume created above if failed to create PV
+		if trial >= defaultRetryCount {
+			if delErr := storageBackend.DeleteLocalVolume(volName); delErr != nil {
+				glog.Errorf("Error clean up volume %q: %v", volName, delErr)
+			}
+			return err
+		}
+		// Create failed, try again after a while.
+		glog.Errorf("Error creating PV %q for claim %q: %v", volName, getClaimName(claim), err)
+		time.Sleep(defaultRetryWaitDuration)
+	}
+
+	glog.Infof("Created PV %q for claim %q", volName, getClaimName(claim))
+	return nil
+
+}
+
+// DeleteLocalVolume clean up the backend volume of the pv
+func (m *DynamicProvisioningManager) DeleteLocalVolume(pv *v1.PersistentVolume) error {
+	pvClass := helper.GetPersistentVolumeClass(pv)
+	storageBackend, ok := m.storageBackends[pvClass]
+	if !ok {
+		// Backend does not exist, return error
+		// This should not happen
+		return fmt.Errorf("cannot handle volume deletion of storage class: %s", pvClass)
+	}
+	return storageBackend.DeleteLocalVolume(pv.Name)
+}
+
+// GetCapacity get capacity of given storage class
+func (m *DynamicProvisioningManager) GetCapacity(storageClass string) int64 {
+	storageBackend, exist := m.storageBackends[storageClass]
+	if !exist {
+		glog.Errorf("Cannot report capacity of class %q, no storage backend found", storageClass)
+		return 0
+	}
+	capacity, err := storageBackend.GetCapacity()
+	if err != nil {
+		glog.Errorf("Error getting capacity of class %q : %v", storageClass, err)
+		return 0
+	}
+
+	return capacity
+}
+
+func getProvisionedVolumeNameForClaim(claim *v1.PersistentVolumeClaim) string {
+	return "pvc-" + string(claim.UID)
+}
+
+func getClaimName(claim *v1.PersistentVolumeClaim) string {
+	return claim.Namespace + "/" + claim.Name
+}

--- a/local-volume/provisioner/pkg/provisioningmanager/manager_test.go
+++ b/local-volume/provisioner/pkg/provisioningmanager/manager_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioningmanager
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/cache"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/common"
+	"github.com/kubernetes-incubator/external-storage/local-volume/provisioner/pkg/util"
+
+	"k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/apis/core/v1/helper"
+)
+
+const (
+	testNamespace      = "testns"
+	testNodeName       = "test-node"
+	testClass          = "sc1"
+	testProvisionerTag = "test-provisioner"
+	testPath           = "/dir1"
+)
+
+var testCapacity = resource.MustParse("2Gi")
+
+type testConfig struct {
+	// Pre-installed storage classes
+	classes map[string]*storagev1.StorageClass
+	// True if testing api failure
+	apiShouldFail bool
+	// The rest are set during setup
+	apiUtil *util.FakeAPIUtil
+	cache   *cache.VolumeCache
+}
+
+var nodeLabels = map[string]string{
+	"failure-domain.beta.kubernetes.io/zone":   "west-1",
+	"failure-domain.beta.kubernetes.io/region": "west",
+	common.NodeLabelKey:                        testNodeName,
+	"label-that-pv-does-not-inherit":           "foo"}
+
+var nodeLabelsForPV = []string{
+	"failure-domain.beta.kubernetes.io/zone",
+	"failure-domain.beta.kubernetes.io/region",
+	common.NodeLabelKey,
+	"non-existent-label-that-pv-will-not-get"}
+
+var expectedPVLabels = map[string]string{
+	"failure-domain.beta.kubernetes.io/zone":   "west-1",
+	"failure-domain.beta.kubernetes.io/region": "west",
+	common.NodeLabelKey:                        testNodeName}
+
+var testNode = &v1.Node{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:   testNodeName,
+		Labels: nodeLabels,
+	},
+}
+
+var scMapping = map[string]common.ProvisionSourceConfig{
+	"sc1": {
+		Fake: &common.FakeSource{
+			RootPath: testPath,
+		},
+	},
+}
+
+func makeClass(name, topologyKey string, capacity resource.Quantity) *storagev1.StorageClass {
+	reclaimPolicy := v1.PersistentVolumeReclaimDelete
+	class := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		ReclaimPolicy: &reclaimPolicy,
+	}
+	if topologyKey != "" {
+		class.Status = &storagev1.StorageClassStatus{
+			Capacity: &storagev1.StorageClassCapacity{
+				TopologyKeys: []string{topologyKey},
+				Capacities:   map[string]resource.Quantity{testNodeName: capacity},
+			},
+		}
+	}
+	return class
+}
+
+func makeClaim(name, namespace, className string, capacity resource.Quantity, hasTopologyAnn bool) *v1.PersistentVolumeClaim {
+	fs := v1.PersistentVolumeFilesystem
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			UID:         types.UID(namespace + name),
+			Annotations: map[string]string{},
+			SelfLink:    fmt.Sprintf("/api/v1/namespaces/%s/persistentvolumeclaims/%s", namespace, name),
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			StorageClassName: &className,
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): capacity,
+				},
+			},
+			VolumeMode: &fs,
+		},
+	}
+
+	if hasTopologyAnn {
+		claim.Annotations[common.AnnProvisionedTopology] = common.NodeLabelKey + ":" + testNodeName
+	}
+
+	return claim
+}
+
+func testSetup(t *testing.T, test *testConfig, useAlphaAPI bool) *DynamicProvisioningManager {
+	test.cache = cache.NewVolumeCache()
+	test.apiUtil = util.NewFakeAPIUtil(test.apiShouldFail, test.cache, test.classes)
+
+	userConfig := &common.UserConfig{
+		Node:               testNode,
+		ProvisionSourceMap: scMapping,
+		NodeLabelsForPV:    nodeLabelsForPV,
+		UseAlphaAPI:        useAlphaAPI,
+	}
+	runConfig := &common.RuntimeConfig{
+		UserConfig: userConfig,
+		Cache:      test.cache,
+		APIUtil:    test.apiUtil,
+		Tag:        testProvisionerTag,
+	}
+	s, err := NewManager(runConfig)
+	if err != nil {
+		t.Fatalf("Error setting up test provisioning manager: %v", err)
+	}
+	return s
+}
+
+func TestCreateLocalVolume(t *testing.T) {
+	testCases := []struct {
+		description    string
+		claimName      string
+		claimNs        string
+		className      string
+		hasTopologyAnn bool
+		apiShouldFail  bool
+		expErr         error
+	}{
+		{
+			description:    "Successful provision",
+			claimName:      "claim1",
+			claimNs:        testNamespace,
+			className:      testClass,
+			hasTopologyAnn: true,
+			apiShouldFail:  false,
+			expErr:         nil,
+		},
+		{
+			description:    "Provision fails: Unknown class",
+			claimName:      "claim1",
+			claimNs:        testNamespace,
+			className:      "sc2",
+			hasTopologyAnn: true,
+			apiShouldFail:  false,
+			expErr:         fmt.Errorf("cannot handle volume creation of storage class sc2"),
+		},
+		{
+			description:    "Provision fails: has no provisioned topology annotation",
+			claimName:      "claim1",
+			claimNs:        testNamespace,
+			className:      testClass,
+			hasTopologyAnn: false,
+			apiShouldFail:  false,
+			expErr:         fmt.Errorf("capacity not reported yet, skip creating volumes for claim \"testns/claim1\""),
+		},
+		{
+			description:    "Provision fails: failed to create PV object",
+			claimName:      "claim1",
+			claimNs:        testNamespace,
+			className:      testClass,
+			hasTopologyAnn: true,
+			apiShouldFail:  true,
+			expErr:         fmt.Errorf("API failed"),
+		},
+	}
+	for _, testCase := range testCases {
+		testConf := &testConfig{
+			classes: map[string]*storagev1.StorageClass{
+				testClass: makeClass("sc1", common.NodeLabelKey, testCapacity),
+			},
+			apiShouldFail: testCase.apiShouldFail,
+		}
+		s := testSetup(t, testConf, false)
+		claim := makeClaim(testCase.claimName, testCase.claimNs, testCase.className, testCapacity, testCase.hasTopologyAnn)
+		err := s.CreateLocalVolume(claim)
+		if !reflect.DeepEqual(err, testCase.expErr) {
+			t.Errorf("Provision error (%v). expected error: %v but got: %v",
+				testCase.description, testCase.expErr, err)
+		}
+		pvName := getProvisionedVolumeNameForClaim(claim)
+		if err == nil {
+			createdPVs := testConf.apiUtil.GetAndResetCreatedPVs()
+			if len(createdPVs) != 1 {
+				t.Errorf("Expected 1 created PVs, got %d", len(createdPVs))
+				break
+			}
+
+			pv, exist := createdPVs[pvName]
+			if !exist {
+				t.Errorf("PV %q not found in created PVs", pvName)
+			}
+			_, exists := testConf.cache.GetPV(pvName)
+			if !exists {
+				t.Errorf("PV %q not in cache", pvName)
+			}
+			verifyCreatedPV(t, pv, claim)
+		} else {
+			if _, exists := testConf.cache.GetPV(pvName); exists {
+				t.Errorf("Expected PV %q to not be in cache", pvName)
+			}
+		}
+	}
+
+}
+
+func verifyCreatedPV(t *testing.T, pv *v1.PersistentVolume, claim *v1.PersistentVolumeClaim) {
+	if pv.Name != getProvisionedVolumeNameForClaim(claim) {
+		t.Errorf("Expected PV name %q, got %q", getProvisionedVolumeNameForClaim(claim), pv.Name)
+	}
+	if pv.Spec.StorageClassName != testClass {
+		t.Errorf("Expected storage class %q, got %q", testClass, pv.Spec.StorageClassName)
+	}
+	if pv.Spec.ClaimRef == nil || pv.Spec.ClaimRef.Name != claim.Name || pv.Spec.ClaimRef.Namespace != claim.Namespace {
+		t.Errorf("Unexpected claim reference: %v", pv.Spec.ClaimRef)
+	}
+	verifyProvisionerName(t, pv)
+	verifyNodeAffinity(t, pv)
+	verifyPVLabels(t, pv)
+	verifyCapacity(t, pv)
+	verifyPath(t, pv)
+}
+
+func verifyNodeAffinity(t *testing.T, pv *v1.PersistentVolume) {
+	var err error
+	var volumeNodeAffinity *v1.VolumeNodeAffinity
+	var nodeAffinity *v1.NodeAffinity
+	var selector *v1.NodeSelector
+
+	volumeNodeAffinity = pv.Spec.NodeAffinity
+	if volumeNodeAffinity == nil {
+		nodeAffinity, err = helper.GetStorageNodeAffinityFromAnnotation(pv.Annotations)
+		if err != nil {
+			t.Errorf("Could not get node affinity from annotation: %v", err)
+			return
+		}
+		if nodeAffinity == nil {
+			t.Errorf("No node affinity found")
+			return
+		}
+		selector = nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	} else {
+		selector = volumeNodeAffinity.Required
+	}
+	if selector == nil {
+		t.Errorf("NodeAffinity node selector is nil")
+		return
+	}
+	terms := selector.NodeSelectorTerms
+	if len(terms) != 1 {
+		t.Errorf("Node selector term count is %v, expected 1", len(terms))
+		return
+	}
+	reqs := terms[0].MatchExpressions
+	if len(reqs) != 1 {
+		t.Errorf("Node selector term requirements count is %v, expected 1", len(reqs))
+		return
+	}
+
+	req := reqs[0]
+	if req.Key != common.NodeLabelKey {
+		t.Errorf("Node selector requirement key is %v, expected %v", req.Key, common.NodeLabelKey)
+	}
+	if req.Operator != v1.NodeSelectorOpIn {
+		t.Errorf("Node selector requirement operator is %v, expected %v", req.Operator, v1.NodeSelectorOpIn)
+	}
+	if len(req.Values) != 1 {
+		t.Errorf("Node selector requirement value count is %v, expected 1", len(req.Values))
+		return
+	}
+	if req.Values[0] != testNodeName {
+		t.Errorf("Node selector requirement value is %v, expected %v", req.Values[0], testNodeName)
+	}
+}
+
+func verifyPVLabels(t *testing.T, pv *v1.PersistentVolume) {
+	if len(pv.Labels) == 0 {
+		t.Errorf("Labels not set")
+		return
+	}
+	eq := reflect.DeepEqual(pv.Labels, expectedPVLabels)
+	if !eq {
+		t.Errorf("Labels not as expected %v != %v", pv.Labels, expectedPVLabels)
+	}
+}
+
+func verifyProvisionerName(t *testing.T, pv *v1.PersistentVolume) {
+	if len(pv.Annotations) == 0 {
+		t.Errorf("Annotations not set")
+		return
+	}
+	tag, found := pv.Annotations[common.AnnProvisionedBy]
+	if !found {
+		t.Errorf("Provisioned by annotations not set")
+		return
+	}
+	if tag != testProvisionerTag {
+		t.Errorf("Provisioned name is %q, expected %q", tag, testProvisionerTag)
+	}
+}
+
+func verifyCapacity(t *testing.T, createdPV *v1.PersistentVolume) {
+	capacity, ok := createdPV.Spec.Capacity[v1.ResourceStorage]
+	if !ok {
+		t.Errorf("Unexpected empty resource storage")
+	}
+	if capacity.Cmp(testCapacity) != 0 {
+		t.Errorf("Expected capacity %v, got %v", testCapacity, capacity)
+	}
+
+}
+
+func verifyPath(t *testing.T, createdPV *v1.PersistentVolume) {
+	expectedPath := testPath + "/" + createdPV.Name
+	actualPath := createdPV.Spec.Local.Path
+	if actualPath != expectedPath {
+		t.Errorf("Expected path %s, got %s", expectedPath, actualPath)
+	}
+}


### PR DESCRIPTION
Design: https://github.com/kubernetes/community/pull/1914

The PR includes:
- Refactor config to include dynamic provisioning config
- Update discovery to be aware of volumemode
- Update populator to watch PVCs for dynamic provisioning
- Implement storage backend
- Implement dynamic provisioning manager
- Update deleter to also handle dynamically provisioned volumes
- Implement capacity reconciler
- Deployment update

TODO:
- Wait for https://github.com/kubernetes/kubernetes/pull/63193 merged, and update API dependency
- Rely on https://github.com/kubernetes/kubernetes/pull/63011, and pass in Fstype for provisioned volumes