### PR TITLE
Added new flag to control image name

### DIFF
--- a/ceph/rbd/cmd/rbd-provisioner/main.go
+++ b/ceph/rbd/cmd/rbd-provisioner/main.go
@@ -35,6 +35,7 @@ var (
 	id             = flag.String("id", "", "Unique provisioner identity")
 	metricsPort    = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
 	commandTimeout = flag.Int("command-timeout", 5, "Timeout for command execution (in seconds)")
+	usePVName      = flag.Bool("use-pv-name", false, "Defines which image name should be used: generated or PV name")
 )
 
 const (
@@ -84,7 +85,7 @@ func main() {
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
 	glog.Infof("Creating RBD provisioner %s with identity: %s", prName, prID)
-	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout)
+	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout, *usePVName)
 
 	// Start the provision controller which will dynamically provision rbd
 	// PVs


### PR DESCRIPTION
Added new bool flag `use-pv-name` to control which name use on creation image step, random or PV name.

Fixed: https://github.com/kubernetes-incubator/external-storage/issues/1080