### PR TITLE
Update nfs-ganesha to 2.7.1

### DIFF
--- a/nfs/deploy/docker/Dockerfile
+++ b/nfs/deploy/docker/Dockerfile
@@ -17,21 +17,21 @@ FROM fedora:28
 
 # Build ganesha from source, installing deps and removing them in one line.
 # Why?
-# 1. Ignore (bind mounted) files in mount table, only present in >= V2.7-rc2 which is not yet packaged
+# 1. Ignore (bind mounted) files in mount table, only present in >= V2.7.1 which is not yet packaged
 # 2. Set NFS_V4_RECOV_ROOT to /export
 
 RUN dnf install -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel libnsl2-devel patch && dnf clean all \
-	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.7-rc2.tar.gz | tar zx \
-	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/b69c2c1.tar.gz | tar zx \
-	&& rm -r nfs-ganesha-2.7-rc2/src/libntirpc \
-	&& mv ntirpc-b69c2c1e3532d8e119712ad0269a7acd9d778251 nfs-ganesha-2.7-rc2/src/libntirpc \
-	&& cd nfs-ganesha-2.7-rc2 \
+	&& curl -L https://github.com/nfs-ganesha/nfs-ganesha/archive/V2.7.1.tar.gz | tar zx \
+	&& curl -L https://github.com/nfs-ganesha/ntirpc/archive/v1.7.1.tar.gz | tar zx \
+	&& rm -r nfs-ganesha-2.7.1/src/libntirpc \
+	&& mv ntirpc-1.7.1 nfs-ganesha-2.7.1/src/libntirpc \
+	&& cd nfs-ganesha-2.7.1 \
 	&& cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_CONFIG=vfs_only src/ \
 	&& make \
 	&& make install \
 	&& cp src/scripts/ganeshactl/org.ganesha.nfsd.conf /etc/dbus-1/system.d/ \
 	&& cd .. \
-	&& rm -rf nfs-ganesha-2.7-rc2 \
+	&& rm -rf nfs-ganesha-2.7.1 \
 	&& dnf remove -y tar gcc cmake autoconf libtool bison flex make gcc-c++ krb5-devel dbus-devel jemalloc-devel libnfsidmap-devel patch && dnf clean all
 
 RUN dnf install -y dbus-x11 rpcbind hostname nfs-utils xfsprogs jemalloc libnfsidmap && dnf clean all


### PR DESCRIPTION
Updating nfs-ganesha, in an attempt to address the apparently random crashes after long usage.
* https://github.com/kubernetes-incubator/external-storage/issues/762
* https://github.com/kubernetes-incubator/external-storage/issues/447
