### PR TITLE
EFS should be mounted with nfs options vers=4.1

### DIFF
--- a/aws/efs/cmd/efs-provisioner/efs-provisioner.go
+++ b/aws/efs/cmd/efs-provisioner/efs-provisioner.go
@@ -171,6 +171,7 @@ func (p *efsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 					ReadOnly: false,
 				},
 			},
+			MountOptions: []string{"vers=4.1"},
 		},
 	}
 	if gidAllocate {


### PR DESCRIPTION
EFS performance will improve by mounting with the vers=4.1 nfs option (https://docs.aws.amazon.com/efs/latest/ug/mounting-fs.html).