### PR TITLE
Remove typo in secret

### DIFF
--- a/nfs/deploy/kubernetes/scc.yaml
+++ b/nfs/deploy/kubernetes/scc.yaml
@@ -32,4 +32,4 @@ volumes:
 - downwardAPI
 - emptyDir
 - persistentVolumeClaim
-- secret<Paste>
+- secret


### PR DESCRIPTION
It seems like there's typo that prevents nfs-provisioner pod from being created. Without this patch, I get this error:

```
  Type     Reason        Age               From                   Message
  ----     ------        ----              ----                   -------
  Warning  FailedCreate  3s (x11 over 8s)  replicaset-controller  Error creating: pods "nfs-provisioner-6bcb8dd785-" is forbidden: unable to validate against any security context constraint: [spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used capabilities.add: Invalid value: "DAC_READ_SEARCH": capability may not be added capabilities.add: Invalid value: "SYS_RESOURCE": capability may not be added spec.volumes[1]: Invalid value: "secret": secret volumes are not allowed to be used]
```