### PR TITLE
[rbd-provisioner] Rename `usePVName` as `deterministicNames`

### DIFF
--- a/ceph/rbd/cmd/rbd-provisioner/main.go
+++ b/ceph/rbd/cmd/rbd-provisioner/main.go
@@ -35,7 +35,6 @@ var (
 	id             = flag.String("id", "", "Unique provisioner identity")
 	metricsPort    = flag.Int("metrics-port", 0, "The port of the metrics server (set to non-zero to enable)")
 	commandTimeout = flag.Int("command-timeout", 5, "Timeout for command execution (in seconds)")
-	usePVName      = flag.Bool("use-pv-name", false, "Defines which image name should be used: generated or PV name")
 )
 
 const (
@@ -86,7 +85,7 @@ func main() {
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
 	klog.Infof("Creating RBD provisioner %s with identity: %s", prName, prID)
-	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout, *usePVName)
+	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout)
 
 	// Start the provision controller which will dynamically provision rbd
 	// PVs


### PR DESCRIPTION
Follow up for #1109, rename `usePVName` as `deterministicNames`, synchronize the style as cephfs-provisioner.

Moreover, also move the `deterministicNames` as parameters of StorageClass.