### PR TITLE
[cephfs] Remove extraneous 'kubernetes' from claimRoot

### DIFF
--- a/ceph/cephfs/example/class.yaml
+++ b/ceph/cephfs/example/class.yaml
@@ -8,5 +8,5 @@ parameters:
     adminId: admin
     adminSecretName: ceph-secret-admin
     adminSecretNamespace: "kube-system"
-    claimRoot: /volumes/kubernetes
+    claimRoot: /pvc-volumes
 


### PR DESCRIPTION
The `cephfs-provisioner` code will add two more 'kubernetes' to the path, e.g. `/volumes/kubernetes/kubernetes/kubernetes-dynamic-pvc-588569ad-1163-11e9-8963-fa2d6096fe7f` so we don't need to add one in the StorageClass.
Fixes #1092