### PR TITLE
[cephfs-provisioner] Provisioner should not fail if secret exists

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/util"
 	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -37,7 +38,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -185,7 +186,7 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 	}
 
 	_, err = p.client.CoreV1().Secrets(nameSpace).Create(secret)
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		klog.Errorf("Cephfs Provisioner: create volume failed, err: %v", err)
 		return nil, fmt.Errorf("failed to create secret")
 	}

--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/util"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -386,7 +386,6 @@ var (
 )
 
 func main() {
-	klog.InitFlags(nil)
 	flag.Parse()
 	flag.Set("logtostderr", "true")
 


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-incubator/external-storage/issues/1192

This will avoid cephfs provisioner to fail when recreating a PVC because the secret to provision it already exists.

cc/ @humblec 