### PR TITLE
Specify initiator name for iSCSI PV source

### DIFF
--- a/openstack/standalone-cinder/pkg/provisioner/iscsi.go
+++ b/openstack/standalone-cinder/pkg/provisioner/iscsi.go
@@ -39,9 +39,10 @@ func getChapSecretName(connection volumeservice.VolumeConnection, options contro
 }
 
 func (m *iscsiMapper) BuildPVSource(conn volumeservice.VolumeConnection, options controller.VolumeOptions) (*v1.PersistentVolumeSource, error) {
+	initiatorName := volumeservice.InitiatorName
 	ret := &v1.PersistentVolumeSource{
 		ISCSI: &v1.ISCSIPersistentVolumeSource{
-			// TODO: Need some way to specify the initiator name
+			InitiatorName:   &initiatorName,
 			TargetPortal:    conn.Data.TargetPortal,
 			IQN:             conn.Data.TargetIqn,
 			Lun:             conn.Data.TargetLun,

--- a/openstack/standalone-cinder/pkg/volumeservice/actions.go
+++ b/openstack/standalone-cinder/pkg/volumeservice/actions.go
@@ -27,10 +27,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+// InitiatorName Initiator name
+const InitiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
+
 const attachMountPoint = "/k8s.io/standalone-cinder"
 const attachHostName = "standalone-cinder.k8s.io"
 
-const initiatorName = "iqn.1994-05.com.redhat:a13fc3d1cc22"
 const interval = 3 * time.Second
 const timeout = 60 * time.Second
 
@@ -102,7 +104,7 @@ func ConnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) (Volume
 	opt := volumeactions.InitializeConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: InitiatorName,
 	}
 	var rcv rcvVolumeConnection
 	err := volumeactions.InitializeConnection(vs, volumeID, &opt).ExtractInto(&rcv)
@@ -137,7 +139,7 @@ func DisconnectCinderVolume(vs *gophercloud.ServiceClient, volumeID string) erro
 	opt := volumeactions.TerminateConnectionOpts{
 		Host:      "localhost",
 		IP:        "127.0.0.1",
-		Initiator: initiatorName,
+		Initiator: InitiatorName,
 	}
 
 	err := volumeactions.TerminateConnection(vs, volumeID, &opt).Result.Err


### PR DESCRIPTION
Usually, initiator name is required for volumes created by cinder.
This specify initiator name for iSCSI PV source when it's created.

Fixes #742

Co-authored-by: Yuuichi Fujioka <fujioka.yuuichi@gmail.com>