### PR TITLE
fix(cephfs): RBAC: allow to manage secrets

### DIFF
--- a/ceph/cephfs/deploy/rbac/clusterrole.yaml
+++ b/ceph/cephfs/deploy/rbac/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cephfs
 rules:
   - apiGroups: [""]
-    resources: ["persistentvolumes"]
+    resources: ["persistentvolumes","secrets"]
     verbs: ["get", "list", "watch", "create", "delete"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]


### PR DESCRIPTION
The ceph provisionner also need to be able to create secrets:

```
cephfs-provisioner.go:186] Cephfs Provisioner: create volume failed, err: secrets is forbidden: User "system:serviceaccount:kube-system:cephfs-provisioner" cannot create resource "secrets" in API group "" in the namespace "x"
event.go:221] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"x", Name:"y", UID:"z", APIVersion:"v1", ResourceVersion:"t", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' failed to provision volume with StorageClass "shared": failed to create secret
```