### PR TITLE
Add -k8sx.xx suffix to image tags

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -37,7 +37,7 @@ openebs-provisioner
 rbd-provisioner
 )
 
-regex="^($(IFS=\|; echo "${provisioners[*]}"))-(v[0-9]\.[0-9]\.[0-9])$"
+regex="^($(IFS=\|; echo "${provisioners[*]}"))-(v[0-9]+\.[0-9]+-k8s1.10)$"
 if [[ "${TRAVIS_TAG}" =~ $regex ]]; then
 	PROVISIONER="${BASH_REMATCH[1]}"
 	export VERSION="${BASH_REMATCH[2]}"


### PR DESCRIPTION
as discussed here https://github.com/kubernetes-incubator/external-storage/issues/369 I want the tag to contain the kube version it is (backwards) compatible with.

realistically this does not affect anybody but me when I push a release but I would hope other people follow