### PR TITLE
Local Volume Provisioner: Support Reclaim Policy

### DIFF
--- a/local-volume/provisioner/deployment/kubernetes/example/default_example_storageclass.yaml
+++ b/local-volume/provisioner/deployment/kubernetes/example/default_example_storageclass.yaml
@@ -5,3 +5,5 @@ metadata:
   name: fast-disks
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
+# Supported policies: Delete, Retain
+reclaimPolicy: Delete

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -110,7 +110,7 @@ type RuntimeConfig struct {
 	// Unique name of this provisioner
 	Name string
 	// K8s API client
-	Client *kubernetes.Clientset
+	Client kubernetes.Interface
 	// Cache to store PVs managed by this provisioner
 	Cache *cache.VolumeCache
 	// K8s API layer
@@ -133,6 +133,7 @@ type LocalPVConfig struct {
 	HostPath        string
 	Capacity        int64
 	StorageClass    string
+	ReclaimPolicy   v1.PersistentVolumeReclaimPolicy
 	ProvisionerName string
 	UseAlphaAPI     bool
 	AffinityAnn     string
@@ -176,7 +177,7 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimDelete,
+			PersistentVolumeReclaimPolicy: config.ReclaimPolicy,
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): *resource.NewQuantity(int64(config.Capacity), resource.BinarySI),
 			},

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -122,6 +123,8 @@ type RuntimeConfig struct {
 	BlockDisabled bool
 	// Mounter used to verify mountpoints
 	Mounter mount.Interface
+	// InformerFactory gives access to informers for the controller.
+	InformerFactory informers.SharedInformerFactory
 }
 
 // LocalPVConfig defines the parameters for creating a local PV

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -62,8 +62,9 @@ type testConfig struct {
 }
 
 type testVol struct {
-	pvPhase    v1.PersistentVolumePhase
-	VolumeMode string
+	pvPhase       v1.PersistentVolumePhase
+	VolumeMode    string
+	reclaimPolicy v1.PersistentVolumeReclaimPolicy
 }
 
 func TestDeleteVolumes_Basic(t *testing.T) {
@@ -82,6 +83,10 @@ func TestDeleteVolumes_Basic(t *testing.T) {
 		},
 		"pv5": {
 			pvPhase: v1.VolumeFailed,
+		},
+		"pv6": {
+			pvPhase:       v1.VolumeReleased,
+			reclaimPolicy: v1.PersistentVolumeReclaimRetain,
 		},
 	}
 	expectedDeletedPVs := map[string]string{"pv4": ""}
@@ -180,6 +185,76 @@ func TestDeleteVolumes_DeletePVNotFound(t *testing.T) {
 	select {
 	case err := <-recorderChan:
 		t.Errorf("error deletePV %v", err)
+	default:
+	}
+}
+
+func TestDeleteVolumes_UnsupportedReclaimPolicy(t *testing.T) {
+	vols := map[string]*testVol{
+		"pv4": {
+			pvPhase:       v1.VolumeReleased,
+			reclaimPolicy: v1.PersistentVolumeReclaimRecycle,
+		},
+	}
+	test := &testConfig{
+		apiShouldFail:      false,
+		vols:               vols,
+		expectedDeletedPVs: map[string]string{},
+	}
+	d := testSetupForProcCleaning(t, test, nil)
+
+	d.DeletePVs()
+	waitForAsyncToComplete(t, d)
+	verifyDeletedPVs(t, test)
+
+	err := d.deletePV(test.generatedPVs["pv4"])
+	if err != nil {
+		t.Error(err)
+	}
+	waitForAsyncToComplete(t, d)
+
+	expectedEvent := "Warning VolumeUnsupportedReclaimPolicy Volume has unsupported PersistentVolumeReclaimPolicy: Recycle"
+	recorderChan := d.RuntimeConfig.Recorder.(*record.FakeRecorder).Events
+	select {
+	case event := <-recorderChan:
+		if event != expectedEvent {
+			t.Errorf("expected event %q, got %q", expectedEvent, event)
+		}
+	default:
+	}
+}
+
+func TestDeleteVolumes_UnknownReclaimPolicy(t *testing.T) {
+	vols := map[string]*testVol{
+		"pv4": {
+			pvPhase:       v1.VolumeReleased,
+			reclaimPolicy: v1.PersistentVolumeReclaimPolicy("unknown"),
+		},
+	}
+	test := &testConfig{
+		apiShouldFail:      false,
+		vols:               vols,
+		expectedDeletedPVs: map[string]string{},
+	}
+	d := testSetupForProcCleaning(t, test, nil)
+
+	d.DeletePVs()
+	waitForAsyncToComplete(t, d)
+	verifyDeletedPVs(t, test)
+
+	err := d.deletePV(test.generatedPVs["pv4"])
+	if err != nil {
+		t.Error(err)
+	}
+	waitForAsyncToComplete(t, d)
+
+	expectedEvent := "Warning VolumeUnknownReclaimPolicy Volume has unrecognized PersistentVolumeReclaimPolicy"
+	recorderChan := d.RuntimeConfig.Recorder.(*record.FakeRecorder).Events
+	select {
+	case event := <-recorderChan:
+		if event != expectedEvent {
+			t.Errorf("expected event %q, got %q", expectedEvent, event)
+		}
 	default:
 	}
 }
@@ -459,6 +534,11 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 			lpvConfig.VolumeMode = v1.PersistentVolumeBlock
 		case util.FakeEntryFile:
 			lpvConfig.VolumeMode = v1.PersistentVolumeFilesystem
+		}
+		if vol.reclaimPolicy != "" {
+			lpvConfig.ReclaimPolicy = vol.reclaimPolicy
+		} else {
+			lpvConfig.ReclaimPolicy = v1.PersistentVolumeReclaimDelete
 		}
 		pv := common.CreateLocalPVSpec(&lpvConfig)
 		pv.Status.Phase = vol.pvPhase


### PR DESCRIPTION
**What this PR does / why we need it**:

Support Reclaim Policy. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes https://github.com/kubernetes-incubator/external-storage/issues/771

**Special notes for reviewer**:

`Recycle` policy is deprecated (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#recycle), I suggest not supporting it.

Although we can treat it as `Delete` policy, but for `Recycle` if we want to support we should not delete it.