### PR TITLE
Add options to skip custom pvc path creation and to keep created pvc …

### DIFF
--- a/aws/efs/deploy/configmap.yaml
+++ b/aws/efs/deploy/configmap.yaml
@@ -7,3 +7,5 @@ data:
   aws.region: us-west-2
   provisioner.name: example.com/aws-efs
   dns.name: ""
+  skip.pvc.named.path: ""
+  keep.pv.path: ""

--- a/aws/efs/deploy/deployment.yaml
+++ b/aws/efs/deploy/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate 
+    type: Recreate
   template:
     metadata:
       labels:
@@ -42,6 +42,18 @@ spec:
                 configMapKeyRef:
                   name: efs-provisioner
                   key: provisioner.name
+            - name: SKIP_PVC_NAMED_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: efs-provisioner
+                  key: skip.pvc.named.path
+                  optional: true
+            - name: KEEP_PV_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: efs-provisioner
+                  key: keep.pv.path
+                  optional: true
           volumeMounts:
             - name: pv-volume
               mountPath: /persistentvolumes

--- a/aws/efs/deploy/manifest.yaml
+++ b/aws/efs/deploy/manifest.yaml
@@ -8,6 +8,8 @@ data:
   aws.region: regionyourEFSisin
   provisioner.name: example.com/aws-efs
   dns.name: ""
+  skip.pvc.named.path: ""
+  keep.pv.path: ""
 ---
 kind: Deployment
 apiVersion: extensions/v1beta1
@@ -16,7 +18,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate 
+    type: Recreate
   template:
     metadata:
       labels:
@@ -47,6 +49,18 @@ spec:
                 configMapKeyRef:
                   name: efs-provisioner
                   key: provisioner.name
+            - name: SKIP_PVC_NAMED_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: efs-provisioner
+                  key: skip.pvc.named.path
+                  optional: true
+            - name: KEEP_PV_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: efs-provisioner
+                  key: keep.pv.path
+                  optional: true
           volumeMounts:
             - name: pv-volume
               mountPath: /persistentvolumes

--- a/aws/efs/deploy/pod.yaml
+++ b/aws/efs/deploy/pod.yaml
@@ -31,6 +31,18 @@ spec:
               name: efs-provisioner
               key: dns.name
               optional: true
+        - name: SKIP_PVC_NAMED_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: efs-provisioner
+              key: skip.pvc.named.path
+              optional: true
+        - name: KEEP_PV_PATH
+          valueFrom:
+            configMapKeyRef:
+              name: efs-provisioner
+              key: keep.pv.path
+              optional: true
       volumeMounts:
         - name: pv-volume
           mountPath: /persistentvolumes


### PR DESCRIPTION
EFS Provisioner is nice, but i wish it had 2 extra options for specific use cases:
1. Do not create Custom PVC-named paths EFS storage
2. Do not delete created/shared paths in EFS storage upon wiping out the PVC

Reasoning:
1. There are cases where you would want to share same EFS path between either multiple namespaces or even clusters or even non-kube resources.
In current state, you cannot do that as the EFS Provisioner creates hardcoded path with unique PVC id.
Example use case is EFS for an App running in cluster A and Jenkins CI/CD process running in cluster B.
I want to be able to mount same EFS volume and PATH to a Jenkins CI/CD run to modify/read/backup some files.
With given change, providing "SKIP_PVC_NAMED_PATH" env variable set to "true" will skip adding unique PVC id to provided path.
You can now mount ROOT EFS path to your PVC.

2. Linked to change/request number 1. Current Provisioner with no ability to control it, deletes created Path in EFS if the PVC get's deleted.
There are cases where i want the folder to persist for debugging purposes.
In other cases, when i mount the PVC to custom/shared path, i don't want it get wiped out once the PVC is poof, gone.