### PR TITLE
deployment and pod YAML file format error under gluster/file/deploy/ directory

### DIFF
--- a/gluster/file/deploy/deployment.yaml
+++ b/gluster/file/deploy/deployment.yaml
@@ -12,8 +12,8 @@ spec:
         app: glusterfile-provisioner
     spec:
       containers:
-          env:
-              name: PROVISIONER_NAME
+        - env:
+            - name: PROVISIONER_NAME
               value: gluster.org/glusterfile
           image: "quay.io/external_storage/glusterfile-provisioner:latest"
           name: glusterfile-provisioner

--- a/gluster/file/deploy/glusterfile-provisioner-pod.yaml
+++ b/gluster/file/deploy/glusterfile-provisioner-pod.yaml
@@ -4,8 +4,8 @@ metadata:
   name: glusterfile-provisioner
 spec: 
   containers: 
-    env:
-      name: PROVISIONER_NAME
+  - env:
+    - name: PROVISIONER_NAME
       value: gluster.org/glusterfile
     image: "quay.io/external_storage/glusterfile-provisioner:latest"
     name: glusterfile-provisioner


### PR DESCRIPTION
This is the PR to address the issue #869  deployment and pod YAML file format error under gluster/file/deploy/ directory. 

These two YAML file cannot be applied into K8S. The expected container and env variables would be array but they were mistakenly given as map data type

```
pwd
~/external-storage/gluster/file/deploy
kubectl create -f deployment.yaml
error: error validating "deployment.yaml": error validating data: ValidationError(Deployment.spec.template.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```

```
pwd
~/external-storage/gluster/file/deploy
kubectl create -f glusterfile-provisioner-pod.yaml
error: error validating "glusterfile-provisioner-pod.yaml": error validating data: ValidationError(Pod.spec.containers): invalid type for io.k8s.api.core.v1.PodSpec.containers: got "map", expected "array"; if you choose to ignore these errors, turn validation off with --validate=false
```