### PR TITLE
NFS: Skip deletion if the corresponding directory is not found

### DIFF
--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -96,6 +96,10 @@ func (p *nfsProvisioner) Delete(volume *v1.PersistentVolume) error {
 	path := volume.Spec.PersistentVolumeSource.NFS.Path
 	pvName := filepath.Base(path)
 	oldPath := filepath.Join(mountPath, pvName)
+	if _, err := os.Stat(oldPath); os.IsNotExist(err) {
+		glog.Warningf("path %s does not exist, deletion skipped", oldPath)
+		return nil
+	}
 	archivePath := filepath.Join(mountPath, "archived-"+pvName)
 	glog.V(4).Infof("archiving path %s to %s", oldPath, archivePath)
 	return os.Rename(oldPath, archivePath)


### PR DESCRIPTION
If the volume directory is removed, the scheduled deletion will hang forever because os.Rename always fails. This commit adds a check on the volume directory before deletion, so if the directory is not available, the controller will proceed removing PV entries.