### PR TITLE
flex: Add capacity value to createVolume

### DIFF
--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -25,9 +25,9 @@ See https://kubernetes.io/.
 * Create a Ceph admin secret
 
 ```bash
-ceph auth get client.admin 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
+ceph auth get-key client.admin > /tmp/secret
 kubectl create ns cephfs
-kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=cephfs
+kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=kube-system
 ```
 
 * Start CephFS provisioner
@@ -35,7 +35,7 @@ kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namesp
 The following example uses `cephfs-provisioner-1` as the identity for the instance and assumes kubeconfig is at `/root/.kube`. The identity should remain the same if the provisioner restarts. If there are multiple provisioners, each should have a different identity.
 
 ```bash
-docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host  cephfs-provisioner /usr/local/bin/cephfs-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=cephfs-provisioner-1
+docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host quay.io/external_storage/cephfs-provisioner /usr/local/bin/cephfs-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=cephfs-provisioner-1
 ```
 
 Alternatively, deploy it in kubernetes, see [deployment](deploy/README.md).

--- a/ceph/rbd/README.md
+++ b/ceph/rbd/README.md
@@ -40,7 +40,7 @@ kubectl create secret generic ceph-admin-secret --from-file=/tmp/secret --namesp
 ```bash
 ceph osd pool create kube 8 8
 ceph auth add client.kube mon 'allow r' osd 'allow rwx pool=kube'
-ceph auth get client.kube 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
+ceph auth get-key client.admin > /tmp/secret
 kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=kube-system
 ```
 
@@ -49,7 +49,7 @@ kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=ku
 The following example uses `rbd-provisioner-1` as the identity for the instance and assumes kubeconfig is at `/root/.kube`. The identity should remain the same if the provisioner restarts. If there are multiple provisioners, each should have a different identity.
 
 ```bash
-docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host rbd-provisioner /usr/local/bin/rbd-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=rbd-provisioner-1
+docker run -ti -v /root/.kube:/kube -v /var/run/kubernetes:/var/run/kubernetes --privileged --net=host quay.io/external_storage/rbd-provisioner /usr/local/bin/rbd-provisioner -master=http://127.0.0.1:8080 -kubeconfig=/kube/config -id=rbd-provisioner-1
 ```
 
 Alternatively, deploy it in kubernetes, see [deployment](deploy/README.md).

--- a/flex/pkg/volume/provision.go
+++ b/flex/pkg/volume/provision.go
@@ -23,7 +23,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/utils/exec"
+	"strconv"
 )
 
 const (
@@ -108,6 +110,14 @@ func (p *flexProvisioner) Provision(options controller.VolumeOptions) (*v1.Persi
 func (p *flexProvisioner) createVolume(volumeOptions controller.VolumeOptions) error {
 	extraOptions := map[string]string{}
 	extraOptions[optionPVorVolumeName] = volumeOptions.PVName
+
+	capacity := volumeOptions.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
+	requestBytes := capacity.Value()
+	requestMiB := int(util.RoundUpSize(requestBytes, 1024*1024))
+	requestGiB := int(util.RoundUpSize(requestBytes, 1024*1024*1024))
+	extraOptions["requestBytes"] = strconv.FormatInt(requestBytes, 10)
+	extraOptions["requestMiB"] = strconv.Itoa(requestMiB)
+	extraOptions["requestGiB"] = strconv.Itoa(requestGiB)
 
 	call := p.NewDriverCall(p.execCommand, provisionCmd)
 	call.AppendSpec(volumeOptions.Parameters, extraOptions)


### PR DESCRIPTION
I think volume `capacity` is the most necessary value for `doProvision()` right now.

`Bytes`, `MiB`, and `GiB` units have been added so that the capacity value can be obtained from the `doProvision()` function. (not a breaking change.)

Related issues. https://github.com/kubernetes-incubator/external-storage/issues/868


This is the tested output.
```
2018-07-25 04:29:47 flex[181]: provision() called: {"kubernetes.io/pvOrVolumeName":"pvc-55160e9c-8fc3-11e8-8cea-525400d87180","requestBytes":"1073741824","requestGiB":"1","requestMiB":"1024"}
```