### PR TITLE
cephfs-provisioner: Add cluster DNS resolution for Ceph monitors

### DIFF
--- a/ceph/cephfs/deploy/rbac/clusterrole.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrole.yaml
@@ -16,3 +16,7 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kube-dns","coredns"]
+    verbs: ["list", "get"]

--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/kubernetes-incubator/external-storage/lib/controller"
 	"github.com/kubernetes-incubator/external-storage/lib/util"
-	"github.com/miekg/dns"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -190,73 +189,6 @@ func (p *rbdProvisioner) Delete(volume *v1.PersistentVolume) error {
 	return p.rbdUtil.DeleteImage(image, opts)
 }
 
-// Look up the cluster dns service by label "coredns", falling back to "kube-dns" if not found
-func findDNSIP(p *rbdProvisioner) (dnsip string) {
-	// find DNS server address through client API
-	// cache result in rbdProvisioner
-	var dnssvc *v1.Service
-
-	if p.dnsip == "" {
-		coredns, err := p.client.CoreV1().Services(metav1.NamespaceSystem).Get("coredns", metav1.GetOptions{})
-
-		if err != nil {
-			glog.Warningf("error getting coredns service: %v. Falling back to kube-dns\n", err)
-			kubedns, err := p.client.CoreV1().Services(metav1.NamespaceSystem).Get("kube-dns", metav1.GetOptions{})
-			if err != nil {
-				glog.Errorf("error getting kube-dns service: %v\n", err)
-				return ""
-			}
-			dnssvc = kubedns
-		} else {
-			dnssvc = coredns
-		}
-
-		if len(dnssvc.Spec.ClusterIP) == 0 {
-			glog.Errorf("DNS service ClusterIP bad\n")
-			return ""
-		}
-
-		p.dnsip = dnssvc.Spec.ClusterIP
-	}
-
-	return p.dnsip
-}
-
-// Look up hostname in dns server serverip.
-func lookuphost(hostname string, serverip string) (iplist []string, err error) {
-	glog.V(4).Infof("lookuphost %q on %q\n", hostname, serverip)
-	m := new(dns.Msg)
-	m.SetQuestion(dns.Fqdn(hostname), dns.TypeA)
-	in, err := dns.Exchange(m, joinHostPort(serverip, "53"))
-	if err != nil {
-		glog.Errorf("dns lookup of %q failed: err %v", hostname, err)
-		return nil, err
-	}
-	for _, a := range in.Answer {
-		glog.V(4).Infof("lookuphost answer: %v\n", a)
-		if t, ok := a.(*dns.A); ok {
-			iplist = append(iplist, t.A.String())
-		}
-	}
-
-	return iplist, nil
-}
-
-func splitHostPort(hostport string) (host, port string) {
-	host, port, err := net.SplitHostPort(hostport)
-	if err != nil {
-		host, port = hostport, ""
-	}
-	return host, port
-}
-
-func joinHostPort(host, port string) (hostport string) {
-	if port != "" {
-		return net.JoinHostPort(host, port)
-	}
-	return host
-}
-
 func (p *rbdProvisioner) parseParameters(parameters map[string]string) (*rbdProvisionOptions, error) {
 	// options with default values
 	opts := &rbdProvisionOptions{
@@ -276,23 +208,25 @@ func (p *rbdProvisioner) parseParameters(parameters map[string]string) (*rbdProv
 		case "monitors":
 			// Try to find DNS info in local cluster DNS so that the kubernetes
 			// host DNS config doesn't have to know about cluster DNS
-			dnsip := findDNSIP(p)
-			glog.V(4).Infof("dnsip: %q\n", dnsip)
+			if p.dnsip == "" {
+				p.dnsip = util.FindDNSIP(p.client)
+			}
+			glog.V(4).Infof("dnsip: %q\n", p.dnsip)
 			arr := strings.Split(v, ",")
 			for _, m := range arr {
-				mhost, mport := splitHostPort(m)
-				if dnsip != "" && net.ParseIP(mhost) == nil {
+				mhost, mport := util.SplitHostPort(m)
+				if p.dnsip != "" && net.ParseIP(mhost) == nil {
 					var lookup []string
-					if lookup, err = lookuphost(mhost, dnsip); err == nil {
+					if lookup, err = util.LookupHost(mhost, p.dnsip); err == nil {
 						for _, a := range lookup {
 							glog.V(1).Infof("adding %+v from mon lookup\n", a)
-							opts.monitors = append(opts.monitors, joinHostPort(a, mport))
+							opts.monitors = append(opts.monitors, util.JoinHostPort(a, mport))
 						}
 					} else {
-						opts.monitors = append(opts.monitors, joinHostPort(mhost, mport))
+						opts.monitors = append(opts.monitors, util.JoinHostPort(mhost, mport))
 					}
 				} else {
-					opts.monitors = append(opts.monitors, joinHostPort(mhost, mport))
+					opts.monitors = append(opts.monitors, util.JoinHostPort(mhost, mport))
 				}
 			}
 			glog.V(4).Infof("final monitors list: %v\n", opts.monitors)


### PR DESCRIPTION
The Ceph RBD provisioner contains code to resolve monitor names via the cluster DNS service so that a Kubernetes host, when trying to provide a volume to a container, doesn't have to participate in the cluster DNS even when the monitor name is cluster internal. This is normally the case for deployments where the monitors are containerized. 
This PR is a port of this feature to the cephfs-provisioner. It requires an additional rule in the ClusterRole to access the cluster DNS service when RBAC is in use (same as rbd-provisioner). If the service lookup fails or the DNS lookup itself is unsuccessful it behaves just like the original code.
