### PR TITLE
Patch ganesha to skip over files when parsing mount table

### DIFF
--- a/nfs/deploy/docker/Dockerfile
+++ b/nfs/deploy/docker/Dockerfile
@@ -20,21 +20,25 @@ FROM fedora:25
 # 1. Root_Id_Squash, only present in >= 2.4.0.3 which is not yet packaged
 # 2. Set NFS_V4_RECOV_ROOT to /export
 # 3. Use device major/minor as fsid major/minor to work on OverlayFS
+# 4. Ignore (bind mounted) files in mount table
+
+COPY ignore-file-mounts.patch /ignore-file-mounts.patch
 
 RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all \
 	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.4.1.tar.gz | tar zx \
-	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/commit/c583534b166be198755d905c82a7687d83b458d8.patch -o /nfs-ganesha.patch \
+	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/commit/c583534b166be198755d905c82a7687d83b458d8.patch -o /fsid-major-minor.patch \
 	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.4.4.tar.gz | tar zx \
 	&& rm -r nfs-ganesha-2.4.1/src/libntirpc \
 	&& mv ntirpc-1.4.4 nfs-ganesha-2.4.1/src/libntirpc \
 	&& cd nfs-ganesha-2.4.1 \
 	&& cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only src/ \
-	&& patch -p1 < /nfs-ganesha.patch \
+	&& patch -p1 < /fsid-major-minor.patch \
+	&& patch -p1 < /ignore-file-mounts.patch \
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
 	&& cd .. \
-	&& rm -rf nfs-ganesha-2.4.1 /nfs-ganesha.patch \
+	&& rm -rf nfs-ganesha-2.4.1 /fsid-major-minor.patch /ignore-file-mounts.patch \
 	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all
 
 RUN dnf install -y dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap && dnf clean all

--- a/nfs/deploy/docker/ignore-file-mounts.patch
+++ b/nfs/deploy/docker/ignore-file-mounts.patch
@@ -1,0 +1,15 @@
+diff --git a/src/FSAL/commonlib.c b/src/FSAL/commonlib.c
+index 66de46d0a..009b91da8 100644
+--- a/src/FSAL/commonlib.c
++++ b/src/FSAL/commonlib.c
+@@ -1266,6 +1266,10 @@ int populate_posix_file_systems(bool force)
+ 	while ((mnt = getmntent(fp)) != NULL) {
+ 		if (mnt->mnt_dir == NULL)
+ 			continue;
++		struct stat st;
++		if (stat(mnt->mnt_dir, &st) == 0 && !S_ISDIR(st.st_mode)) {
++			continue;
++		}
+ 
+ 		posix_create_file_system(mnt);
+ 	}


### PR DESCRIPTION
fixes https://github.com/kubernetes-incubator/external-storage/issues/432

i'll try to get the patch in upstream ganesha as well, it is very small.