### PR TITLE
Initialize exponentialBackOffOnError by default.

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -428,6 +428,7 @@ func NewProvisionController(
 		identity:                      identity,
 		eventRecorder:                 eventRecorder,
 		resyncPeriod:                  DefaultResyncPeriod,
+		exponentialBackOffOnError:     DefaultExponentialBackOffOnError,
 		threadiness:                   DefaultThreadiness,
 		createProvisionedPVRetryCount: DefaultCreateProvisionedPVRetryCount,
 		createProvisionedPVInterval:   DefaultCreateProvisionedPVInterval,


### PR DESCRIPTION
Claim/volume queues are constructed with following rate limiter because exponentialBackOffOnError is false  by default, it cannot save failures with RateLimiting feature:

```
ratelimiter = workqueue.NewMaxOfRateLimiter(
        &workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
)  
```

Fixes #890.