### PR TITLE
fix rbd monitors missing

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -281,7 +281,7 @@ func (p *rbdProvisioner) parseParameters(parameters map[string]string) (*rbdProv
 			arr := strings.Split(v, ",")
 			for _, m := range arr {
 				mhost, mport := splitHostPort(m)
-				if dnsip != "" {
+				if dnsip != "" && net.ParseIP(mhost) == nil {
 					var lookup []string
 					if lookup, err = lookuphost(mhost, dnsip); err == nil {
 						for _, a := range lookup {


### PR DESCRIPTION
close #942 #778

If I set monitors in IP address format like this:

```
 monitors: 192.168.200.15:6789,192.168.200.17:6789,192.168.200.19:6789
```

rbd provisioner will complain `Failed to provision volume for claim "nextcloud/ceph-claim" with StorageClass "dynamic": missing Ceph monitors`.

This is because rbd provisioner treat the monitors always as DNS hostname and try to call `lookuphost` to resolve `mhost`. Because the monitor is an IP so `lookuphost` return an empty iplist array and error is nil. So, no monitor is added to `opt.monitors` and rbd provisioner complains.

```go
	if dnsip != "" {
		var lookup []string
		if lookup, err = lookuphost(mhost, dnsip); err == nil {
			for _, a := range lookup {
				glog.V(1).Infof("adding %+v from mon lookup\n", a)
				opts.monitors = append(opts.monitors, joinHostPort(a, mport))
			}
		} else {
			opts.monitors = append(opts.monitors, joinHostPort(mhost, mport))
		}
	}
```

I add a check `&& net.ParseIP(mhost) == nil` to avoid `lookuphost` for IP address, and it works well.

Signed-off-by: silenceshell <me@ieevee.com>