### PR TITLE
CoreDNS support for RBD

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -193,18 +193,31 @@ func (p *rbdProvisioner) Delete(volume *v1.PersistentVolume) error {
 func findDNSIP(p *rbdProvisioner) (dnsip string) {
 	// find DNS server address through client API
 	// cache result in rbdProvisioner
+	var dnssvc *v1.Service
+
 	if p.dnsip == "" {
-		dnssvc, err := p.client.CoreV1().Services(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
+		coredns, err := p.client.CoreV1().Services(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
+
 		if err != nil {
-			glog.Errorf("error getting kube-dns service: %v\n", err)
-			return ""
+			glog.Warningf("error getting coredns service: %v. Falling back to kube-dns\n", err)
+			kubedns, err := p.client.CoreV1().Services(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
+			if err != nil {
+				glog.Errorf("error getting kube-dns service: %v\n", err)
+				return ""
+			}
+			dnssvc = kubedns
+		} else {
+			dnssvc = coredns
 		}
+
 		if len(dnssvc.Spec.ClusterIP) == 0 {
-			glog.Errorf("kube-dns service ClusterIP bad\n")
+			glog.Errorf("DNS service ClusterIP bad\n")
 			return ""
 		}
+
 		p.dnsip = dnssvc.Spec.ClusterIP
 	}
+
 	return p.dnsip
 }
 

--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -189,7 +189,7 @@ func (p *rbdProvisioner) Delete(volume *v1.PersistentVolume) error {
 	return p.rbdUtil.DeleteImage(image, opts)
 }
 
-// Look up the cluster dns service by label "kube-dns"
+// Look up the cluster dns service by label "coredns", falling back to "kube-dns" if not found
 func findDNSIP(p *rbdProvisioner) (dnsip string) {
 	// find DNS server address through client API
 	// cache result in rbdProvisioner


### PR DESCRIPTION
Addresses https://github.com/kubernetes-incubator/external-storage/issues/780. 

This PR adds "coredns" as a supported option for RBD by first looking up the coredns ClusterIP, and falling back to "kubedns" if it's not found