### PR TITLE
[Cephfs] Improved docs

### DIFF
--- a/ceph/cephfs/README.md
+++ b/ceph/cephfs/README.md
@@ -27,7 +27,7 @@ See https://kubernetes.io/.
 ```bash
 ceph auth get-key client.admin > /tmp/secret
 kubectl create ns cephfs
-kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=kube-system
+kubectl create secret generic ceph-secret-admin --from-file=/tmp/secret --namespace=cephfs
 ```
 
 * Start CephFS provisioner

--- a/ceph/cephfs/deploy/README.md
+++ b/ceph/cephfs/deploy/README.md
@@ -2,8 +2,15 @@
 
 ## Table of contents
 
+* [Deployment Environment variables](#deployment-environment-variables)
 * [Install without RBAC roles](#install-without-rbac-roles)
 * [Install with RBAC roles](#install-with-rbac-roles)
+
+## Deployment environment variables
+|Parameter|Description|Default|
+|---|---|---|
+|PROVISIONER_NAME | Name of the provisioner. If you change this, you also have to change it in the StorageClass `provisioner` field. | ceph.com/cephfs|
+|PROVISIONER_SECRET_NAMESPACE | The namespace to which the secrets will be deployed. If this differs from the namespace where the rolebinding is deployed you have to adjust the role and rolebinding or use a clusterrole. | PVC namespace|
 
 ## Install without RBAC roles
 
@@ -18,5 +25,6 @@ kubectl apply -f ./non-rbac
 cd $GOPATH/src/github.com/kubernetes-incubator/external-storage/ceph/cephfs/deploy
 NAMESPACE=cephfs # change this if you want to deploy it in another namespace
 sed -r -i "s/namespace: [^ ]+/namespace: $NAMESPACE/g" ./rbac/*.yaml
+sed -r -i "N;s/(name: PROVISIONER_SECRET_NAMESPACE.*\n[[:space:]]*)value:.*/\1value: $NAMESPACE/" ./rbac/deployment.yaml
 kubectl -n $NAMESPACE apply -f ./rbac
 ```

--- a/ceph/cephfs/deploy/rbac/deployment.yaml
+++ b/ceph/cephfs/deploy/rbac/deployment.yaml
@@ -18,6 +18,8 @@ spec:
         env:
         - name: PROVISIONER_NAME
           value: ceph.com/cephfs
+        - name: PROVISIONER_SECRET_NAMESPACE
+          value: cephfs
         command:
         - "/usr/local/bin/cephfs-provisioner"
         args:


### PR DESCRIPTION
As described in #1130 the provisioner currently errors because of missing permission to access the secrets in an other namespace.

```
cephfs-provisioner.go:186] Cephfs Provisioner: create volume failed, err: secrets is forbidden: User "system:serviceaccount:kube-system:cephfs-provisioner" cannot create resource "secrets" in API group "" in the namespace "x"
event.go:221] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"x", Name:"y", UID:"z", APIVersion:"v1", ResourceVersion:"t", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' failed to provision volume with StorageClass "shared": failed to create secret
```

This PR adds information about environment variables and adds `PROVISIONER_SECRET_NAMESPACE` as environment to `rbac/deployment.yaml` to put the created secrets in the same namespace as the deployment.
