### PR TITLE
Make nfs-client ARM deployment consistent with regular deployment.

### DIFF
--- a/nfs-client/deploy/deployment-arm.yaml
+++ b/nfs-client/deploy/deployment-arm.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         app: nfs-client-provisioner
     spec:
-      serviceAccount: nfs-client-provisioner
+      serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
           image: quay.io/external_storage/nfs-client-provisioner-arm:latest
@@ -27,11 +27,11 @@ spec:
             - name: PROVISIONER_NAME
               value: fuseim.pri/ifs
             - name: NFS_SERVER
-              value: 192.168.1.20
+              value: 10.10.10.60
             - name: NFS_PATH
-              value: /mnt/kube_nfs
+              value: /ifs/kubernetes
       volumes:
         - name: nfs-client-root
           nfs:
-            server: 192.168.1.20
-            path: /mnt/kube_nfs
+            server: 10.10.10.60
+            path: /ifs/kubernetes

--- a/nfs-client/deploy/objects/deployment-arm.yaml
+++ b/nfs-client/deploy/objects/deployment-arm.yaml
@@ -11,7 +11,7 @@ spec:
       labels:
         app: nfs-client-provisioner
     spec:
-      serviceAccount: nfs-client-provisioner
+      serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
           image: quay.io/external_storage/nfs-client-provisioner-arm:latest
@@ -22,11 +22,11 @@ spec:
             - name: PROVISIONER_NAME
               value: fuseim.pri/ifs
             - name: NFS_SERVER
-              value: 192.168.1.20
+              value: 10.10.10.60
             - name: NFS_PATH
-              value: /mnt/kube_nfs
+              value: /ifs/kubernetes
       volumes:
         - name: nfs-client-root
           nfs:
-            server: 192.168.1.20
-            path: /mnt/kube_nfs
+            server: 10.10.10.60
+            path: /ifs/kubernetes


### PR DESCRIPTION
I happen to be using the nfs-client provisioner for a [project](http://www.pidramble.com) which runs Kubernetes on both ARM and AMD64 platforms, so I was trying to see what differences there were in the deployment (since there's one specific for ARM).

A `diff` showed a number of differences, but it seems that they are probably just the result of the two manifests getting out of sync (especially evidenced by the fact that the ARM manifest uses the deprecated `serviceAccount` instead of `serviceAccountName`).

I've made it so the ARM manifest matches the normal one; the only difference is the addition of the `-arm` to the end of the image name (which I've preserved).

Merging this PR will help people be able to see the exact, (currently) single difference between the templates to help them template the manifest or just to understand what's different.

I'm not sure what 'ifs' is, but I figure it's better to be consistent with the primary deployment manifest than have something that makes sense to me :)