### PR TITLE
Shifted installation of helm, for local-volume/helm/test/run.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ all: aws/efs ceph/cephfs ceph/rbd flex gluster/block gluster/glusterfs gluster/f
 clean: clean-aws/efs clean-ceph/cephfs clean-ceph/rbd clean-flex clean-gluster/block clean-gluster/glusterfs clean-iscsi/targetd clean-local-volume/provisioner clean-nfs-client clean-nfs clean-openebs clean-snapshot
 .PHONY: clean
 
-test: test-aws/efs test-local-volume/provisioner test-local-volume/helm test-nfs test-snapshot
+test: test-aws/efs test-local-volume/provisioner test-nfs test-snapshot
 .PHONY: test
 
 verify:

--- a/local-volume/helm/test/run.sh
+++ b/local-volume/helm/test/run.sh
@@ -21,16 +21,9 @@ set -o pipefail
 ROOT=$(unset CDPATH && cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 cd $ROOT
 
-function install_helm() {
-    local OS=$(uname | tr A-Z a-z)
-    local VERSION=v2.7.2
-    local ARCH=amd64
-    local HELM_URL=http://storage.googleapis.com/kubernetes-helm/helm-${VERSION}-${OS}-${ARCH}.tar.gz
-    curl -s "$HELM_URL" | sudo tar --strip-components 1 -C /usr/local/bin -zxf - ${OS}-${ARCH}/helm
-}
-
 if ! which helm &>/dev/null; then
-    install_helm
+    echo "helm not installed, see README.md for instructions on installing it"
+    exit 2
 fi
 
 # lint first


### PR DESCRIPTION
It is no longer installed during execution of integration test automatically, as root.
It is installed during travisci test.sh.