### PR TITLE
Rename MY_NAMESPACE to JOB_NAMESPACE

### DIFF
--- a/local-volume/helm/provisioner/templates/provisioner.yaml
+++ b/local-volume/helm/provisioner/templates/provisioner.yaml
@@ -69,7 +69,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal-cleanbyjobs.yaml
+++ b/local-volume/helm/test/expected/baremetal-cleanbyjobs.yaml
@@ -41,7 +41,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal-resyncperiod.yaml
+++ b/local-volume/helm/test/expected/baremetal-resyncperiod.yaml
@@ -41,7 +41,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal-tolerations.yaml
+++ b/local-volume/helm/test/expected/baremetal-tolerations.yaml
@@ -44,7 +44,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal-with-resource-limits.yaml
+++ b/local-volume/helm/test/expected/baremetal-with-resource-limits.yaml
@@ -48,7 +48,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal-without-rbac.yaml
+++ b/local-volume/helm/test/expected/baremetal-without-rbac.yaml
@@ -40,7 +40,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/baremetal.yaml
+++ b/local-volume/helm/test/expected/baremetal.yaml
@@ -41,7 +41,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/gce-pre1.9.yaml
+++ b/local-volume/helm/test/expected/gce-pre1.9.yaml
@@ -39,7 +39,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/gce-retain.yaml
+++ b/local-volume/helm/test/expected/gce-retain.yaml
@@ -41,7 +41,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/gce.yaml
+++ b/local-volume/helm/test/expected/gce.yaml
@@ -41,7 +41,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/helm/test/expected/gke.yaml
+++ b/local-volume/helm/test/expected/gke.yaml
@@ -38,7 +38,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name: MY_NAMESPACE
+          - name: JOB_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace

--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -65,10 +65,10 @@ func main() {
 		glog.Fatalf("MY_NODE_NAME environment variable not set\n")
 	}
 
-	namespace := os.Getenv("MY_NAMESPACE")
-	if namespace == "" {
-		glog.Warningf("MY_NAMESPACE environment variable not set, will be set to default.\n")
-		namespace = "default"
+	jobNamespace := os.Getenv("JOB_NAMESPACE")
+	if jobNamespace == "" {
+		glog.Warningf("JOB_NAMESPACE environment variable not set, will be set to default.\n")
+		jobNamespace = "default"
 	}
 
 	jobImage := os.Getenv("JOB_CONTAINER_IMAGE")
@@ -88,7 +88,7 @@ func main() {
 		UseAlphaAPI:       provisionerConfig.UseAlphaAPI,
 		UseJobForCleaning: provisionerConfig.UseJobForCleaning,
 		MinResyncPeriod:   provisionerConfig.MinResyncPeriod,
-		Namespace:         namespace,
+		JobNamespace:      jobNamespace,
 		JobContainerImage: jobImage,
 	})
 

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -91,8 +91,8 @@ type UserConfig struct {
 	UseAlphaAPI bool
 	// UseJobForCleaning indicates if Jobs should be spawned for cleaning block devices (as opposed to process),.
 	UseJobForCleaning bool
-	// Namespace of this Pod (optional)
-	Namespace string
+	// Namespace to create jobs (optional)
+	JobNamespace string
 	// Image of container to use for jobs (optional)
 	JobContainerImage string
 	// MinResyncPeriod is minimum resync period. Resync period in reflectors

--- a/local-volume/provisioner/pkg/deleter/deleter.go
+++ b/local-volume/provisioner/pkg/deleter/deleter.go
@@ -340,7 +340,7 @@ func (d *Deleter) runJob(pv *v1.PersistentVolume, blkdevPath string, config comm
 	if d.JobContainerImage == "" {
 		return fmt.Errorf("cannot run cleanup job without specifying job image name in the environment variable")
 	}
-	job := NewCleanupJob(pv, d.JobContainerImage, d.Node.Name, d.Namespace, blkdevPath, config)
+	job := NewCleanupJob(pv, d.JobContainerImage, d.Node.Name, d.JobNamespace, blkdevPath, config)
 	return d.RuntimeConfig.APIUtil.CreateJob(job)
 }
 

--- a/local-volume/provisioner/pkg/deleter/deleter_test.go
+++ b/local-volume/provisioner/pkg/deleter/deleter_test.go
@@ -571,7 +571,7 @@ func testSetup(t *testing.T, config *testConfig, cleanupCmd []string, useJobForC
 		Node:              &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: "somehost.acme.com"}},
 		UseJobForCleaning: useJobForCleaning,
 		JobContainerImage: containerImage,
-		Namespace:         ns,
+		JobNamespace:      ns,
 	}
 
 	// set buffer size big enough, not all cases care about recorder.

--- a/local-volume/provisioner/pkg/deleter/jobcontroller.go
+++ b/local-volume/provisioner/pkg/deleter/jobcontroller.go
@@ -74,7 +74,7 @@ type jobController struct {
 
 // NewJobController instantiates  a new job controller.
 func NewJobController(labelmap map[string]string, config *common.RuntimeConfig) (JobController, error) {
-	namespace := config.Namespace
+	namespace := config.JobNamespace
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	labelset := labels.Set(labelmap)
 	optionsModifier := func(options *meta_v1.ListOptions) {


### PR DESCRIPTION
I think `JOB_NAMESPACE` is a better name, because it's used to specify namespace to create jobs in, although we use same namespace as provisioner in helm chart by default (hardcoded now but it's possible to make it configurable).