### PR TITLE
Fix non-exponentialbackoff having 0 delay, make it 15s

### DIFF
--- a/lib/controller/controller.go
+++ b/lib/controller/controller.go
@@ -457,6 +457,7 @@ func NewProvisionController(
 	)
 	if !controller.exponentialBackOffOnError {
 		ratelimiter = workqueue.NewMaxOfRateLimiter(
+			workqueue.NewItemExponentialFailureRateLimiter(15*time.Second, 15*time.Second),
 			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 		)
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-incubator/external-storage/issues/890 so that even if exponentialBackOff is false we retry every ~15s and respect the threshold

W0730 21:07:41.215547       1 controller.go:688] retrying syncing claim "default/nfs-with-bad-class" because failures 5 < threshold 15
W0730 21:07:58.235704       1 controller.go:688] retrying syncing claim "default/nfs-with-bad-class" because failures 6 < threshold 15
W0730 21:08:15.259908       1 controller.go:688] retrying syncing claim "default/nfs-with-bad-class" because failures 7 < threshold 15
