### PR TITLE
Plumbing topology information through Provision call in external PVController library.

### DIFF
--- a/lib/controller/volume.go
+++ b/lib/controller/volume.go
@@ -87,4 +87,9 @@ type VolumeOptions struct {
 	PVC *v1.PersistentVolumeClaim
 	// Volume provisioning parameters from StorageClass
 	Parameters map[string]string
+
+	// Node selected by the scheduler for the volume.
+	SelectedNode *v1.Node
+	// Topology constraint parameter from StorageClass
+	AllowedTopologies []v1.TopologySelectorTerm
 }


### PR DESCRIPTION
This is a dependency for adding topology functionality to CSI.

In the future, we'd like to cache Node objects since almost all plugins will go through CSI. For now I hope to get the provisioner interface change in first to unblock CSI work, and open an issue to track the work once this PR is merged.

/cc @wongma7 @msau42 @lichuqiang