### PR TITLE
local volume provisioner: improve helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ clean: clean-aws/efs clean-ceph/cephfs clean-ceph/rbd clean-flex clean-gluster/b
 .PHONY: clean
 
 
-test: test-aws/efs test-local-volume/provisioner test-nfs test-snapshot test-openstack/standalone-cinder test-openstack-sharedfilesystems
+test: test-aws/efs test-local-volume/provisioner test-local-volume/helm test-nfs test-snapshot test-openstack/standalone-cinder test-openstack-sharedfilesystems
 .PHONY: test
 
 verify:
@@ -126,6 +126,11 @@ test-local-volume/provisioner:
 	cd local-volume/provisioner; \
 	go test ./...
 .PHONY: test-local-volume/provisioner
+
+test-local-volume/helm:
+	cd local-volume/helm; \
+	./test/run.sh
+.PHONY: test-local-volume/helm
 
 clean-local-volume/provisioner:
 	cd local-volume/provisioner; \

--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -44,21 +44,47 @@ The generated specs can be further customized as needed (usually not necessary),
 Default values.yaml is located in local-volume/helm/provisioner folder, user should not remove variables from this file but can
 change any values of these variables.
 
-## Advanced options
+## Configurations
 
-### Set engine
-In order to generate the environment specific provisioner's spec, **--set engine={gcepre19,gcepost19,gke,baremetal}** parameter
-can be used in helm template command. Example for GKE environment, the command line will look like:
+The following table lists the configurable parameters of the local volume
+provisioner chart and their default values.
 
-``` console
-helm template ./helm/provisioner --set engine=gke > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+| Parameter                              | Description                                                                                           | Type     | Default                                                    |
+| ---                                    | ---                                                                                                   | ---      | ---                                                        |
+| common.rbac                            | Generating RBAC (Role Based Access Control) objects.                                                  | bool     | `true`                                                     |
+| common.namespace                       | Namespace where provisioner runs.                                                                     | str      | `default`                                                  |
+| common.useAlphaAPI                     | If running against pre-1.10 k8s version, the `useAlphaAPI` flag must be enabled.                      | bool     | `false`                                                    |
+| common.useJobForCleaning               | Is set to true, provisioner will use jobs-based block cleaning.                                       | bool     | `false`                                                    |
+| common.configMapName                   | Provisioner ConfigMap name.                                                                           | str      | `local-provisioner-config`                                 |
+| classes.[n].name                       | StorageClass name.                                                                                    | str      | `-`                                                        |
+| classes.[n].hostDir                    | Path on the host where local volumes of this storage class are mounted under.                         | str      | `-`                                                        |
+| classes.[n].mountDir                   | Optionally specify mount path of local volumes. By default, we use same path as hostDir in container. | str      | `-`                                                        |
+| classes.[n].blockCleanerCommand        | List of command and arguments of block cleaner command.                                               | list     | `-`                                                        |
+| classes.[n].storageClass               | Create storage class for this class and configure it optionally.                                      | bool/map | `false`                                                    |
+| classes.[n].storageClass.reclaimPolicy | Specify reclaimPolicy of storage class, available: Delete/Retain.                                     | str      | `Delete`                                                   |
+| daemonset.name                         | Provisioner DaemonSet name.                                                                           | str      | `local-volume-provisioner`                                 |
+| daemonset.image                        | Provisioner image.                                                                                    | str      | `quay.io/external_storage/local-volume-provisioner:v2.1.0` |
+| daemonset.imagePullPolicy              | Provisioner DaemonSet image pull policy.                                                              | str      | `-`                                                        |
+| daemonset.serviceAccount               | Provisioner DaemonSet service account.                                                                | str      | `local-storage-admin`                                      |
+| daemonset.kubeConfigEnv                | Specify the location of kubernetes config file.                                                       | str      | `-`                                                        |
+| daemonset.nodeLabels                   | List of node labels to be copied to the PVs created by the provisioner.                               | list     | `-`                                                        |
+
+Note: `classes` is a list of objects, you can specify one or more classes.
+
+## Examples
+
+To try out one of the [examples](examples/). you can run, e.g. for gce:
+
+```console
+$ helm template ./helm/provisioner -f helm/examples/gce.yaml > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
 ```
-Parameter **--set engine=** can be used in conjunction with custom values.yaml file in the same command line.
 
-### Generating RBAC (Role Based Access Control) specs
-By default, common.rbac is set to "true" which generates the necessary ServiceAccount, ClusterRole, and ClusterRoleBinding
-for an RBAC enabled kubernetes cluster. If your cluster does not use RBAC, you should add --set common.rbac=false when
-running your helm install command, such as:
+Currently you can try the following examples:
 
-``` console
-helm template ./helm/provisioner --set common.rbac=false > ./provisioner/deployment/kubernetes/provisioner_generated.yaml
+* [examples/baremetal-cleanbyjobs.yaml](examples/baremetal-cleanbyjobs.yaml)
+* [examples/baremetal-without-rbac.yaml](examples/baremetal-without-rbac.yaml)
+* [examples/baremetal.yaml](examples/baremetal.yaml)
+* [examples/gce-pre1.9.yaml](examples/gce-pre1.9.yaml)
+* [examples/gce-retain.yaml](examples/gce-retain.yaml)
+* [examples/gce.yaml](examples/gce.yaml)
+* [examples/gke.yaml](examples/gke.yaml)

