### PR TITLE
Able to clean filesystem volume with job

### DIFF
--- a/local-volume/provisioner/deployment/docker/scripts/common.sh
+++ b/local-volume/provisioner/deployment/docker/scripts/common.sh
@@ -29,3 +29,15 @@ function validateBlockDevice {
     fi
 }
 
+function validateFilesystem {
+    if [ -z ${LOCAL_PV_FILESYSTEM+x} ]
+    then
+        errorExit "Environment variable LOCAL_PV_FILESYSTEM has not been set"
+    fi
+
+    if [ ! -d "$LOCAL_PV_FILESYSTEM" ]
+    then
+        errorExit "$LOCAL_PV_FILESYSTEM is not a filesystem directory."
+    fi
+}
+

--- a/local-volume/provisioner/deployment/docker/scripts/fsclean.sh
+++ b/local-volume/provisioner/deployment/docker/scripts/fsclean.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+# $ fsclean.sh 
+
+# Import common functions.
+. $(dirname "$0")/common.sh
+
+if [ "$1" == "-h" ]; then
+  echo "Usage: $(basename $0)"
+  echo "Invokes fsclean on the filesystem directory specified by environment variable LOCAL_PV_FILESYSTEM"
+  exit 0
+fi
+
+# Validate that we got a valid filesystem directory to cleanup
+validateFilesystem
+
+# Remove all contents under directory.
+#
+# find:
+#  -mindetph 1 -maxdepth 1: List first level children only, let `rm` to remove them recursively.
+#  -print0: Use NULL to separate filenames. This allows file names that
+#  contain newlines or other types of white space to be correctly
+#  interpreted by programs that process the find output.
+#
+# xargs:
+#  -0: Input items are terminated by a null character instead of by whitespace.
+# 
+ionice -c 3 find "$LOCAL_PV_FILESYSTEM" -mindepth 1 -maxdepth 1 -print0 | xargs -0 ionice -c 3 rm -rf

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -72,6 +72,8 @@ const (
 
 	// LocalPVEnv will contain the device path when script is invoked
 	LocalPVEnv = "LOCAL_PV_BLKDEVICE"
+	// LocalFilesystemEnv will contain the filesystm path when script is invoked
+	LocalFilesystemEnv = "LOCAL_PV_FILESYSTEM"
 	// KubeConfigEnv will (optionally) specify the location of kubeconfig file on the node.
 	KubeConfigEnv = "KUBECONFIG"
 


### PR DESCRIPTION
Fixes #737.

- ~~Add `-delete-contents` flag to delete contents in directory~~ (use `/scripts/fsclean.sh` script now)
  - Reuse in-process delete code
- ~~Rename DeviceAnnotation ("device") to VolumePathAnnotation ("volume-path")~~
- Create job to clean filesystem volume too when `useJobForCleaning` is true

Discussion:

- Should we allow user to specify minimum capacity of volumes to clean by jobs? For examples, provisioner only starts cleaner jobs for volumes larger than 1T. For small volumes, in-process will be much quicker.