### PR TITLE
Fix archiveOnDelete parsing

### DIFF
--- a/nfs-client/cmd/nfs-client-provisioner/provisioner.go
+++ b/nfs-client/cmd/nfs-client-provisioner/provisioner.go
@@ -113,12 +113,14 @@ func (p *nfsProvisioner) Delete(volume *v1.PersistentVolume) error {
 	// If it exists and has a falsey value, delete the directory.
 	// Otherwise, archive it.
 	archiveOnDelete, exists := storageClass.Parameters["archiveOnDelete"]
-	archiveBool, err := strconv.ParseBool(archiveOnDelete)
-	if err != nil {
-		return err
-	}
-	if exists && !archiveBool {
-		return os.RemoveAll(oldPath)
+	if exists {
+		archiveBool, err := strconv.ParseBool(archiveOnDelete)
+		if err != nil {
+			return err
+		}
+		if !archiveBool {
+			return os.RemoveAll(oldPath)
+		}
 	}
 
 	archivePath := filepath.Join(mountPath, "archived-"+pvName)


### PR DESCRIPTION
fixes https://github.com/kubernetes-incubator/external-storage/issues/925 (hopefully)

I can't verify this fixes it. e2e tests may be needed in the future; nfs, nfs-client, and flex can definitely be e2e tested. Depends how much we want to abuse travis.