### PR TITLE
Upgrade nfs-ganesha to 2.7.1 and OS to Fedora 29

### DIFF
--- a/nfs/deploy/docker/Dockerfile
+++ b/nfs/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Modified from https://github.com/rootfs/nfs-ganesha-docker by Huamin Chen
-FROM fedora:28
+FROM fedora:29
 
 # Build ganesha from source, installing deps and removing them in one line.
 # Why?
@@ -21,17 +21,17 @@ FROM fedora:28
 # 2. Set NFS_V4_RECOV_ROOT to /export
 
 RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel libnsl2-devel patch && dnf clean all \
-	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.7-rc2.tar.gz | tar zx \
-	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/b69c2c1.tar.gz | tar zx \
-	&& rm -r nfs-ganesha-2.7-rc2/src/libntirpc \
-	&& mv ntirpc-b69c2c1e3532d8e119712ad0269a7acd9d778251 nfs-ganesha-2.7-rc2/src/libntirpc \
-	&& cd nfs-ganesha-2.7-rc2 \
+	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.7.1.tar.gz | tar zx \
+	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/05fe1d.tar.gz | tar zx \
+	&& rm -r nfs-ganesha-2.7.1/src/libntirpc \
+	&& mv ntirpc-05fe1d01b68f50d1220f4b1f51159e67f211078b nfs-ganesha-2.7.1/src/libntirpc \
+	&& cd nfs-ganesha-2.7.1 \
 	&& cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only src/ \
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
 	&& cd .. \
-	&& rm -rf nfs-ganesha-2.7-rc2 \
+	&& rm -rf nfs-ganesha-2.7.1 \
 	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all
 
 RUN dnf install -y dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap && dnf clean all


### PR DESCRIPTION
Upgrading to nfs-ganesha > 2.7-rc5 resolves nfs-ganesga issue 341:
https://github.com/nfs-ganesha/nfs-ganesha/issues/341

**Note:** When booting this version of the container I saw the following error when pv's were being provisioned

```
E1111 22:05:54.017965       1 controller.go:700] error syncing claim "gitlab/repo-data-gitlab-gitaly-0": failed to provision volume with StorageClass "nfs-dynamic": error creating export for volume: error exporting export block
EXPORT
{
	Export_Id = 1;
	Path = /export/pvc-7f1c4a78-e5fd-11e8-be16-54bf6464a586;
	Pseudo = /export/pvc-7f1c4a78-e5fd-11e8-be16-54bf6464a586;
	Access_Type = RW;
	Squash = no_root_squash;
	SecType = sys;
	Filesystem_id = 1.1;
	FSAL {
		Name = VFS;
	}
}
: error getting dbus session bus: user: Current not implemented on linux/amd64
```

The fix is to make the environment variable USER available inside the container with the value of root. I did this as follows in the deployment spec:

```
          env:
            - name: USER
              value: root
```