### PR TITLE
Update README in rbd and cephfs

### DIFF
--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -25,9 +25,9 @@ See https://kubernetes.io/.
 * Create a Ceph admin secret
 
 ```bash
-ceph auth get client.admin 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
+ceph auth get-key client.admin > /tmp/secret
 kubectl create ns cephfs
-kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=cephfs
+kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=kube-system
 ```
 
 * Start CephFS provisioner
@@ -35,7 +35,7 @@ kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namesp
 The following example uses `cephfs-provisioner-1` as the identity for the instance and assumes kubeconfig is at `/root/.kube`. The identity should remain the same if the provisioner restarts. If there are multiple provisioners, each should have a different identity.
 
 ```bash
-docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host  cephfs-provisioner /usr/local/bin/cephfs-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=cephfs-provisioner-1
+docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host quay.io/external_storage/cephfs-provisioner /usr/local/bin/cephfs-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=cephfs-provisioner-1
 ```
 
 Alternatively, deploy it in kubernetes, see [deployment](deploy/README.md).

--- a/ceph/rbd/README.md
+++ b/ceph/rbd/README.md
@@ -40,7 +40,7 @@ kubectl create secret generic ceph-admin-secret --from-file=/tmp/secret --namesp
 ```bash
 ceph osd pool create kube 8 8
 ceph auth add client.kube mon 'allow r' osd 'allow rwx pool=kube'
-ceph auth get client.kube 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
+ceph auth get-key client.admin > /tmp/secret
 kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=kube-system
 ```
 
@@ -49,7 +49,7 @@ kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=ku
 The following example uses `rbd-provisioner-1` as the identity for the instance and assumes kubeconfig is at `/root/.kube`. The identity should remain the same if the provisioner restarts. If there are multiple provisioners, each should have a different identity.
 
 ```bash
-docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host rbd-provisioner /usr/local/bin/rbd-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=rbd-provisioner-1
+docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host quay.io/external_storage/rbd-provisioner /usr/local/bin/rbd-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=rbd-provisioner-1
 ```
 
 Alternatively, deploy it in kubernetes, see [deployment](deploy/README.md).


### PR DESCRIPTION
Currently there are three issues when walk through the README.

1. cephfs example creates secret in `cephfs` even though [`class.yaml` specified kube-system](https://github.com/kubernetes-incubator/external-storage/blob/83f870173c188fccd8262df05bf64d82ecaa744b/ceph/cephfs/example/class.yaml#L10)
2. `docker run cephfs-provisioner` fails as the image is stored in `quay.io/external_storage`.
3. (Not an issue but) `ceph auth get-key client.xxx` could be used instead of `ceph auth get client.admin` with grep/awk/xargs.


Hence, this patch chagnes to:
- create secret for cephfs in kube-system namespace as `cephfs/example/class.yaml` specified so.
- put `quay.io/external_storage/` in front of image name (cephfs-provisioner and rbd-provisioner)
- use `ceph auth get-key client.xxx` command to get secret