### PR TITLE
Update clusterrole.yaml events verbs

### DIFF
--- a/nfs-client/deploy/auth/clusterrole.yaml
+++ b/nfs-client/deploy/auth/clusterrole.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]


### PR DESCRIPTION
The current events verbs are not sufficient (kubernetes 1.11.1). I've added watch, list and get to the resource events to get it working again.