### PR TITLE
Add option to generate local provisioner name only with node name and not uid

### DIFF
--- a/local-volume/provisioner/cmd/main.go
+++ b/local-volume/provisioner/cmd/main.go
@@ -88,6 +88,7 @@ func main() {
 		UseAlphaAPI:       provisionerConfig.UseAlphaAPI,
 		UseJobForCleaning: provisionerConfig.UseJobForCleaning,
 		MinResyncPeriod:   provisionerConfig.MinResyncPeriod,
+		UseNodeNameOnly:   provisionerConfig.UseNodeNameOnly,
 		Namespace:         namespace,
 		JobContainerImage: jobImage,
 	})

--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -100,6 +100,9 @@ type UserConfig struct {
 	// MinResyncPeriod is minimum resync period. Resync period in reflectors
 	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
 	MinResyncPeriod metav1.Duration
+	// UseNodeNameOnly indicates if Node.Name should be used in the provisioner name
+	// instead of Node.UID.
+	UseNodeNameOnly bool
 }
 
 // MountConfig stores a configuration for discoverying a specific storageclass
@@ -175,6 +178,10 @@ type ProvisionerConfiguration struct {
 	// MinResyncPeriod is minimum resync period. Resync period in reflectors
 	// will be random between MinResyncPeriod and 2*MinResyncPeriod.
 	MinResyncPeriod metav1.Duration `json:"minResyncPeriod" yaml:"minResyncPeriod"`
+	// UseNodeNameOnly indicates if Node.Name should be used in the provisioner name
+	// instead of Node.UID. Default is false.
+	// +optional
+	UseNodeNameOnly bool `json:"useNodeNameOnly" yaml:"useNodeNameOnly"`
 }
 
 // CreateLocalPVSpec returns a PV spec that can be used for PV creation

--- a/local-volume/provisioner/pkg/controller/controller.go
+++ b/local-volume/provisioner/pkg/controller/controller.go
@@ -44,7 +44,12 @@ import (
 func StartLocalController(client *kubernetes.Clientset, ptable deleter.ProcTable, config *common.UserConfig) {
 	glog.Info("Initializing volume cache\n")
 
-	provisionerName := fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
+	var provisionerName string
+	if config.UseNodeNameOnly {
+		provisionerName = fmt.Sprintf("local-volume-provisioner-%v", config.Node.Name)
+	} else {
+		provisionerName = fmt.Sprintf("local-volume-provisioner-%v-%v", config.Node.Name, config.Node.UID)
+	}
 
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.CoreV1().RESTClient()).Events("")})


### PR DESCRIPTION
Helm template and deployment spec updates will be done after this is merged and a new container image is tagged.

Fixes #636