### PR TITLE
Propagate MountOptions from StorageClasses to nfs-client-provisioner PVs

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -1029,11 +1029,17 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 		}
 	}
 
+	mountOptions, err := ctrl.fetchMountOptions(claimClass)
+	if err != nil {
+		return err
+	}
+
 	options := VolumeOptions{
 		PersistentVolumeReclaimPolicy: reclaimPolicy,
-		PVName:     pvName,
-		PVC:        claim,
-		Parameters: parameters,
+		PVName:         pvName,
+		PVC:            claim,
+		MountOptions:   mountOptions,
+		Parameters:     parameters,
 	}
 
 	ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("External provisioner is provisioning volume for claim %q", claimToClaimKey(claim)))
@@ -1360,4 +1366,23 @@ func (ctrl *ProvisionController) fetchReclaimPolicy(storageClassName string) (v1
 	}
 
 	return v1.PersistentVolumeReclaimDelete, fmt.Errorf("Cannot convert object to StorageClass: %+v", classObj)
+}
+
+func (ctrl *ProvisionController) fetchMountOptions(storageClassName string) ([]string, error) {
+	classObj, found, err := ctrl.classes.GetByKey(storageClassName)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("StorageClass %q not found", storageClassName)
+	}
+
+	switch class := classObj.(type) {
+	case *storage.StorageClass:
+		return class.MountOptions, nil
+	case *storagebeta.StorageClass:
+		return class.MountOptions, nil
+	}
+
+	return nil, fmt.Errorf("Cannot convert object to StorageClass: %+v", classObj)
 }

--- a/lib/controller/volume.go
+++ b/lib/controller/volume.go
@@ -68,6 +68,10 @@ type VolumeOptions struct {
 	// PV.Name of the appropriate PersistentVolume. Used to generate cloud
 	// volume name.
 	PVName string
+
+	// PV mount options. Not validated - mount of the PVs will simply fail if one is invalid.
+	MountOptions []string
+
 	// PVC is reference to the claim that lead to provisioning of a new PV.
 	// Provisioners *must* create a PV that would be matched by this PVC,
 	// i.e. with required capacity, accessMode, labels matching PVC.Selector and

--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -76,6 +76,7 @@ func (p *nfsProvisioner) Provision(options controller.VolumeOptions) (*v1.Persis
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
 			AccessModes:                   options.PVC.Spec.AccessModes,
+			MountOptions:                  options.MountOptions,
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},


### PR DESCRIPTION
This PR will allow StorageClasses to propagate MountOptions to PVs provisioned by nfs-client-provisioner. This is useful, for example, to specify the NFS protocol version to use to communicate with a server.