--- a/local-volume/helm/examples/baremetal-cleanbyjobs.yaml
+++ b/local-volume/helm/examples/baremetal-cleanbyjobs.yaml
@@ -1,0 +1,8 @@
+common:
+  useJobForCleaning: true
+classes:
+- name: local-storage
+  hostDir: /mnt/disks
+  blockCleanerCommand:
+  - "/scripts/quick_reset.sh"
+  storageClass: true

--- a/local-volume/helm/examples/baremetal-without-rbac.yaml
+++ b/local-volume/helm/examples/baremetal-without-rbac.yaml
@@ -1,0 +1,8 @@
+common:
+  rbac: false
+classes:
+- name: local-storage
+  hostDir: /mnt/disks
+  blockCleanerCommand:
+  - "/scripts/quick_reset.sh"
+  storageClass: true

--- a/local-volume/helm/examples/baremetal.yaml
+++ b/local-volume/helm/examples/baremetal.yaml
@@ -1,0 +1,15 @@
+classes:
+- name: local-storage
+  hostDir: /mnt/disks
+  blockCleanerCommand:
+  # Do a quick reset of the block device during its cleanup.
+  # - "/scripts/quick_reset.sh"
+  # or use dd to zero out block dev in two iterations by uncommenting these lines.
+  # - "/scripts/dd_zero.sh"
+  # - "2"
+  # or run shred utility for 2 iterations.
+  - "/scripts/shred.sh"
+  - "2"
+  # or blkdiscard utility by uncommenting the line below.
+  # - "/scripts/blkdiscard.sh"
+  storageClass: true

--- a/local-volume/helm/examples/gce-pre1.9.yaml
+++ b/local-volume/helm/examples/gce-pre1.9.yaml
@@ -1,0 +1,6 @@
+common:
+  useAlphaAPI: true
+classes:
+- name: local-scsi
+  hostDir: "/mnt/disks"
+  storageClass: true

--- a/local-volume/helm/examples/gce-retain.yaml
+++ b/local-volume/helm/examples/gce-retain.yaml
@@ -1,0 +1,9 @@
+classes:
+- name: local-scsi
+  hostDir: "/mnt/disks/by-uuid/google-local-ssds-scsi-fs"
+  storageClass:
+    reclaimPolicy: Retain
+- name: local-nvme
+  hostDir: "/mnt/disks/by-uuid/google-local-ssds-nvme-fs" 
+  storageClass:
+    reclaimPolicy: Retain

--- a/local-volume/helm/examples/gce.yaml
+++ b/local-volume/helm/examples/gce.yaml
@@ -1,0 +1,11 @@
+common:
+  # Beta PV.NodeAffinity field is used by default. If running against pre-1.10
+  # k8s version, the `useAlphaAPI` flag must be enabled in the configMap.
+  useAlphaAPI: false
+classes:
+- name: local-scsi
+  hostDir: "/mnt/disks/by-uuid/google-local-ssds-scsi-fs"
+  storageClass: true
+- name: local-nvme
+  hostDir: "/mnt/disks/by-uuid/google-local-ssds-nvme-fs" 
+  storageClass: true

--- a/local-volume/helm/examples/gke.yaml
+++ b/local-volume/helm/examples/gke.yaml
@@ -1,0 +1,4 @@
+classes:
+- name: local-scsi
+  hostDir: "/mnt/disks"
+  storageClass: true

--- a/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner-cluster-role-binding.yaml
@@ -36,12 +36,12 @@ roleRef:
   kind: ClusterRole
   name: local-storage-provisioner-node-clusterrole
   apiGroup: rbac.authorization.k8s.io
