### PR TITLE
[WIP] Add block volume support check to external provisioners

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -115,6 +116,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	cluster, adminID, adminSecret, mon, err := p.parseParameters(options.Parameters)
 	if err != nil {
 		return nil, err
+	}
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
 	}
 	// create random share name
 	share := fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())

--- a/digitalocean/pkg/volume/provision.go
+++ b/digitalocean/pkg/volume/provision.go
@@ -82,6 +82,9 @@ func (p *digitaloceanProvisioner) Provision(options controller.VolumeOptions) (*
 	if !util.AccessModesContainedInAll(p.getAccessModes(), options.PVC.Spec.AccessModes) {
 		return nil, fmt.Errorf("Invalid Access Modes: %v, Supported Access Modes: %v", options.PVC.Spec.AccessModes, p.getAccessModes())
 	}
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", createdBy)
+	}
 
 	vol, err := p.createVolume(options)
 	if err != nil {

--- a/docs/demo/hostpath-provisioner/README.md
+++ b/docs/demo/hostpath-provisioner/README.md
@@ -65,6 +65,10 @@ func (p *hostPathProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 		return nil, err
 	}
 
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
+	}
+
 	pv := &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: options.PVName,

--- a/docs/demo/hostpath-provisioner/hostpath-provisioner.go
+++ b/docs/demo/hostpath-provisioner/hostpath-provisioner.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,6 +67,10 @@ func (p *hostPathProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 
 	if err := os.MkdirAll(path, 0777); err != nil {
 		return nil, err
+	}
+
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
 	}
 
 	pv := &v1.PersistentVolume{

--- a/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
+++ b/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
@@ -149,6 +149,10 @@ func (p *glusterfileProvisioner) Provision(options controller.VolumeOptions) (*v
 		return nil, fmt.Errorf("invalid AccessModes %v: only AccessModes %v are supported", options.PVC.Spec.AccessModes, p.GetAccessModes())
 	}
 
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
+	}
+
 	glog.V(1).Infof("VolumeOptions %v", options)
 	p.options = options
 	gidAllocate := true

--- a/gluster/glusterfs/pkg/volume/provision.go
+++ b/gluster/glusterfs/pkg/volume/provision.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/kubernetes-incubator/external-storage/lib/gidallocator"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +81,11 @@ func (p *glusterfsProvisioner) Provision(options controller.VolumeOptions) (*v1.
 	if options.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
 	}
+
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", createdBy)
+	}
+
 	glog.V(4).Infof("Start Provisioning volume: VolumeOptions %v", options)
 
 	gid, err := p.allocator.AllocateNext(options)

--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -59,3 +59,10 @@ func AccessModesContainedInAll(indexedModes []v1.PersistentVolumeAccessMode, req
 	}
 	return true
 }
+
+// CheckPersistentVolumeClaimModeBlock checks VolumeMode.
+// If the mode is Block, return true otherwise return false.
+func CheckPersistentVolumeClaimModeBlock(pvc *v1.PersistentVolumeClaim) bool {
+	// TODO Check if features.BlockVolume is enabled. (Currently, no way to check it in external provisioner.)
+	return pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
+}

--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -54,6 +55,10 @@ func (p *nfsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		return nil, fmt.Errorf("claim Selector is not supported")
 	}
 	glog.V(4).Infof("nfs provisioner: VolumeOptions %v", options)
+
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
+	}
 
 	pvcNamespace := options.PVC.Namespace
 	pvcName := options.PVC.Name

--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,6 +193,10 @@ func (p *nfsProvisioner) ShouldProvision(claim *v1.PersistentVolumeClaim) bool {
 // Provision creates a volume i.e. the storage asset and returns a PV object for
 // the volume.
 func (p *nfsProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", createdBy)
+	}
+
 	volume, err := p.createVolume(options)
 	if err != nil {
 		return nil, err

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -81,6 +81,10 @@ var _ controller.Provisioner = &openEBSProvisioner{}
 // Provision creates a storage asset and returns a PV object representing it.
 func (p *openEBSProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
 
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
+	}
+
 	//Issue a request to Maya API Server to create a volume
 	var volume mayav1.Volume
 	var openebsVol mApiv1.OpenEBSVolume

--- a/openstack-sharedfilesystems/cmd/manila-provisioner/main.go
+++ b/openstack-sharedfilesystems/cmd/manila-provisioner/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/apiversions"
 	"github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	sharedfilesystems "github.com/kubernetes-incubator/external-storage/openstack-sharedfilesystems/pkg/sharedfilesystems"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -92,6 +93,9 @@ func buildConfig(kubeconfig string) (*rest.Config, error) {
 func (p *manilaProvisioner) Provision(pvc controller.VolumeOptions) (*v1.PersistentVolume, error) {
 	if pvc.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
+	}
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", provisionerName)
 	}
 
 	client := createManilaV2Client()

--- a/openstack/standalone-cinder/pkg/provisioner/provisioner.go
+++ b/openstack/standalone-cinder/pkg/provisioner/provisioner.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-incubator/external-storage/lib/util"
 	"github.com/kubernetes-incubator/external-storage/openstack/standalone-cinder/pkg/volumeservice"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -116,6 +117,10 @@ func (p *cinderProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 
 	if options.PVC.Spec.Selector != nil {
 		return nil, fmt.Errorf("claim Selector is not supported")
+	}
+
+	if util.CheckPersistentVolumeClaimModeBlock(options.PVC) {
+		return nil, fmt.Errorf("%s does not support block volume provisioning", ProvisionerName)
 	}
 
 	// TODO: Check access mode


### PR DESCRIPTION
Adding the similar check logic to below PR for external provisioners which don't support block volume.
* Add block volume support to internal provisioners.
  https://github.com/kubernetes/kubernetes/pull/64447

There could be many other external provisioners that are not in this git repository, however it would be better adding check to the ones in this git repository. 

Not all external provisioner are tested currently, however, comments for this PR is welcomed.

Please review the code with below in mind:

- From external provisioner, features.BlockVolume is not acessible, so there is no check for this feature flag,
- Check logic are implemented with assuming below block volume support status,
- Flex volume and snapshot will be a special case, so they need further discussion,
- CSI is out of scope for this PR, because its in a different git repository, however, it needs similar consideration to flex volume.

[Unknown/Needdiscussion]
 - flex/pkg/volume/provision.go
 - snapshot/cmd/snapshot-pv-provisioner/snapshot-pv-provisioner.go

[Support block volume]
 - ceph/rbd/pkg/provision/provision.go
 - gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go (iSCSI backend?)
 - iscsi/targetd/provisioner/iscsi-provisioner.go
  
[Not Support block volume]
 - ceph/cephfs/cephfs-provisioner.go
 - openebs/openebs-provisioner.go
 - openstack/standalone-cinder/pkg/provisioner/provisioner.go
 - gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
 - gluster/glusterfs/pkg/volume/provision.go
 - digitalocean/pkg/volume/provision.go
 - docs/demo/hostpath-provisioner/hostpath-provisioner.go (document)
 - docs/demo/hostpath-provisioner/README.md (document)
 - nfs/pkg/volume/provision.go
 - nfs-client/cmd/nfs-client-provisioner/provisioner.go
 - openstack-sharedfilesystems/cmd/manila-provisioner/main.go
