### PR TITLE
Use non-zero resync period as last insurance in local volume provisioner

### DIFF
--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -55,6 +55,7 @@ provisioner chart and their default values.
 | common.namespace                       | Namespace where provisioner runs.                                                                     | str      | `default`                                                  |
 | common.useAlphaAPI                     | If running against pre-1.10 k8s version, the `useAlphaAPI` flag must be enabled.                      | bool     | `false`                                                    |
 | common.useJobForCleaning               | Is set to true, provisioner will use jobs-based block cleaning.                                       | bool     | `false`                                                    |
+| common.minResyncPeriod                 | Resync period in reflectors will be random between `minResyncPeriod` and `2*minResyncPeriod`.         | str      | `5m0s`
 | common.configMapName                   | Provisioner ConfigMap name.                                                                           | str      | `local-provisioner-config`                                 |
 | classes.[n].name                       | StorageClass name.                                                                                    | str      | `-`                                                        |
 | classes.[n].hostDir                    | Path on the host where local volumes of this storage class are mounted under.                         | str      | `-`                                                        |
@@ -82,6 +83,7 @@ $ helm template ./helm/provisioner -f helm/examples/gce.yaml > ./provisioner/dep
 Currently you can try the following examples:
 
 * [examples/baremetal-cleanbyjobs.yaml](examples/baremetal-cleanbyjobs.yaml)
+* [examples/baremetal-resyncperiod.yaml](examples/baremetal-resyncperiod.yaml)
 * [examples/baremetal-without-rbac.yaml](examples/baremetal-without-rbac.yaml)
 * [examples/baremetal.yaml](examples/baremetal.yaml)
 * [examples/gce-pre1.9.yaml](examples/gce-pre1.9.yaml)

--- a/local-volume/helm/examples/baremetal-resyncperiod.yaml
+++ b/local-volume/helm/examples/baremetal-resyncperiod.yaml
@@ -1,0 +1,8 @@
+common:
+  minResyncPeriod: 1h
+classes:
+- name: local-storage
+  hostDir: /mnt/disks
+  blockCleanerCommand:
+  - "/scripts/quick_reset.sh"
+  storageClass: true

--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -16,6 +16,9 @@ data:
 {{- if .Values.common.useJobForCleaning }}
   useJobForCleaning: "yes"
 {{- end}}
+{{- if .Values.common.minResyncPeriod }}
+  minResyncPeriod: {{ .Values.common.minResyncPeriod | quote }}
+{{- end}}
   storageClassMap: |
     {{- range $classConfig := .Values.classes }}
     {{ $classConfig.name }}:

--- a/local-volume/helm/provisioner/values.yaml
+++ b/local-volume/helm/provisioner/values.yaml
@@ -21,6 +21,11 @@ common:
   #
   useJobForCleaning: false
   #
+  # Resync period in reflectors will be random between minResyncPeriod and
+  # 2*minResyncPeriod. Default: 5m0s.
+  #
+  #minResyncPeriod: 5m0s
+  #
   # Defines the name of configmap used by Provisioner
   #
   configMapName: "local-provisioner-config"

