### PR TITLE
flex: Add capacity value to createVolume

### DIFF
--- a/flex/pkg/volume/provision.go
+++ b/flex/pkg/volume/provision.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/exec"
+	"k8s.io/kubernetes/pkg/volume/util"
+	"strconv"
 )
 
 const (
@@ -108,6 +110,14 @@ func (p *flexProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 func (p *flexProvisioner) createVolume(volumeOptions controller.VolumeOptions) error {
 	extraOptions := map[string]string{}
 	extraOptions[optionPVorVolumeName] = volumeOptions.PVName
+
+	capacity := volumeOptions.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+        requestBytes := capacity.Value()
+        requestMiB := int(util.RoundUpSize(requestBytes, 1024*1024))
+        requestGiB := int(util.RoundUpSize(requestBytes, 1024*1024*1024))
+        extraOptions["requestBytes"] = strconv.FormatInt(requestBytes, 10)
+        extraOptions["requestMiB"] = strconv.Itoa(requestMiB)
+        extraOptions["requestGiB"] = strconv.Itoa(requestGiB)
 
 	call := p.NewDriverCall(p.execCommand, provisionCmd)
 	call.AppendSpec(volumeOptions.Parameters, extraOptions)


### PR DESCRIPTION
I think volume `capacity` is the most necessary value for `doProvision()` right now.

`Bytes`, `MiB`, and `GiB` units have been added so that the capacity value can be obtained from the `doProvision()` function. (not a breaking change.)

Related issues. https://github.com/kubernetes-incubator/external-storage/issues/868


This is the tested output.
```
2018-07-25 04:29:47 flex[181]: provision() called: {"kubernetes.io/pvOrVolumeName":"pvc-55160e9c-8fc3-11e8-8cea-525400d87180","requestBytes":"1073741824","requestGiB":"1","requestMiB":"1024"}
```