### PR TITLE
[logs] Fix "operaion" typo in `controller` error log.

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -1171,7 +1171,7 @@ func (ctrl *ProvisionController) scheduleOperation(operationName string, operati
 		if goroutinemap.IsAlreadyExists(err) {
 			glog.V(4).Infof("operation %q is already running, skipping", operationName)
 		} else {
-			glog.Errorf("Error scheduling operaion %q: %v", operationName, err)
+			glog.Errorf("Error scheduling operation %q: %v", operationName, err)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Came across a typo in the logs today. Easy fix. `operaion` => `operation`