### PR TITLE
Add export-subnet for limit NFS clients

### DIFF
--- a/nfs/cmd/nfs-provisioner/main.go
+++ b/nfs/cmd/nfs-provisioner/main.go
@@ -42,6 +42,7 @@ var (
 	gracePeriod    = flag.Uint("grace-period", 90, "NFS Ganesha grace period to use in seconds, from 0-180. If the server is not expected to survive restarts, i.e. it is running as a pod & its export directory is not persisted, this can be set to 0. Can only be set if both run-server and use-ganesha are true. Default 90.")
 	enableXfsQuota = flag.Bool("enable-xfs-quota", false, "If the provisioner will set xfs quotas for each volume it provisions. Requires that the directory it creates volumes in ('/export') is xfs mounted with option prjquota/pquota, and that it has the privilege to run xfs_quota. Default false.")
 	serverHostname = flag.String("server-hostname", "", "The hostname for the NFS server to export from. Only applicable when running out-of-cluster i.e. it can only be set if either master or kubeconfig are set. If unset, the first IP output by `hostname -i` is used.")
+	exportSubnet   = flag.String("export-subnet", "*", "Subnet for NFS export to allow mount only from")
 	maxExports     = flag.Int("max-exports", -1, "The maximum number of volumes to be exported by this provisioner. New claims will be ignored once this limit has been reached. A negative value is interpreted as 'unlimited'. Default -1.")
 )
 
