### PR TITLE
Fix secret type in rbd readme

### DIFF
--- a/ceph/rbd/README.md
+++ b/ceph/rbd/README.md
@@ -31,8 +31,8 @@ See https://kubernetes.io/.
 * Create a Ceph admin secret
 
 ```bash
-ceph auth get client.admin 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/secret
-kubectl create secret generic ceph-admin-secret --from-file=/tmp/secret --namespace=kube-system
+ceph auth get client.admin 2>&1 |grep "key = " |awk '{print  $3'} |xargs echo -n > /tmp/key
+kubectl create secret generic ceph-admin-secret --from-file=/tmp/key --namespace=kube-system --type=kubernetes.io/rbd
 ```
 
 * Create a Ceph pool and a user secret
@@ -40,8 +40,8 @@ kubectl create secret generic ceph-admin-secret --from-file=/tmp/secret --namesp
 ```bash
 ceph osd pool create kube 8 8
 ceph auth add client.kube mon 'allow r' osd 'allow rwx pool=kube'
-ceph auth get-key client.kube > /tmp/secret
-kubectl create secret generic ceph-secret --from-file=/tmp/secret --namespace=kube-system
+ceph auth get-key client.kube > /tmp/key
+kubectl create secret generic ceph-secret --from-file=/tmp/key --namespace=kube-system --type=kubernetes.io/rbd
 ```
 
 * Start RBD provisioner


### PR DESCRIPTION
For rbd, secret type should be `kubernetes.io/rbd` otherwise kube-controller-manager will not find it.
And key should be `key` not `secret`

Example yaml is already correct, but readme was misleading

official secret example:
https://github.com/kubernetes/examples/blob/master/staging/volumes/rbd/secret/ceph-secret.yaml

Related to https://github.com/kubernetes-incubator/external-storage/issues/622 and https://github.com/kubernetes-incubator/external-storage/issues/992