### PR TITLE
mountOptions support for local storage

### DIFF
--- a/local-volume/provisioner/pkg/common/common.go
+++ b/local-volume/provisioner/pkg/common/common.go
@@ -161,6 +161,7 @@ type LocalPVConfig struct {
 	AffinityAnn     string
 	NodeAffinity    *v1.VolumeNodeAffinity
 	VolumeMode      v1.PersistentVolumeMode
+	MountOptions    []string
 	FsType          *string
 	Labels          map[string]string
 }
@@ -222,6 +223,7 @@ func CreateLocalPVSpec(config *LocalPVConfig) *v1.PersistentVolume {
 			},
 			StorageClassName: config.StorageClass,
 			VolumeMode:       &config.VolumeMode,
+			MountOptions:     config.MountOptions,
 		},
 	}
 	if config.UseAlphaAPI {

--- a/local-volume/provisioner/pkg/discovery/discovery_test.go
+++ b/local-volume/provisioner/pkg/discovery/discovery_test.go
@@ -78,6 +78,7 @@ var testStorageClasses = []*storagev1.StorageClass{
 			Name: "sc1",
 		},
 		ReclaimPolicy: &reclaimPolicyDelete,
+		MountOptions:  []string{"ro"},
 	},
 	{
 		ObjectMeta: metav1.ObjectMeta{
@@ -505,6 +506,19 @@ func verifyVolumeMode(t *testing.T, createdPV *v1.PersistentVolume, expectedPV *
 	}
 }
 
+func verifyMountOptions(t *testing.T, createdPV *v1.PersistentVolume) {
+	var expectedMountOptions []string
+	for _, class := range testStorageClasses {
+		if class.Name == createdPV.Spec.StorageClassName {
+			expectedMountOptions = class.MountOptions
+		}
+	}
+	eq := reflect.DeepEqual(expectedMountOptions, createdPV.Spec.MountOptions)
+	if !eq {
+		t.Errorf("MountOptions not as expected %v != %v", createdPV.Spec.MountOptions, expectedMountOptions)
+	}
+}
+
 // testPVInfo contains all the fields we are intested in validating.
 type testPVInfo struct {
 	pvName       string
@@ -564,6 +578,7 @@ func verifyCreatedPVs(t *testing.T, test *testConfig) {
 		verifyPVLabels(t, createdPV)
 		verifyCapacity(t, createdPV, expectedPV)
 		verifyVolumeMode(t, createdPV, expectedPV)
+		verifyMountOptions(t, createdPV)
 		// TODO: Verify volume type once that is supported in the API.
 	}
 }


### PR DESCRIPTION
Address https://github.com/kubernetes/kubernetes/issues/68317
Follow-up https://github.com/kubernetes/kubernetes/pull/69211
let the plugin pass the mountOptions specified in storageclasses into the PVs to make it effective

/area local-volume
/kind feature

/assign @msau42