### PR TITLE
update quickstart instructions

### DIFF
--- a/aws/efs/README.md
+++ b/aws/efs/README.md
@@ -12,16 +12,29 @@ The efs-provisioner allows you to mount EFS storage as PersistentVolumes in kube
 
 If you are new to Kubernetes or to PersistentVolumes this quick start will get you up and running with simple defaults.
 
-- Download the manifest file [manifest.yaml](deploy/manifest.yaml).
+- Download the repository
   ```
-  wget https://raw.githubusercontent.com/kubernetes-incubator/external-storage/master/aws/efs/deploy/manifest.yaml
+  git clone https://github.com/kubernetes-incubator/external-storage
   ```
 
-- In the configmap section change the `file.system.id:` and `aws.region:` to match the details of the EFS you created. Change `dns.name` if you want to mount by your own DNS name and not by AWS's `*file-system-id*.efs.*aws-region*.amazonaws.com`.
+- Switch to the deploy directory
+  ```
+  cd external-storage/aws/efs/deploy/
+  ```
+
+- Apply rbac permissions
+  ```
+  kubectl apply -f rbac.yaml  
+  ```
+
+- Modify manifest.yaml. In the configmap section change the `file.system.id:` and `aws.region:` to match the details of the EFS you created. Change `dns.name` if you want to mount by your own DNS name and not by AWS's `*file-system-id*.efs.*aws-region*.amazonaws.com`.
 
 - In the deployment section change the `server:` to the DNS endpoint of the EFS you created.
 
-- `kubectl apply -f manifest.yaml` 
+- Apply the manifest
+  ```
+  kubectl apply -f manifest.yaml
+  ```
 
 - Now you can use your PersistentVolume in your pod or deployment by referencing your claim name when it's created.
 


### PR DESCRIPTION
The README states "If your cluster has RBAC enabled ... you must authorize the provisioner." 

Since many/most kubernetes clusters have RBAC enabled, the step shouldn't be omitted from the Quick Start Guide.