### PR TITLE
Manila: CI: test openstack-sharedfilesystems compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-snapshot:
 
 openstack-sharedfilesystems:
 	cd openstack-sharedfilesystems; \
-	make container
+	make
 .PHONY: openstack-sharedfilesystems
 
 test-openstack-sharedfilesystems:

--- a/test.sh
+++ b/test.sh
@@ -94,6 +94,7 @@ elif [ "$TEST_SUITE" = "everything-else" ]; then
 	make nfs-client
 	make snapshot
 	make test-snapshot
+	make openstack-sharedfilesystems
 	make test-openstack/standalone-cinder
 elif [ "$TEST_SUITE" = "local-volume" ]; then
 	make local-volume/provisioner


### PR DESCRIPTION
Let's test whether the Manila provisioner compiles as part of the CI.

@rootfs, @childsb: PTAL