--- a/local-volume/helm/test/expected/baremetal-resyncperiod.yaml
+++ b/local-volume/helm/test/expected/baremetal-resyncperiod.yaml
@@ -1,0 +1,127 @@
+---
+# Source: provisioner/templates/provisioner.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: default
+data:
+  minResyncPeriod: "1h"
+  storageClassMap: |
+    local-storage:
+       hostDir: /mnt/disks
+       mountDir: /mnt/disks
+       blockCleanerCommand:
+         - "/scripts/quick_reset.sh"
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner
+  namespace: default
+  labels:
+    app: local-volume-provisioner
+spec:
+  selector:
+    matchLabels:
+      app: local-volume-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-volume-provisioner
+    spec:
+      serviceAccountName: local-storage-admin
+      containers:
+        - image: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          name: provisioner
+          securityContext:
+            privileged: true
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: JOB_CONTAINER_IMAGE
+            value: "quay.io/external_storage/local-volume-provisioner:v2.1.0"
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /dev
+              name: provisioner-dev
+            - mountPath: /mnt/disks
+              name: local-storage
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: provisioner-dev
+          hostPath:
+            path: /dev
+        - name: local-storage
+          hostPath:
+            path: /mnt/disks
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+# Source: provisioner/templates/provisioner-service-account.yaml
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: default
+
+---
+# Source: provisioner/templates/provisioner-cluster-role-binding.yaml
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: default
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: local-storage-admin
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/local-volume/helm/test/run.sh
+++ b/local-volume/helm/test/run.sh
@@ -49,7 +49,7 @@ function test_values_file() {
     trap "test -f $tmpfile && rm $tmpfile || true" EXIT
     helm template ./provisioner -f examples/$f > $tmpfile
     echo -n "Checking $input "
-    local diff=$(diff -u $expected $tmpfile) || true
+    local diff=$(diff -u $expected $tmpfile 2>&1) || true
     if [[ -n "${diff}" ]]; then
         echo "failed, diff: "
         echo "$diff"

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -92,6 +92,9 @@ type UserConfig struct {
 	Namespace string
 	// Image of container to use for jobs (optional)
 	JobContainerImage string
+	// MinResyncPeriod is minimum resync period. Resync period in reflectors
+	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
+	MinResyncPeriod metav1.Duration
 }
 
 // MountConfig stores a configuration for discoverying a specific storageclass
@@ -164,6 +167,9 @@ type ProvisionerConfiguration struct {
 	// default is false.
 	// +optional
 	UseJobForCleaning bool `json:"useJobForCleaning" yaml:"useJobForCleaning"`
+	// MinResyncPeriod is minimum resync period. Resync period in reflectors
+	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
+	MinResyncPeriod metav1.Duration `json:"minResyncPeriod" yaml:"minResyncPeriod"`
 }
 
 // CreateLocalPVSpec returns a PV spec that can be used for PV creation

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/golang/glog"
@@ -49,6 +50,11 @@ func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.CoreV1().RESTClient()).Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: provisionerName})
 
+	// We choose a random resync period between MinResyncPeriod and 2 *
+	// MinResyncPeriod, so that local provisioners deployed on multiple nodes
+	// at same time don't list the apiserver simultaneously.
+	resyncPeriod := time.Duration(config.MinResyncPeriod.Seconds()*(1+rand.Float64())) * time.Second
+
 	runtimeConfig := &common.RuntimeConfig{
 		UserConfig:      config,
 		Cache:           cache.NewVolumeCache(),
@@ -58,7 +64,7 @@ func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable
 		Name:            provisionerName,
 		Recorder:        recorder,
 		Mounter:         mount.New("" /* default mount path */),
-		InformerFactory: informers.NewSharedInformerFactory(client, 0),
+		InformerFactory: informers.NewSharedInformerFactory(client, resyncPeriod),
 	}
 
 	populator.NewPopulator(runtimeConfig)

--- a/local-volume/provisioner/pkg/deleter/jobcontroller.go
+++ b/local-volume/provisioner/pkg/deleter/jobcontroller.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	resyncPeriod = 120 * time.Second
-	maxRetries   = 10
+	maxRetries = 10
 	// JobContainerName is name of the container running the cleanup process.
 	JobContainerName = "cleaner"
 	// JobNamePrefix is the prefix of the name of the cleaning job.
@@ -82,7 +81,7 @@ func NewJobController(labelmap map[string]string, config *common.RuntimeConfig) 
 		options.LabelSelector = labels.SelectorFromSet(labelset).String()
 	}
 
-	informer := config.InformerFactory.InformerFor(&batch_v1.Job{}, func(client kubernetes.Interface, _ time.Duration) cache.SharedIndexInformer {
+	informer := config.InformerFactory.InformerFor(&batch_v1.Job{}, func(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			cache.NewFilteredListWatchFromClient(client.BatchV1().RESTClient(), "jobs", namespace, optionsModifier),
 			&batch_v1.Job{},


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/external-storage/issues/795.

- Add `MinResyncPeriod` configuration, defaults: 5m0s.
- Update JobController to use default resync period.
- Test `TestLoadProvisionerConfigs ` with real cases.
- Add example for customizing resync period.
- Update test/run.sh to fail on errors.