### PR TITLE
Remove extra chars from scc.yaml

### DIFF
--- a/nfs/deploy/kubernetes/scc.yaml
+++ b/nfs/deploy/kubernetes/scc.yaml
@@ -32,4 +32,4 @@ volumes:
 - downwardAPI
 - emptyDir
 - persistentVolumeClaim
-- secret<Paste>
+- secret


### PR DESCRIPTION
You can check previous version here https://raw.githubusercontent.com/kubernetes-incubator/external-storage/2ceb856d855744dda6cc22cfb666c2df4c8c0703/nfs/deploy/kubernetes/auth/openshift-scc.yaml