### PR TITLE
[v2] Add block volume support check to external provisioners

### DIFF
--- a/iscsi/targetd/provisioner/iscsi-provisioner.go
+++ b/iscsi/targetd/provisioner/iscsi-provisioner.go
@@ -475,3 +475,7 @@ func (p *iscsiProvisioner) getConnection() (*jsonrpc2.Client, error) {
 	log.Debugln("targetd client created")
 	return client, nil
 }
+
+func (p *iscsiProvisioner) SupportsBlock() bool {
+	return true
+}

--- a/lib/controller/volume.go
+++ b/lib/controller/volume.go
@@ -47,6 +47,14 @@ type Qualifier interface {
 	ShouldProvision(*v1.PersistentVolumeClaim) bool
 }
 
+// BlockProvisioner is an optional interface implemented by provisioners to determine
+// whether it supports block volume.
+type BlockProvisioner interface {
+	Provisioner
+	// SupportsBlock returns whether provisioner supports block volume.
+	SupportsBlock() bool
+}
+
 // IgnoredError is the value for Delete to return to indicate that the call has
 // been ignored and no action taken. In case multiple provisioners are serving
 // the same storage class, provisioners may ignore PVs they are not responsible

--- a/lib/util/util.go
+++ b/lib/util/util.go
@@ -59,3 +59,9 @@ func AccessModesContainedInAll(indexedModes []v1.PersistentVolumeAccessMode, req
 	}
 	return true
 }
+
+// CheckPersistentVolumeClaimModeBlock checks VolumeMode.
+// If the mode is Block, return true otherwise return false.
+func CheckPersistentVolumeClaimModeBlock(pvc *v1.PersistentVolumeClaim) bool {
+	return pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == v1.PersistentVolumeBlock
+}


### PR DESCRIPTION
This PR add a block volume support check to external provisioners. This PR introduces BlockProvisioner interface and SupportsBlock() to check whether the provisioner supports block volume. They are used by the external provisioner library and if a provisioner doesn't supports block volume, the library output an error and doesn't try provisioning the block volume.
    
With this change, external provisioner that supports block volume is required to implement SupportsBlock() and return true. (Also, it must set volumeMode to pv spec that it returns.)

Specification and implementation have been discussed in below PR.
https://github.com/kubernetes-incubator/external-storage/pull/787
