### PR TITLE
aws/efs/deploy/rbac.yaml: moved endpoints auth to ClusterRole

### DIFF
--- a/aws/efs/deploy/rbac.yaml
+++ b/aws/efs/deploy/rbac.yaml
@@ -15,6 +15,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -29,26 +32,4 @@ roleRef:
   kind: ClusterRole
   name: efs-provisioner-runner
   apiGroup: rbac.authorization.k8s.io
----
-kind: Role
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: leader-locking-efs-provisioner
-rules:
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: leader-locking-efs-provisioner
-subjects:
-  - kind: ServiceAccount
-    name: efs-provisioner
-    # replace with namespace where provisioner is deployed
-    namespace: default
-roleRef:
-  kind: Role
-  name: leader-locking-efs-provisioner
-  apiGroup: rbac.authorization.k8s.io
+  


### PR DESCRIPTION
This is pointing to the "I am not using HELM" deployment method.

As the RBAC setup of this file isn't working (also see issue #1177) I removed the unnecessary Role resource which had the rule:
  - apiGroups: [""]
    resources: ["endpoints"]
    verbs: ["get", "list", "watch", "create", "update", "patch"]

I moved this to the ClusterRole.

Kind regards
Martin