### PR TITLE
Enabling k8s Deployment ability to control Replica Set's life cycle with selectors.

### DIFF
--- a/aws/efs/deploy/deployment.yaml
+++ b/aws/efs/deploy/deployment.yaml
@@ -2,10 +2,15 @@ kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
   name: efs-provisioner
+  labels:
+    app: efs-provisioner
 spec:
   replicas: 1
   strategy:
-    type: Recreate 
+    type: Recreate
+  selector:
+    matchLabels:
+      app: efs-provisioner
   template:
     metadata:
       labels:


### PR DESCRIPTION
Before:
  Every time you update `specs` of the Deployment, new Replica Set is created by Deployment without deleting an old one.
After: 
  Deployment is able to delete old Replica Set.