-{{- end }}
+{{- if .Values.common.useJobForCleaning }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: jobsrole
+  name: local-storage-provisioner-jobs-role
   namespace: {{ .Values.common.namespace }}
 rules:
 - apiGroups:
@@ -54,7 +54,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: local-storage-provisioner-job-binding
+  name: local-storage-provisioner-jobs-rolebinding
   namespace: {{ .Values.common.namespace }}
 subjects:
 - kind: ServiceAccount
@@ -62,5 +62,7 @@ subjects:
   namespace: {{ .Values.common.namespace }}
 roleRef:
   kind: Role
-  name: jobsrole
+  name: local-storage-provisioner
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -1,94 +1,56 @@
-{{- define "configStorageClass" }}
-{{- $classPath := . }}
-{{- range $tmp, $val := $classPath }}
-   {{- range $storageClass, $classConfig := $val }}
-{{ $storageClass }}:
-   hostDir: {{ $classConfig.hostDir }}
-   mountDir: {{ if $classConfig.mountDir }} {{$classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
-   {{- if $classConfig.blockCleanerCommand }}
-   blockCleanerCommand:
-   {{- range $tmp, $val := $classConfig.blockCleanerCommand }}
-     - "{{ $val -}}"{{- end}}
-   {{- end }}
-{{- end}}
-{{- end}}
-{{- end }}
-{{- define "configVolumes" }}
-{{- $classPath := . }}
-{{- range $tmp, $val := $classPath }}
-   {{- range $storageClass, $classConfig := $val }}
-- name: {{ $storageClass }}
-  hostPath:
-    path: {{ $classConfig.hostDir }}
-   {{- end}}
-{{- end}}
-{{- end }}
-{{- define "configVolumeMounts" }}
-{{- $classPath := . }}
-{{- range $tmp, $val := $classPath }}
-   {{- range $storageClass, $classConfig := $val }}
-- mountPath: {{ if $classConfig.mountDir }} {{$classConfig.mountDir }} {{ else }} {{ $classConfig.hostDir }} {{ end }}
-  name: {{ $storageClass }}
-  mountPropagation: "HostToContainer"
-   {{- end}}
-{{- end}}
-{{- end }}
-{{- $configMapName := .Values.configmap.configMapName }}
-{{- $provisionerNamespace := .Values.common.namespace }}
-{{- $useAlphaAPI := .Values.common.useAlphaAPI }}
-{{- $useJobForCleaning := .Values.common.useJobForCleaning }}
-{{- $provisionerName := .Values.daemonset.name }}
-{{- $imageFull := .Values.daemonset.image }}
-{{- $imagePullPolicy := .Values.daemonset.imagePullPolicy }}
-{{- $serviceAccount := .Values.daemonset.serviceAccount }}
-{{- $kubeConfigEnv := .Values.daemonset.kubeConfigEnv }}
-{{- $nodeLabels := .Values.daemonset.nodeLabels }}
-{{- $engine := .Values.engine | default "baremetal" }} 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $configMapName }} 
-  namespace: {{ $provisionerNamespace }} 
+  name: {{ .Values.common.configMapName }}
+  namespace: {{ .Values.common.namespace }}
 data:
-{{- if $nodeLabels }}
+{{- if .Values.daemonset.nodeLabels }}
   nodeLabelsForPV: |
-   {{- range $label := $nodeLabels }}
+   {{- range $label := .Values.daemonset.nodeLabels }}
     - {{$label}}
    {{- end }}
 {{- end }}
-{{- if $useAlphaAPI }}
+{{- if .Values.common.useAlphaAPI }}
   useAlphaAPI: "true"
 {{- end }}
-{{- if $useJobForCleaning }}
+{{- if .Values.common.useJobForCleaning }}
   useJobForCleaning: "yes"
 {{- end}}
   storageClassMap: |
-{{- if eq ( $engine | lower ) "gcepre19" }} {{ include "configStorageClass" (.Values.configmap.gcePre19.storageClass) | indent 4 }} {{ end }}
-{{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configStorageClass" (.Values.configmap.gcePost19.storageClass) | indent 4 }} {{ end }}
-{{- if eq ( $engine | lower ) "gke" }} {{ include "configStorageClass" (.Values.configmap.gke.storageClass) | indent 4 }} {{ end }}
-{{- if eq ( $engine | lower ) "baremetal" }} {{ include "configStorageClass" (.Values.configmap.baremetal.storageClass) | indent 4 }} {{ end }}
+    {{- range $classConfig := .Values.classes }}
+    {{ $classConfig.name }}:
+       hostDir: {{ $classConfig.hostDir }}
+       mountDir: {{ if $classConfig.mountDir }} {{- $classConfig.mountDir -}} {{ else }} {{- $classConfig.hostDir -}} {{ end }}
+       {{- if $classConfig.blockCleanerCommand }}
+       blockCleanerCommand:
+       {{- range $val := $classConfig.blockCleanerCommand }}
+         - "{{ $val -}}"{{- end}}
+       {{- end }}
+    {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: {{ $provisionerName }}
-  namespace: {{ $provisionerNamespace }}
+  name: {{ .Values.daemonset.name }}
+  namespace: {{ .Values.common.namespace }}
   labels:
     app: local-volume-provisioner
 spec:
   selector:
     matchLabels:
-      app: local-volume-provisioner 
+      app: local-volume-provisioner
   template:
     metadata:
       labels:
         app: local-volume-provisioner
     spec:
-      serviceAccountName: {{$serviceAccount}}
+      serviceAccountName: {{.Values.daemonset.serviceAccount}}
       containers:
-        - image: "{{ $imageFull }}"
-          imagePullPolicy: {{ $imagePullPolicy | quote }}
-          name: provisioner 
+        - image: "{{ .Values.daemonset.image }}"
+          {{- if .Values.daemonset.imagePullPolicy }}
+          imagePullPolicy: {{ .Values.daemonset.imagePullPolicy | quote }}
+          {{- end }}
+          name: provisioner
           securityContext:
             privileged: true
           env:
@@ -101,25 +63,39 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: JOB_CONTAINER_IMAGE
-            value: "{{ $imageFull }}"
-
-{{- if $kubeConfigEnv }}
+            value: "{{ .Values.daemonset.image }}"
+          {{- if .Values.daemonset.kubeConfigEnv }}
             - name: KUBECONFIG
-              value: {{$kubeConfigEnv}}
-{{- end }}
+              value: {{.Values.daemonset.kubeConfigEnv}}
+          {{- end }}
           volumeMounts:
-            - mountPath: /etc/provisioner/config 
+            - mountPath: /etc/provisioner/config
               name: provisioner-config
               readOnly: true
-{{- if eq ( $engine | lower ) "gcepre19" }} {{ include "configVolumeMounts" (.Values.configmap.gcePre19.storageClass) | indent 12 }} {{ end }}
-{{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configVolumeMounts" (.Values.configmap.gcePost19.storageClass) | indent 12 }} {{ end }}
-{{- if eq ( $engine | lower ) "gke" }} {{ include "configVolumeMounts" (.Values.configmap.gke.storageClass) | indent 12 }} {{ end }}
-{{- if eq ( $engine | lower ) "baremetal" }} {{ include "configVolumeMounts" (.Values.configmap.baremetal.storageClass) | indent 12 }} {{ end }}
+            {{- range $classConfig := .Values.classes }}
+            - mountPath: {{ if $classConfig.mountDir }} {{- $classConfig.mountDir -}} {{ else }} {{- $classConfig.hostDir -}} {{ end }}
+              name: {{ $classConfig.name }}
+              mountPropagation: "HostToContainer"
+            {{- end }}
       volumes:
         - name: provisioner-config
           configMap:
-            name: {{ $configMapName }}
-{{- if eq ( $engine | lower ) "gcepre19" }} {{ include "configVolumes" (.Values.configmap.gcePre19.storageClass) | indent 8 }} {{ end }}
-{{- if eq ( $engine | lower ) "gcepost19" }} {{ include "configVolumes" (.Values.configmap.gcePost19.storageClass) | indent 8 }} {{ end }}
-{{- if eq ( $engine | lower ) "gke" }} {{ include "configVolumes" (.Values.configmap.gke.storageClass) | indent 8 }} {{ end }}
-{{- if eq ( $engine | lower ) "baremetal" }} {{ include "configVolumes" (.Values.configmap.baremetal.storageClass) | indent 8 }} {{ end }}
+            name: {{ .Values.common.configMapName }}
+        {{- range $classConfig := .Values.classes }}
+        - name: {{ $classConfig.name }}
+          hostPath:
+            path: {{ $classConfig.hostDir }}
+        {{- end }}
+{{- range $val := .Values.classes }}
+{{- if $val.storageClass }}
+{{- $reclaimPolicy := $val.reclaimPolicy | default "Delete" }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ $val.name }}
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: {{ $reclaimPolicy }}
+{{- end }}
+{{- end }}

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -1,3 +1,6 @@
+#
+# Common options.
+#
 common:
   #
   # Defines whether to generate service account and role bindings.
@@ -17,66 +20,40 @@ common:
   # will use Jobs to clean.
   #
   useJobForCleaning: false
-configmap:
   #
   # Defines the name of configmap used by Provisioner
   #
   configMapName: "local-provisioner-config"
-  #
-  # Defines storage classes in a format:
-  #
-  #  storageClass:
-  #    - {storage class name}:
-  #        hostDir: "{path on the host where local volume of this storage class are mounted}"
-  #        mountDir: "{Optional path where a local volume will be mounted inside of a container}"
-  #
-  # Note: At least one storage class must be configuredi, baremetal is used as default if no
-  # explicit environment is specified in helm template command line.
-  baremetal:
-    storageClass:
-    - fast-disks:
-        hostDir: /mnt/fast-disks
-        blockCleanerCommand:
-        #  Do a quick reset of the block device during its cleanup.
-        #  - "/scripts/quick_reset.sh"
-        #  or use dd to zero out block dev in two iterations by uncommenting these lines
-        #  - "/scripts/dd_zero.sh"
-        #  - "2"
-        # or run shred utility for 2 iteration.s
-           - "/scripts/shred.sh"
-           - "2"
-        # or blkdiscard utility by uncommenting the line below.
-        #  - "/scripts/blkdiscard.sh"
- 
-  #
-  # Storage classes for GCE Pre-1.9
-  gcePre19:
-    storageClass:
-      - local-scsi:
-          hostDir: "/mnt/disks"
-          blockCleanerCommand:
-            - "/scripts/quick_reset.sh"
-  #
-  # Storage classes for GCE 1.9+
-  gcePost19:
-    storageClass:
-      - local-scsi:
-          hostDir: "/mnt/disks/by-uuid/google-local-ssds-scsi-fs"
-          blockCleanerCommand:
-            - "/scripts/quick_reset.sh"
-      - local-nvme:
-          hostDir: "/mnt/disks/by-uuid/google-local-ssds-nvme-fs" 
-          blockCleanerCommand:
-            - "/scripts/quick_reset.sh"
-  #
-  # Storage classes for GKE
-  gke:
-    storageClass:
-      - local-scsi:
-          hostDir: "/mnt/disks"
-          blockCleanerCommand:
-            - "/scripts/quick_reset.sh"
-  #
+#
+# Configure storage classes.
+#
+classes:
+- name: fast-disks # Defines name of storage classe.
+  # Path on the host where local volumes of this storage class are mounted
+  # under.
+  hostDir: /mnt/fast-disks
+  # Optionally specify mount path of local volumes. By default, we use same
+  # path as hostDir in container.
+  # mountDir: /mnt/fast-disks
+  blockCleanerCommand:
+  #  Do a quick reset of the block device during its cleanup.
+  #  - "/scripts/quick_reset.sh"
+  #  or use dd to zero out block dev in two iterations by uncommenting these lines
+  #  - "/scripts/dd_zero.sh"
+  #  - "2"
+  # or run shred utility for 2 iteration.s
+     - "/scripts/shred.sh"
+     - "2"
+  # or blkdiscard utility by uncommenting the line below.
+  #  - "/scripts/blkdiscard.sh"
+  # Uncomment to create storage class object with default configuration.
+  # storageClass: true
+  # Uncomment to create storage class object and configure it.
+  # storageClass:
+    # reclaimPolicy: Delete # Avaiable reclaim policies: Delete/Retain, defaults: Delete.
+#
+# Configure DaemonSet for provisioner.
+# 
 daemonset:
   #
   # Defines the name of a Provisioner
@@ -89,7 +66,7 @@ daemonset:
   #
   # Defines Image download policy, see kubernetes documentation for available values.
   #
-  imagePullPolicy: Always
+  #imagePullPolicy: Always
   #
   # Defines a name of the service account which Provisioner will use to communicate with API server.
   #

--- a/local-volume/helm/test/expected/baremetal-cleanbyjobs.yaml
+++ b/local-volume/helm/test/expected/baremetal-cleanbyjobs.yaml
@@ -1,0 +1,149 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  useJobForCleaning: "yes"
+  storageClassMap: |
+    local-storage:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+       blockCleanerCommand:
+         - "/scripts/quick_reset.sh"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks
+              name: local-storage
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-storage
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-storage-provisioner-jobs-role
+  namespace: default
+rules:
+- apiGroups:
+    - 'batch'
+  resources:
+    - jobs
+  verbs:
+    - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-storage-provisioner-jobs-rolebinding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: Role
+  name: local-storage-provisioner
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/expected/baremetal-without-rbac.yaml
+++ b/local-volume/helm/test/expected/baremetal-without-rbac.yaml
@@ -1,0 +1,79 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  storageClassMap: |
+    local-storage:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+       blockCleanerCommand:
+         - "/scripts/quick_reset.sh"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks
+              name: local-storage
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-storage
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+

--- a/local-volume/helm/test/expected/baremetal.yaml
+++ b/local-volume/helm/test/expected/baremetal.yaml
@@ -1,0 +1,122 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  storageClassMap: |
+    local-storage:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+       blockCleanerCommand:
+         - "/scripts/shred.sh"
+         - "2"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks
+              name: local-storage
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-storage
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/expected/gce-pre1.9.yaml
+++ b/local-volume/helm/test/expected/gce-pre1.9.yaml
@@ -1,0 +1,120 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  useAlphaAPI: "true"
+  storageClassMap: |
+    local-scsi:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks
+              name: local-scsi
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-scsi
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-scsi
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/expected/gce-retain.yaml
+++ b/local-volume/helm/test/expected/gce-retain.yaml
@@ -1,0 +1,136 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  storageClassMap: |
+    local-scsi:
+       hostDir: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+       mountDir: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+    local-nvme:
+       hostDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+       mountDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+              name: local-scsi
+              mountPropagation: "HostToContainer"
+            - mountPath: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+              name: local-nvme
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-scsi
+          hostPath:
+            path: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+        - name: local-nvme
+          hostPath:
+            path: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-scsi
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-nvme
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/expected/gce.yaml
+++ b/local-volume/helm/test/expected/gce.yaml
@@ -1,0 +1,136 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  storageClassMap: |
+    local-scsi:
+       hostDir: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+       mountDir: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+    local-nvme:
+       hostDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+       mountDir: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+              name: local-scsi
+              mountPropagation: "HostToContainer"
+            - mountPath: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+              name: local-nvme
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-scsi
+          hostPath:
+            path: /mnt/disks/by-uuid/google-local-ssds-scsi-fs
+        - name: local-nvme
+          hostPath:
+            path: /mnt/disks/by-uuid/google-local-ssds-nvme-fs
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-scsi
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-nvme
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/expected/gke.yaml
+++ b/local-volume/helm/test/expected/gke.yaml
@@ -1,0 +1,119 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  storageClassMap: |
+    local-scsi:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /mnt/disks
+              name: local-scsi
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-scsi
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-scsi
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/run.sh
+++ b/local-volume/helm/test/run.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+cd $ROOT
+
+function install_helm() {
+    local HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
+    curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/bin linux-amd64/helm -zxf -
+}
+
+if ! which helm &>/dev/null; then
+    install_helm
+fi
+
+# lint first
+ret=0
+helm lint ./provisioner || ret=$?
+if [ $ret -ne 0 ]; then
+    echo "helm lint failed"
+    exit 2
+fi
+
+# check examples
+function test_values_file() {
+    local input="examples/$1"
+    local expected="test/expected/$1"
+    local tmpfile=$(mktemp)
+    trap "test -f $tmpfile && rm $tmpfile || true" EXIT
+    helm template ./provisioner -f examples/$f > $tmpfile
+    echo -n "Checking $input "
+    local diff=$(diff -u $expected $tmpfile) || true
+    if [[ -n "${diff}" ]]; then
+        echo "failed, diff: "
+        echo "$diff"
+        exit 1
+    else
+        echo "passed."
+    fi
+}
+
+FILES=$(ls examples/)
+for f in $FILES; do
+    test_values_file $f
+done

--- a/local-volume/utils/update-helm-values-pre-v2.2.0/README.md
+++ b/local-volume/utils/update-helm-values-pre-v2.2.0/README.md
@@ -1,0 +1,8 @@
+## update helm values pre v2.2.0
+
+If you are using old helm chart (pre local-volume-provisioner-v2.2.0), you can
+use this utility to upgrade your values file:
+
+```
+go run utils/update-helm-values-pre-v2.2.0/main.go -input <your-old-values-file> -engine <engine>
+```

--- a/local-volume/utils/update-helm-values-pre-v2.2.0/main.go
+++ b/local-volume/utils/update-helm-values-pre-v2.2.0/main.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	"github.com/kubernetes-incubator/external-storage/local-volume/utils/update-helm-values/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	optEngine        string
+	optInput         string
+	optOutput        string
+	supportedEngines = sets.NewString(
+		"baremetal",
+		"gcePre19",
+		"gcePost19",
+		"gke",
+	)
+)
+
+func init() {
+	flag.StringVar(&optInput, "input", "", "values file to update")
+	flag.StringVar(&optOutput, "output", "-", "values file to write out")
+	flag.StringVar(&optEngine, "engine", "baremetal", "engine")
+}
+
+func isNoValueError(err error) bool {
+	_, ok := err.(chartutil.ErrNoValue)
+	return ok
+}
+
+func isNoTableError(err error) bool {
+	_, ok := err.(chartutil.ErrNoTable)
+	return ok
+}
+
+func upgrade(val chartutil.Values, engine string) (chartutil.Values, error) {
+	out := val
+	// 1. Move configmap.configMapName to common.configMapName
+	configMapName, err := val.PathValue("configmap.configMapName")
+	if err != nil && !isNoValueError(err) {
+		return out, err
+	}
+	if err == nil {
+		outCommon, err := out.Table("common")
+		if err != nil && !isNoTableError(err) {
+			return out, err
+		}
+		if isNoTableError(err) {
+			outCommon = chartutil.Values{}
+			out["common"] = outCommon
+		}
+		outCommon["configMapName"] = configMapName
+	}
+	// 2. Replace configmap with classes
+	classes := make([]chartutil.Values, 0)
+	key := fmt.Sprintf("configmap.%s.storageClass", engine)
+	storageClass, err := val.PathValue(key)
+	if err != nil {
+		return out, err
+	}
+	storageClassList, ok := storageClass.([]interface{})
+	if !ok {
+		return out, fmt.Errorf("invalid values")
+	}
+	for _, class := range storageClassList {
+		classMap, ok := class.(map[string]interface{})
+		if !ok {
+			return out, fmt.Errorf("invalid values")
+		}
+		for name, val := range classMap {
+			classValue := chartutil.Values{
+				"name": name,
+			}
+			if kvs, ok := val.(map[string]interface{}); ok {
+				for k, v := range kvs {
+					classValue[k] = v
+				}
+			}
+			classes = append(classes, classValue)
+		}
+	}
+	out["classes"] = classes
+	delete(out, "configmap")
+	// 3. Set daemonset.imagePullPolicy if needed
+	imagePullPolicy, err := val.PathValue("daemonset.imagePullPolicy")
+	if err != nil && !isNoValueError(err) {
+		return out, err
+	}
+	if v, ok := imagePullPolicy.(string); (ok && v == "") || isNoValueError(err) {
+		daemonset, err := out.Table("daemonset")
+		if err != nil && !isNoTableError(err) {
+			return out, err
+		}
+		if isNoTableError(err) {
+			daemonset = chartutil.Values{}
+			out["daemonset"] = daemonset
+		}
+		daemonset["imagePullPolicy"] = "Always"
+	}
+	return out, nil
+}
+
+func main() {
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	if optInput == "" || optOutput == "" {
+		flag.Usage()
+		return
+	}
+
+	if !supportedEngines.Has(optEngine) {
+		glog.Errorf("not supported engine: %s, available: %v", optEngine, supportedEngines.List())
+		return
+	}
+
+	var (
+		err error
+		out *os.File
+	)
+
+	if optOutput == "-" {
+		out = os.Stdout
+	} else {
+		out, err = os.OpenFile(optOutput, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			glog.Fatal(err)
+		}
+	}
+
+	inVal, err := chartutil.ReadValuesFile(optInput)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	outVal, err := upgrade(inVal, optEngine)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	outStr, err := outVal.YAML()
+	if err != nil {
+		glog.Fatal(err)
+	}
+	out.WriteString(outStr)
+}

--- a/local-volume/utils/update-helm-values-pre-v2.2.0/main_test.go
+++ b/local-volume/utils/update-helm-values-pre-v2.2.0/main_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/kubernetes-incubator/external-storage/local-volume/utils/update-helm-values/pkg/chartutil"
+)
+
+func TestUpgrade(t *testing.T) {
+	testcases := []struct {
+		in       string
+		engine   string
+		expected string
+	}{
+		{
+			`
+common:
+  useAlphaAPI: true
+configmap:
+  baremetal:
+    storageClass:
+    - fast-disks:
+        blockCleanerCommand:
+        - /scripts/shred.sh
+        - "2"
+        hostDir: /mnt/fast-disks
+  configMapName: local-provisioner-test
+  gcePre19:
+    storageClass:
+    - local-scsi:
+        blockCleanerCommand:
+        - /scripts/quick_reset.sh
+        hostDir: /mnt/disks`,
+			"baremetal",
+			`
+common:
+  useAlphaAPI: true
+  configMapName: local-provisioner-test
+classes:
+- name: fast-disks
+  blockCleanerCommand:
+  - /scripts/shred.sh
+  - "2"
+  hostDir: /mnt/fast-disks
+daemonset:
+  imagePullPolicy: Always`,
+		},
+		{
+			`
+common:
+  useAlphaAPI: true
+configmap:
+  baremetal:
+    storageClass:
+    - fast-disks:
+        blockCleanerCommand:
+        - /scripts/shred.sh
+        - "2"
+        hostDir: /mnt/fast-disks
+  configMapName: local-provisioner-test
+  gcePre19:
+    storageClass:
+    - local-scsi:
+        blockCleanerCommand:
+        - /scripts/quick_reset.sh
+        hostDir: /mnt/disks`,
+			"gcePre19",
+			`
+common:
+  useAlphaAPI: true
+  configMapName: local-provisioner-test
+classes:
+- name: local-scsi
+  blockCleanerCommand:
+  - /scripts/quick_reset.sh
+  hostDir: /mnt/disks
+daemonset:
+  imagePullPolicy: Always`,
+		},
+		{
+			`
+configmap:
+  baremetal:
+    storageClass:
+    - fast-disks:
+        blockCleanerCommand:
+        - /scripts/shred.sh
+        - "2"
+        hostDir: /mnt/fast-disks
+  configMapName: local-provisioner-test`,
+			"baremetal",
+			`
+common:
+  configMapName: local-provisioner-test
+classes:
+- name: fast-disks
+  blockCleanerCommand:
+  - /scripts/shred.sh
+  - "2"
+  hostDir: /mnt/fast-disks
+daemonset:
+  imagePullPolicy: Always`,
+		},
+		{
+			`
+configmap:
+  baremetal:
+    storageClass:
+    - fast-disks:
+        blockCleanerCommand:
+        - /scripts/shred.sh
+        - "2"
+        hostDir: /mnt/fast-disks
+daemonset:
+  imagePullPolicy: IfNotPresent`,
+			"baremetal",
+			`
+classes:
+- name: fast-disks
+  blockCleanerCommand:
+  - /scripts/shred.sh
+  - "2"
+  hostDir: /mnt/fast-disks
+daemonset:
+  imagePullPolicy: IfNotPresent`,
+		},
+	}
+
+	for _, v := range testcases {
+		val, err := chartutil.ReadValues([]byte(v.in))
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedOut, err := chartutil.ReadValues([]byte(v.expected))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out, err := upgrade(val, v.engine)
+		if err != nil {
+			t.Fatal(err)
+		}
+		outStr, err := out.YAML()
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedOutStr, err := expectedOut.YAML()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if outStr != expectedOutStr {
+			t.Errorf("expected %v, got: %v", expectedOutStr, outStr)
+		}
+	}
+}

--- a/local-volume/utils/update-helm-values-pre-v2.2.0/pkg/chartutil/values.go
+++ b/local-volume/utils/update-helm-values-pre-v2.2.0/pkg/chartutil/values.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Help utilities copied from https://github.com/kubernetes/helm/blob/v2.9.1/pkg/chartutil/values.go.
+
+package chartutil
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/ghodss/yaml"
+)
+
+// ErrNoTable indicates that a chart does not have a matching table.
+type ErrNoTable error
+
+// ErrNoValue indicates that Values does not contain a key with a value
+type ErrNoValue error
+
+// Values represents a collection of chart values.
+type Values map[string]interface{}
+
+// YAML encodes the Values into a YAML string.
+func (v Values) YAML() (string, error) {
+	b, err := yaml.Marshal(v)
+	return string(b), err
+}
+
+// ReadValues will parse YAML byte data into a Values.
+func ReadValues(data []byte) (vals Values, err error) {
+	err = yaml.Unmarshal(data, &vals)
+	if len(vals) == 0 {
+		vals = Values{}
+	}
+	return
+}
+
+// ReadValuesFile will parse a YAML file into a map of values.
+func ReadValuesFile(filename string) (Values, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return map[string]interface{}{}, err
+	}
+	return ReadValues(data)
+}
+
+// Table gets a table (YAML subsection) from a Values object.
+//
+// The table is returned as a Values.
+//
+// Compound table names may be specified with dots:
+//
+//	foo.bar
+//
+// The above will be evaluated as "The table bar inside the table
+// foo".
+//
+// An ErrNoTable is returned if the table does not exist.
+func (v Values) Table(name string) (Values, error) {
+	names := strings.Split(name, ".")
+	table := v
+	var err error
+
+	for _, n := range names {
+		table, err = tableLookup(table, n)
+		if err != nil {
+			return table, err
+		}
+	}
+	return table, err
+}
+
+// AsMap is a utility function for converting Values to a map[string]interface{}.
+//
+// It protects against nil map panics.
+func (v Values) AsMap() map[string]interface{} {
+	if v == nil || len(v) == 0 {
+		return map[string]interface{}{}
+	}
+	return v
+}
+
+func tableLookup(v Values, simple string) (Values, error) {
+	v2, ok := v[simple]
+	if !ok {
+		return v, ErrNoTable(fmt.Errorf("no table named %q (%v)", simple, v))
+	}
+	if vv, ok := v2.(map[string]interface{}); ok {
+		return vv, nil
+	}
+
+	// This catches a case where a value is of type Values, but doesn't (for some
+	// reason) match the map[string]interface{}. This has been observed in the
+	// wild, and might be a result of a nil map of type Values.
+	if vv, ok := v2.(Values); ok {
+		return vv, nil
+	}
+
+	var e ErrNoTable = fmt.Errorf("no table named %q", simple)
+	return map[string]interface{}{}, e
+}
+
+// istable is a special-purpose function to see if the present thing matches the definition of a YAML table.
+func istable(v interface{}) bool {
+	_, ok := v.(map[string]interface{})
+	return ok
+}
+
+// PathValue takes a path that traverses a YAML structure and returns the value at the end of that path.
+// The path starts at the root of the YAML structure and is comprised of YAML keys separated by periods.
+// Given the following YAML data the value at path "chapter.one.title" is "Loomings".
+//
+//	chapter:
+//	  one:
+//	    title: "Loomings"
+func (v Values) PathValue(ypath string) (interface{}, error) {
+	if len(ypath) == 0 {
+		return nil, errors.New("YAML path string cannot be zero length")
+	}
+	yps := strings.Split(ypath, ".")
+	if len(yps) == 1 {
+		// if exists must be root key not table
+		vals := v.AsMap()
+		k := yps[0]
+		if _, ok := vals[k]; ok && !istable(vals[k]) {
+			// key found
+			return vals[yps[0]], nil
+		}
+		// key not found
+		return nil, ErrNoValue(fmt.Errorf("%v is not a value", k))
+	}
+	// join all elements of YAML path except last to get string table path
+	ypsLen := len(yps)
+	table := yps[:ypsLen-1]
+	st := strings.Join(table, ".")
+	// get the last element as a string key
+	key := yps[ypsLen-1:]
+	sk := string(key[0])
+	// get our table for table path
+	t, err := v.Table(st)
+	if err != nil {
+		//no table
+		return nil, ErrNoValue(fmt.Errorf("%v is not a value", sk))
+	}
+	// check table for key and ensure value is not a table
+	if k, ok := t[sk]; ok && !istable(k) {
+		// key found
+		return k, nil
+	}
+
+	// key not found
+	return nil, ErrNoValue(fmt.Errorf("key not found: %s", sk))
+}

--- a/test.sh
+++ b/test.sh
@@ -98,4 +98,5 @@ elif [ "$TEST_SUITE" = "everything-else" ]; then
 elif [ "$TEST_SUITE" = "local-volume" ]; then
 	make local-volume/provisioner
 	make test-local-volume/provisioner
+	make test-local-volume/helm
 fi


### PR DESCRIPTION
- Get rid of `engine` thing, it's better to use differnt values files for different environments.
- Rename `jobsrole` and `local-storage-provisioner-job-binding` to `local-storage-provisioner`, and only create them when necessary.
- Able to create StorageClass object and configure it.
- Add docs for all chart configurations.
  - https://github.com/cofyc/external-storage/blob/refactor_heml_chart/local-volume/helm/README.md#configurations
- Add some examples.
  - https://github.com/cofyc/external-storage/blob/refactor_heml_chart/local-volume/helm/README.md#examples