### PR TITLE
Added timeout for rbd commands execution and improved logging

### DIFF
--- a/ceph/rbd/cmd/rbd-provisioner/main.go
+++ b/ceph/rbd/cmd/rbd-provisioner/main.go
@@ -30,10 +30,11 @@ import (
 )
 
 var (
-	master      = flag.String("master", "", "Master URL")
-	kubeconfig  = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
-	id          = flag.String("id", "", "Unique provisioner identity")
-	metricsPort = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
+	master         = flag.String("master", "", "Master URL")
+	kubeconfig     = flag.String("kubeconfig", "", "Absolute path to the kubeconfig")
+	id             = flag.String("id", "", "Unique provisioner identity")
+	metricsPort    = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
+	commandTimeout = flag.Int("command-timeout", 5, "Timeout for command execution (in seconds)")
 )
 
 const (
@@ -83,7 +84,7 @@ func main() {
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
 	glog.Infof("Creating RBD provisioner %s with identity: %s", prName, prID)
-	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID)
+	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout)
 
 	// Start the provision controller which will dynamically provision rbd
 	// PVs

--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -90,11 +90,13 @@ type rbdProvisioner struct {
 }
 
 // NewRBDProvisioner creates a Provisioner that provisions Ceph RBD PVs backed by Ceph RBD images.
-func NewRBDProvisioner(client kubernetes.Interface, id string) controller.Provisioner {
+func NewRBDProvisioner(client kubernetes.Interface, id string, timeout int) controller.Provisioner {
 	return &rbdProvisioner{
 		client:   client,
 		identity: id,
-		rbdUtil:  &RBDUtil{},
+		rbdUtil: &RBDUtil{
+			timeout: timeout,
+		},
 	}
 }
 

--- a/ceph/rbd/pkg/provision/rbd_util.go
+++ b/ceph/rbd/pkg/provision/rbd_util.go
@@ -30,12 +30,14 @@ import (
 )
 
 const (
-	imageWatcherStr       = "watcher="
-	defaultCommandTimeOut = 5
+	imageWatcherStr = "watcher="
 )
 
 // RBDUtil is the utility structure to interact with the RBD.
-type RBDUtil struct{}
+type RBDUtil struct {
+	// Command execution timeout
+	timeout int
+}
 
 // See https://github.com/kubernetes/kubernetes/pull/57512.
 func (u *RBDUtil) kernelRBDMonitorsOpt(mons []string) string {
@@ -147,7 +149,7 @@ func (u *RBDUtil) DeleteImage(image string, pOpts *rbdProvisionOptions) error {
 }
 
 func (u *RBDUtil) execCommand(command string, args []string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultCommandTimeOut*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(u.timeout)*time.Second)
 	defer cancel()
 
 	// Create the command with our context

--- a/ceph/rbd/pkg/provision/rbd_util.go
+++ b/ceph/rbd/pkg/provision/rbd_util.go
@@ -17,9 +17,11 @@ limitations under the License.
 package provision
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
@@ -28,7 +30,8 @@ import (
 )
 
 const (
-	imageWatcherStr = "watcher="
+	imageWatcherStr       = "watcher="
+	defaultCommandTimeOut = 5
 )
 
 // RBDUtil is the utility structure to interact with the RBD.
@@ -144,6 +147,22 @@ func (u *RBDUtil) DeleteImage(image string, pOpts *rbdProvisionOptions) error {
 }
 
 func (u *RBDUtil) execCommand(command string, args []string) ([]byte, error) {
-	cmd := exec.Command(command, args...)
-	return cmd.CombinedOutput()
+	ctx, cancel := context.WithTimeout(context.Background(), defaultCommandTimeOut*time.Second)
+	defer cancel()
+
+	// Create the command with our context
+	cmd := exec.CommandContext(ctx, command, args...)
+	glog.V(4).Infof("Executing command: %v %v", command, args)
+	out, err := cmd.CombinedOutput()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return nil, fmt.Errorf("rbd: Command timed out")
+	}
+
+	// If there's no context error, we know the command completed (or errored).
+	if err != nil {
+		return nil, fmt.Errorf("rbd: Command exited with non-zero code: %v", err)
+	}
+
+	return out, err
 }


### PR DESCRIPTION
Added context to control the command execution time.
Added addition log with full command for better debugging and fail reproduction.

Fixed: https://github.com/kubernetes-incubator/external-storage/issues/1000