### PR TITLE
CephFS Provisioner: Add option to disable namespace isolation.

### DIFF
--- a/ceph/cephfs/Dockerfile
+++ b/ceph/cephfs/Dockerfile
@@ -15,9 +15,10 @@
 FROM centos:7
 
 ENV CEPH_VERSION "mimic"
-RUN rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
+RUN rpm --import 'https://download.ceph.com/keys/release.asc' && \
+  rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
   yum install -y epel-release && \
-  yum install -y --nogpgcheck ceph-common python-cephfs && \
+  yum install -y ceph-common python-cephfs && \
   yum clean all
 
 COPY cephfs-provisioner /usr/local/bin/cephfs-provisioner

--- a/ceph/cephfs/Dockerfile.release
+++ b/ceph/cephfs/Dockerfile.release
@@ -21,10 +21,11 @@ RUN go build -a -ldflags '-extldflags "-static"' -o /go/bin/cephfs-provisioner c
 
 FROM centos:7
 
-ENV CEPH_VERSION "luminous"
-RUN rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
+ENV CEPH_VERSION "mimic"
+RUN rpm --import 'https://download.ceph.com/keys/release.asc' && \
+  rpm -Uvh https://download.ceph.com/rpm-$CEPH_VERSION/el7/noarch/ceph-release-1-1.el7.noarch.rpm && \
   yum install -y epel-release && \
-  yum install -y --nogpgcheck ceph-common python-cephfs && \
+  yum install -y ceph-common python-cephfs && \
   yum clean all
 
 COPY --from=build /go/bin/cephfs-provisioner /usr/local/bin/cephfs-provisioner

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -149,6 +149,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	if deterministicNames {
 		cmd.Env = append(cmd.Env, "CEPH_VOLUME_GROUP="+options.PVC.Namespace)
 	}
+	if *disableCephNamespaceIsolation {
+		cmd.Env = append(cmd.Env, "CEPH_NAMESPACE_ISOLATION_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -255,6 +258,9 @@ func (p *cephFSProvisioner) Delete(volume *v1.PersistentVolume) error {
 		"CEPH_AUTH_ID=" + adminID,
 		"CEPH_AUTH_KEY=" + adminSecret,
 		"CEPH_VOLUME_ROOT=" + pvcRoot}
+	if *disableCephNamespaceIsolation {
+		cmd.Env = append(cmd.Env, "CEPH_NAMESPACE_ISOLATION_DISABLED=true")
+	}
 
 	output, cmdErr := cmd.CombinedOutput()
 	if cmdErr != nil {
@@ -345,12 +351,13 @@ func (p *cephFSProvisioner) parsePVSecret(namespace, secretName string) (string,
 }
 
 var (
-	master          = flag.String("master", "", "Master URL")
-	kubeconfig      = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
-	id              = flag.String("id", "", "Unique provisioner identity")
-	secretNamespace = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
-	enableQuota     = flag.Bool("enable-quota", false, "Enable PVC quota")
-	metricsPort     = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
+	master                        = flag.String("master", "", "Master URL")
+	kubeconfig                    = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
+	id                            = flag.String("id", "", "Unique provisioner identity")
+	secretNamespace               = flag.String("secret-namespace", "", "Namespace secrets will be created in (default: '', created in each PVC's namespace)")
+	enableQuota                   = flag.Bool("enable-quota", false, "Enable PVC quota")
+	metricsPort                   = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
+	disableCephNamespaceIsolation = flag.Bool("disable-ceph-namespace-isolation", false, "Disable ceph namespace isolation")
 )
 
 func main() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Linux kernel cephfs only support Rados Pool Namespace in 4.8+. See
https://github.com/torvalds/linux/commit/779fe0fb8e1883d5c479ac6bd85fbd237deed1f7.

If security is not critical, we can configure cephfs provisioner not to enforce pool namespace, then we can use it with linux kernels before 4.8.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/kubernetes-incubator/external-storage/issues/345

**Special notes for reviewer**:

This patches `ceph_volume_client.py` with patch from https://github.com/ceph/ceph/pull/21808.