@@ -124,7 +125,7 @@ func main() {
 
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
-	nfsProvisioner := vol.NewNFSProvisioner(exportDir, clientset, outOfCluster, *useGanesha, ganeshaConfig, *enableXfsQuota, *serverHostname, *maxExports)
+	nfsProvisioner := vol.NewNFSProvisioner(exportDir, clientset, outOfCluster, *useGanesha, ganeshaConfig, *enableXfsQuota, *serverHostname, *maxExports, *exportSubnet)
 
 	// Start the provision controller which will dynamically provision NFS PVs
 	pc := controller.NewProvisionController(

--- a/nfs/cmd/nfs-provisioner/main.go
+++ b/nfs/cmd/nfs-provisioner/main.go
@@ -66,6 +66,10 @@ func main() {
 		glog.Fatalf("Invalid flags specified: if run-server is true, use-ganesha must also be true.")
 	}
 
+	if *useGanesha && *exportSubnet != "*" {
+		glog.Warningf("If use-ganesha is true, there is no effect on export-subnet.")
+	}
+
 	if *gracePeriod != 90 && (!*runServer || !*useGanesha) {
 		glog.Fatalf("Invalid flags specified: custom grace period can only be set if both run-server and use-ganesha are true.")
 	} else if *gracePeriod > 180 && *runServer && *useGanesha {

--- a/nfs/pkg/volume/export.go
+++ b/nfs/pkg/volume/export.go
@@ -31,14 +31,14 @@ import (
 
 type exporter interface {
 	CanExport(int) bool
-	AddExportBlock(string, bool) (string, uint16, error)
+	AddExportBlock(string, bool, string) (string, uint16, error)
 	RemoveExportBlock(string, uint16) error
 	Export(string) error
 	Unexport(*v1.PersistentVolume) error
 }
 
 type exportBlockCreator interface {
-	CreateExportBlock(string, string, bool) string
+	CreateExportBlock(string, string, bool, string) string
 }
 
 type exportMap struct {
@@ -87,11 +87,11 @@ func newGenericExporter(ebc exportBlockCreator, config string, re *regexp.Regexp
 	}
 }
 
-func (e *genericExporter) AddExportBlock(path string, rootSquash bool) (string, uint16, error) {
+func (e *genericExporter) AddExportBlock(path string, rootSquash bool, exportSubnet string) (string, uint16, error) {
 	exportID := generateID(e.mapMutex, e.exportIDs)
 	exportIDStr := strconv.FormatUint(uint64(exportID), 10)
 
-	block := e.ebc.CreateExportBlock(exportIDStr, path, rootSquash)
+	block := e.ebc.CreateExportBlock(exportIDStr, path, rootSquash, exportSubnet)
 
 	// Add the export block to the config file
 	if err := addToFile(e.fileMutex, e.config, block); err != nil {
@@ -161,7 +161,7 @@ type ganeshaExportBlockCreator struct{}
 var _ exportBlockCreator = &ganeshaExportBlockCreator{}
 
 // CreateBlock creates the text block to add to the ganesha config file.
-func (e *ganeshaExportBlockCreator) CreateExportBlock(exportID, path string, rootSquash bool) string {
+func (e *ganeshaExportBlockCreator) CreateExportBlock(exportID, path string, rootSquash bool, exportSubnet string) string {
 	squash := "no_root_squash"
 	if rootSquash {
 		squash = "root_id_squash"
@@ -217,10 +217,10 @@ type kernelExportBlockCreator struct{}
 var _ exportBlockCreator = &kernelExportBlockCreator{}
 
 // CreateBlock creates the text block to add to the /etc/exports file.
-func (e *kernelExportBlockCreator) CreateExportBlock(exportID, path string, rootSquash bool) string {
+func (e *kernelExportBlockCreator) CreateExportBlock(exportID, path string, rootSquash bool, exportSubnet string) string {
 	squash := "no_root_squash"
 	if rootSquash {
 		squash = "root_squash"
 	}
-	return "\n" + path + " *(rw,insecure," + squash + ",fsid=" + exportID + ")\n"
+	return "\n" + path + " " + exportSubnet + "(rw,insecure," + squash + ",fsid=" + exportID + ")\n"
 }

--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -127,7 +127,7 @@ func newNFSProvisionerInternal(exportDir string, client kubernetes.Interface, ou
 		quotaer:        quotaer,
 		serverHostname: serverHostname,
 		maxExports:     maxExports,
-		exportSubnet:	exportSubnet,
+		exportSubnet:   exportSubnet,
 		identity:       identity,
 		podIPEnv:       podIPEnv,
 		serviceEnv:     serviceEnv,

--- a/nfs/pkg/volume/provision.go
+++ b/nfs/pkg/volume/provision.go
@@ -78,7 +78,7 @@ const (
 
 // NewNFSProvisioner creates a Provisioner that provisions NFS PVs backed by
 // the given directory.
-func NewNFSProvisioner(exportDir string, client kubernetes.Interface, outOfCluster bool, useGanesha bool, ganeshaConfig string, enableXfsQuota bool, serverHostname string, maxExports int) controller.Provisioner {
+func NewNFSProvisioner(exportDir string, client kubernetes.Interface, outOfCluster bool, useGanesha bool, ganeshaConfig string, enableXfsQuota bool, serverHostname string, maxExports int, exportSubnet string) controller.Provisioner {
 	var exp exporter
 	if useGanesha {
 		exp = newGaneshaExporter(ganeshaConfig)
@@ -95,10 +95,10 @@ func NewNFSProvisioner(exportDir string, client kubernetes.Interface, outOfClust
 	} else {
 		quotaer = newDummyQuotaer()
 	}
-	return newNFSProvisionerInternal(exportDir, client, outOfCluster, exp, quotaer, serverHostname, maxExports)
+	return newNFSProvisionerInternal(exportDir, client, outOfCluster, exp, quotaer, serverHostname, maxExports, exportSubnet)
 }
 
-func newNFSProvisionerInternal(exportDir string, client kubernetes.Interface, outOfCluster bool, exporter exporter, quotaer quotaer, serverHostname string, maxExports int) *nfsProvisioner {
+func newNFSProvisionerInternal(exportDir string, client kubernetes.Interface, outOfCluster bool, exporter exporter, quotaer quotaer, serverHostname string, maxExports int, exportSubnet string) *nfsProvisioner {
 	if _, err := os.Stat(exportDir); os.IsNotExist(err) {
 		glog.Fatalf("exportDir %s does not exist!", exportDir)
 	}
@@ -127,6 +127,7 @@ func newNFSProvisionerInternal(exportDir string, client kubernetes.Interface, ou
 		quotaer:        quotaer,
 		serverHostname: serverHostname,
 		maxExports:     maxExports,
+		exportSubnet:	exportSubnet,
 		identity:       identity,
 		podIPEnv:       podIPEnv,
 		serviceEnv:     serviceEnv,
@@ -161,6 +162,9 @@ type nfsProvisioner struct {
 
 	// The maximum number of volumes to be exported by the provisioner
 	maxExports int
+
+	// Subnet for NFS export to allow mount only from
+	exportSubnet string
 
 	// Identity of this nfsProvisioner, generated & persisted to exportDir or
 	// recovered from there. Used to mark provisioned PVs
@@ -483,7 +487,7 @@ func (p *nfsProvisioner) createDirectory(directory, gid string) error {
 func (p *nfsProvisioner) createExport(directory string, rootSquash bool) (string, uint16, error) {
 	path := path.Join(p.exportDir, directory)
 
-	block, exportID, err := p.exporter.AddExportBlock(path, rootSquash)
+	block, exportID, err := p.exporter.AddExportBlock(path, rootSquash, p.exportSubnet)
 	if err != nil {
 		return "", 0, fmt.Errorf("error adding export block for path %s: %v", path, err)
 	}

--- a/nfs/pkg/volume/provision_test.go
+++ b/nfs/pkg/volume/provision_test.go
@@ -200,7 +200,7 @@ func TestCreateVolume(t *testing.T) {
 		config:    conf,
 	}
 	maxExports := 3
-	p := newNFSProvisionerInternal(tmpDir+"/", client, false, exporter, newDummyQuotaer(), "", maxExports)
+	p := newNFSProvisionerInternal(tmpDir+"/", client, false, exporter, newDummyQuotaer(), "", maxExports, "*")
 
 	for _, test := range tests {
 		os.Setenv(test.envKey, "1.1.1.1")
@@ -344,7 +344,7 @@ func TestValidateOptions(t *testing.T) {
 	}
 
 	client := fake.NewSimpleClientset()
-	p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{}, newDummyQuotaer(), "", -1)
+	p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{}, newDummyQuotaer(), "", -1, "*")
 
 	for _, test := range tests {
 		gid, rootSquash, _, err := p.validateOptions(test.options)
@@ -403,7 +403,7 @@ func evaluateExportTests(t *testing.T, output string, checker func(*nfsProvision
 	}
 	for _, test := range tests {
 		client := fake.NewSimpleClientset()
-		p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{exportMap: &exportMap{exportIDs: test.exportIDs}}, newDummyQuotaer(), "", test.maxExports)
+		p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{exportMap: &exportMap{exportIDs: test.exportIDs}}, newDummyQuotaer(), "", test.maxExports, "*")
 		ok := checker(p)
 		evaluate(t, test.name, test.expectError, nil, test.expectedResult, ok, output)
 	}
@@ -459,7 +459,7 @@ func TestCreateDirectory(t *testing.T) {
 	}
 
 	client := fake.NewSimpleClientset()
-	p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{}, newDummyQuotaer(), "", -1)
+	p := newNFSProvisionerInternal(tmpDir+"/", client, false, &testExporter{}, newDummyQuotaer(), "", -1, "*")
 
 	for _, test := range tests {
 		path := p.exportDir + test.directory
@@ -740,7 +740,7 @@ func TestGetServer(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(test.objs...)
-		p := newNFSProvisionerInternal(tmpDir+"/", client, test.outOfCluster, &testExporter{}, newDummyQuotaer(), test.serverHostname, -1)
+		p := newNFSProvisionerInternal(tmpDir+"/", client, test.outOfCluster, &testExporter{}, newDummyQuotaer(), test.serverHostname, -1, "*")
 
 		server, err := p.getServer()
 
@@ -826,7 +826,7 @@ func (e *testExporter) CanExport(limit int) bool {
 	return true
 }
 
-func (e *testExporter) AddExportBlock(path string, _ bool) (string, uint16, error) {
+func (e *testExporter) AddExportBlock(path string, _ bool, _ string) (string, uint16, error) {
 	id := uint16(1)
 	for ; id <= math.MaxUint16; id++ {
 		if _, ok := e.exportIDs[id]; !ok {


### PR DESCRIPTION
This is PR for issue #908.
It adds support for export-subnet parameter to limit exports to particular NFS clients.
