### PR TITLE
[standalone-cinder-provisioner] Support for HTTPS endpoints and auth url

### DIFF
--- a/openstack/standalone-cinder/Dockerfile
+++ b/openstack/standalone-cinder/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM alpine:latest
 
+# support for HTTPS endpoints
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+
 COPY cinder-provisioner /
 
 ENTRYPOINT ["/cinder-provisioner"]


### PR DESCRIPTION
`alpine` doesn't have certificates needed to connect to a HTTPS auth url or HTTPS endpoints, so I added certificates to the `DockerFile`