### PR TITLE
Update cephfs-provisioner.go

### DIFF
--- a/ceph/cephfs/cephfs-provisioner.go
+++ b/ceph/cephfs/cephfs-provisioner.go
@@ -129,9 +129,9 @@ func (p *cephFSProvisioner) Provision(options controller.VolumeOptions) (*v1.Per
 		user = fmt.Sprintf("k8s.%s.%s", options.PVC.Namespace, options.PVC.Name)
 	} else {
 		// create random share name
-		share = fmt.Sprintf("kubernetes-dynamic-pvc-%s", uuid.NewUUID())
+		share = fmt.Sprintf("kubernetes-dm-pvc-%s", uuid.NewUUID())
 		// create random user id
-		user = fmt.Sprintf("kubernetes-dynamic-user-%s", uuid.NewUUID())
+		user = fmt.Sprintf("kubernetes-dm-user-%s", uuid.NewUUID())
 	}
 	// provision share
 	// create cmd


### PR DESCRIPTION
/var/log/ceph/ceph-client.kubernetes-dynamic-user-f79c632f-a382-11e9-9ae4-028d79779981.log:2019-07-17 14:59:49.438 7f4998301f40 -1 asok(0x20b5870) AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: The UNIX domain socket path /var/run/ceph/ceph-client.kubernetes-dynamic-user-f79c632f-a382-11e9-9ae4-028d79779981.1596928.34311296.asok is too long! The maximum length on this system is 107