### PR TITLE
Added RBAC to GlusterFS Simple Provisioner

### DIFF
--- a/gluster/glusterfs/README.md
+++ b/gluster/glusterfs/README.md
@@ -49,6 +49,17 @@ And add nodes to trusted pool
 [root@localhost]# kubectl exec -ti glusterfs-mgmnd gluster peer probe 172.16.2.132
 ```
 
+## Configure RBAC (Kubernetes 1.8+)
+
+If you are running Kubernetes 1.8+, you will need to bind a set of permissions to a new ServiceAccount for the provisioner to access the Kubernetes API.
+
+Run the following to configure RBAC for a new `glfs-provisioner` ServiceAccount:
+```bash
+kubectl create -f deploy/rbac.yaml
+```
+
+NOTE: Make sure that your deployment contains a reference to `serviceAccount: glfs-provisioner`.
+
 ## Start glusterfs simple provisioner
 
 The following example assumes kubeconfig is at `/root/.kube`.

--- a/gluster/glusterfs/deploy/deployment.yaml
+++ b/gluster/glusterfs/deploy/deployment.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: glusterfs-simple-provisioner
     spec:
+      serviceAccount: glfs-provisioner
       containers:
         - image: "quay.io/external_storage/glusterfs-simple-provisioner:latest"
           name: glusterfs-simple-provisioner

--- a/gluster/glusterfs/deploy/rbac.yaml
+++ b/gluster/glusterfs/deploy/rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: glfs-provisioner
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: glfs-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events", "pods/exec"]
+    verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-glfs-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: glfs-provisioner
+    namespace: default
+# update namespace above to your namespace in order to make this work
+roleRef:
+  kind: ClusterRole
+  name: glfs-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fixes #931 

Adds a new ServiceAccount and RBAC roles/bindings for the GlusterFS Simple Provisioner.

Also updated `README.md` with instructions on how and when to use it.