### PR TITLE
Add osx support for helm installation script to fix travis OSX test

### DIFF
--- a/local-volume/helm/README.md
+++ b/local-volume/helm/README.md
@@ -6,11 +6,11 @@ In order to be able to use **helm** to render templates, it has to be installed 
 to generate templates.
 
 ## Helm Installation
-On Linux, run these two commands to download and copy helm binary into /usr/bin directory.
+On Linux or Mac OS, run these two commands to download and copy helm binary into /usr/local/bin directory.
 
 ``` console
-export HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
-curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/bin linux-amd64/helm -zxf -
+export HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-$(uname | tr A-Z a-z)-amd64.tar.gz
+curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/local/bin -zxf - $(uname | tr A-Z a-z)-amd64/helm
 ```
 Provisioner's spec generation process has been tested with helm version 2.7.2.
 

--- a/local-volume/helm/test/run.sh
+++ b/local-volume/helm/test/run.sh
@@ -22,8 +22,11 @@ ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 cd $ROOT
 
 function install_helm() {
-    local HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-v2.7.2-linux-amd64.tar.gz
-    curl "$HELM_URL" | sudo tar --strip-components 1 -C /usr/bin linux-amd64/helm -zxf -
+    local OS=$(uname | tr A-Z a-z)
+    local VERSION=v2.7.2
+    local ARCH=amd64
+    local HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-${OS}-${ARCH}.tar.gz
+    curl -s "$HELM_URL" | sudo tar --strip-components 1 -C /usr/local/bin -zxf - ${OS}-${ARCH}/helm
 }
 
 if ! which helm &>/dev/null; then


### PR DESCRIPTION
Fixes https://travis-ci.org/kubernetes-incubator/external-storage/jobs/392538641.

I also updated script to install binary in `/usr/local/bin` which is more appropriate to install programs not managed by distribution.