### PR TITLE
Update image tag to latest v1.0.9 for easy testing

### DIFF
--- a/nfs/README.md
+++ b/nfs/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/kubernetes_incubator/nfs-provisioner/status "Docker Repository on Quay")](https://quay.io/repository/kubernetes_incubator/nfs-provisioner)
 ```
-quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
 ```
 
 nfs-provisioner is an out-of-tree dynamic provisioner for Kubernetes 1.4. You can use it to quickly & easily deploy shared storage that works almost anywhere. Or it can help you write your own out-of-tree dynamic provisioner by serving as an example implementation of the requirements detailed in [the proposal](https://github.com/kubernetes/kubernetes/pull/30285). Go [here](./docs/demo) for a demo of how to use it and [here](../docs/demo/hostpath-provisioner) for an example of how to write your own.

--- a/nfs/deploy/kubernetes/auth/daemonset-sa.yaml
+++ b/nfs/deploy/kubernetes/auth/daemonset-sa.yaml
@@ -13,7 +13,7 @@ spec:
         app: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/deploy/kubernetes/auth/deployment-sa.yaml
+++ b/nfs/deploy/kubernetes/auth/deployment-sa.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccount: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/deploy/kubernetes/auth/pod-sa.yaml
+++ b/nfs/deploy/kubernetes/auth/pod-sa.yaml
@@ -6,7 +6,7 @@ spec:
   serviceAccount: nfs-provisioner
   containers:
     - name: nfs-provisioner
-      image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+      image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
       ports:
         - name: nfs
           containerPort: 2049

--- a/nfs/deploy/kubernetes/auth/statefulset-sa.yaml
+++ b/nfs/deploy/kubernetes/auth/statefulset-sa.yaml
@@ -36,7 +36,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/deploy/kubernetes/daemonset.yaml
+++ b/nfs/deploy/kubernetes/daemonset.yaml
@@ -12,7 +12,7 @@ spec:
         app: nfs-provisioner
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/deploy/kubernetes/deployment.yaml
+++ b/nfs/deploy/kubernetes/deployment.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/deploy/kubernetes/pod.yaml
+++ b/nfs/deploy/kubernetes/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: nfs-provisioner
-      image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+      image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
       ports:
         - name: nfs
           containerPort: 2049

--- a/nfs/deploy/kubernetes/statefulset.yaml
+++ b/nfs/deploy/kubernetes/statefulset.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 0
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/docs/demo/deployment.yaml
+++ b/nfs/docs/demo/deployment.yaml
@@ -33,7 +33,7 @@ spec:
     spec:
       containers:
         - name: nfs-provisioner
-          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+          image: quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
           ports:
             - name: nfs
               containerPort: 2049

--- a/nfs/docs/deployment.md
+++ b/nfs/docs/deployment.md
@@ -22,7 +22,7 @@ $ make container
 If you are running in Kubernetes, it will pull the image from Quay for you. Or you can do it yourself.
 
 ```
-$ docker pull quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
+$ docker pull quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9
 ```
 
 ## Deploying the provisioner
@@ -103,7 +103,7 @@ You may want to specify the hostname the NFS server exports from, i.e. the serve
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
 -v $HOME/.kube:/.kube:Z \
-quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8 \
+quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config
 ```
@@ -111,7 +111,7 @@ or
 ```
 $ docker run --cap-add DAC_READ_SEARCH --cap-add SYS_RESOURCE \
 --security-opt seccomp:deploy/docker/nfs-provisioner-seccomp.json \
-quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8 \
+quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9 \
 -provisioner=example.com/nfs \
 -master=http://172.17.0.1:8080
 ```
@@ -126,7 +126,7 @@ With the two above options, the run command will look something like this.
 $ docker run --privileged \
 -v $HOME/.kube:/.kube:Z \
 -v /xfs:/export:Z \
-quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8 \
+quay.io/kubernetes_incubator/nfs-provisioner:v1.0.9 \
 -provisioner=example.com/nfs \
 -kubeconfig=/.kube/config \
 -enable-xfs-quota=true


### PR DESCRIPTION
There is latest image of v1.0.9 that support storage class of "Retain" [Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1547884), I just want to contribute for easy testing. Thanks.