### PR TITLE
tests: use "go lint" from golang.org/x/lint/golint

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ if [ "$TRAVIS_OS_NAME" != "osx" ]; then
 fi
 
 # Install golint, cfssl
-go get -u github.com/golang/lint/golint
+go get -u golang.org/x/lint/golint
 export PATH=$PATH:$GOPATH/bin
 go get -u github.com/alecthomas/gometalinter
 gometalinter --install

--- a/vendor/github.com/docker/go-units/circle.yml
+++ b/vendor/github.com/docker/go-units/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   post:
     # install golint
-    - go get github.com/golang/lint/golint
+    - go get golang.org/x/lint/golint
 
 test:
   pre:

--- a/vendor/github.com/fsnotify/fsnotify/.travis.yml
+++ b/vendor/github.com/fsnotify/fsnotify/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
 
 before_script:
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 script:
   - go test -v --race ./...

--- a/vendor/github.com/spf13/pflag/.travis.yml
+++ b/vendor/github.com/spf13/pflag/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - go: tip
 
 install:
-  - go get github.com/golang/lint/golint
+  - go get golang.org/x/lint/golint
   - export PATH=$GOPATH/bin:$PATH
   - go install ./...
 

--- a/vendor/github.com/stretchr/objx/Taskfile.yml
+++ b/vendor/github.com/stretchr/objx/Taskfile.yml
@@ -4,7 +4,7 @@ default:
 dl-deps:
   desc: Downloads cli dependencies
   cmds:
-    - go get -u github.com/golang/lint/golint
+    - go get -u golang.org/x/lint/golint
     - go get -u github.com/golang/dep/cmd/dep
 
 update-deps:


### PR DESCRIPTION
Travis currently fails with this error:

    +go get -u github.com/golang/lint/golint
    package github.com/golang/lint/golint: code in directory /home/travis/gopath/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"

It seems 'github.com/golang/lint/golint' is the old path, and now
'golang.org/x/lint/golint' should be used.

See-also: golang/lint#415