### PR TITLE
Snapshot: Store fsType in VolumeSnapshotData for AWS

### DIFF
--- a/snapshot/pkg/apis/crd/v1/types.go
+++ b/snapshot/pkg/apis/crd/v1/types.go
@@ -214,6 +214,10 @@ type GlusterVolumeSnapshotSource struct {
 type AWSElasticBlockStoreVolumeSnapshotSource struct {
 	// Unique id of the persistent disk snapshot resource. Used to identify the disk snapshot in AWS
 	SnapshotID string `json:"snapshotId"`
+	// Original volume file system type. The volume created from the snapshot would be pre-formatted
+	// using the same file system, so it has to be saved along with the AWS snapshot ID
+	// +optional
+	FSType string `json:"fsType"`
 }
 
 // CinderVolumeSnapshotSource is Cinder volume snapshot source

--- a/snapshot/pkg/volume/awsebs/processor.go
+++ b/snapshot/pkg/volume/awsebs/processor.go
@@ -78,6 +78,7 @@ func (a *awsEBSPlugin) SnapshotCreate(
 	return &crdv1.VolumeSnapshotDataSource{
 		AWSElasticBlockStore: &crdv1.AWSElasticBlockStoreVolumeSnapshotSource{
 			SnapshotID: snapshotID,
+			FSType:     spec.AWSElasticBlockStore.FSType,
 		},
 	}, convertAWSStatus(status), nil
 }
@@ -184,11 +185,11 @@ func (a *awsEBSPlugin) SnapshotRestore(snapshotData *crdv1.VolumeSnapshotData, p
 	pv := &v1.PersistentVolumeSource{
 		AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
 			VolumeID:  string(volumeID),
-			FSType:    "ext4",
 			Partition: 0,
 			ReadOnly:  false,
 		},
 	}
+	pv.AWSElasticBlockStore.FSType = snapshotData.Spec.AWSElasticBlockStore.FSType
 
 	return pv, labels, nil
 


### PR DESCRIPTION
When AWS restores snapshot it creates a volume that is formatted exactly as the original. The original volume filesystem has to be stored somewhere so the provisioner can create a PV with proper fsType.

The patch is simple but adds new API attribute to the AWSElasticBlockStoreVolumeSnapshotSource.

Related: issue #879 