### PR TITLE
Add metrics server support for provision controller

### DIFF
--- a/lib/controller/metrics/metrics.go
+++ b/lib/controller/metrics/metrics.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	// ControllerSubsystem is prometheus subsystem name.
+	ControllerSubsystem = "controller"
+)
+
+var (
+	// PersistentVolumeClaimProvisionTotal is used to collect accumulated count of persistent volumes provisioned.
+	PersistentVolumeClaimProvisionTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolumeclaim_provision_total",
+			Help:      "Total number of persistent volumes provisioned. Broken down by storage class name.",
+		},
+		[]string{"class"},
+	)
+	// PersistentVolumeClaimProvisionFailedTotal is used to collect accumulated count of persistent volume provision failed attempts.
+	PersistentVolumeClaimProvisionFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolumeclaim_provision_failed_total",
+			Help:      "Total number of persistent volume provision failed attempts. Broken down by storage class name.",
+		},
+		[]string{"class"},
+	)
+	// PersistentVolumeClaimProvisionDurationSeconds is used to collect latency in seconds to provision persistent volumes.
+	PersistentVolumeClaimProvisionDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolumeclaim_provision_duration_seconds",
+			Help:      "Latency in seconds to provision persistent volumes. Broken down by storage class name.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"class"},
+	)
+	// PersistentVolumeDeleteTotal is used to collect accumulated count of persistent volumes deleted.
+	PersistentVolumeDeleteTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolume_delete_total",
+			Help:      "Total number of persistent volumes deleteed. Broken down by storage class name.",
+		},
+		[]string{"class"},
+	)
+	// PersistentVolumeDeleteFailedTotal is used to collect accumulated count of persistent volume delete failed attempts.
+	PersistentVolumeDeleteFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolume_delete_failed_total",
+			Help:      "Total number of persistent volume delete failed attempts. Broken down by storage class name.",
+		},
+		[]string{"class"},
+	)
+	// PersistentVolumeDeleteDurationSeconds is used to collect latency in seconds to delete persistent volumes.
+	PersistentVolumeDeleteDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Subsystem: ControllerSubsystem,
+			Name:      "persistentvolume_delete_duration_seconds",
+			Help:      "Latency in seconds to delete persistent volumes. Broken down by storage class name.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		[]string{"class"},
+	)
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pr add metrics server support for provision controller. 

Like kubelet's `storage_operation_xxx` metrics, it's better we can have some metrics to monitor latency of provision/delete operations and failures in provisioner.

Current metrics:

- controller_persistentvolumeclaim_provision_total
- controller_persistentvolumeclaim_provision_failed_total
- controller_persistentvolumeclaim_provision_duration_seconds
- controller_persistentvolume_delete_total
- controller_persistentvolume_delete_failed_total
- controller_persistentvolume_delete_duration_seconds

Metrics server is disabled by default. Each provisioner can enable based on needs. 
rbd/cephfs example: https://github.com/kubernetes-incubator/external-storage/pull/797/files

Examples:

```
...
controller_persistentvolume_delete_duration_seconds_bucket{class="rbd",le="10"} 4
controller_persistentvolume_delete_duration_seconds_bucket{class="rbd",le="+Inf"} 4
controller_persistentvolume_delete_duration_seconds_sum{class="rbd"} 1.0242772740000001
controller_persistentvolume_delete_duration_seconds_count{class="rbd"} 4
controller_persistentvolume_delete_total{class="rbd"} 4
...
controller_persistentvolumeclaim_discovery_duration_seconds_bucket{class="rbd",le="10"} 4
controller_persistentvolumeclaim_discovery_duration_seconds_bucket{class="rbd",le="+Inf"} 4
controller_persistentvolumeclaim_discovery_duration_seconds_sum{class="rbd"} 1.467650504
controller_persistentvolumeclaim_discovery_duration_seconds_count{class="rbd"} 4
controller_persistentvolumeclaim_provision_failed_total{class="rbd"} 9
controller_persistentvolumeclaim_provision_total{class="rbd"} 4
```