### PR TITLE
update text on using unique snapshot name

### DIFF
--- a/snapshot/doc/volume-snapshotting-proposal.md
+++ b/snapshot/doc/volume-snapshotting-proposal.md
@@ -123,7 +123,7 @@ There are a few uniqueness related to snapshots:
 
 * There are use cases that data from snapshots taken from one namespace need to be accessible by users in another namespace.
 
-* For security purpose, if a snapshot object is created by a user, kubernetes should prevent other users duplicating this object in a different namespace if they happen to get the snapshot name.
+* For security purpose, if a snapshot object is created by a user, kubernetes should prevent other users from duplicating this object in a different namespace if they happen to use the same snapshot name. The snapshot object names should be unique within a cluster. 
 
 * There might be some existing snapshots taken by admins/users and they want to use those snapshots through kubernetes API interface.
 


### PR DESCRIPTION
The text was a bit unclear on whether, same snapshot name can be used in a cluster -- on different PV objects or not. Example: is it possible to create:
- Alex creates - Snapshot ( nightly-monday ) on PV - MySQL-VOL
- David creates - Snapshot ( nightly-monday ) on PV - RabbitMQ-VOL

Alex and David run their MySQL and RabbitMQ applications in their own namespaces. 

It appears that - the same name can't be used. Is this right?