### PR TITLE
[aws-efs] Update base image to Alpine 3.10

### DIFF
--- a/aws/efs/Dockerfile
+++ b/aws/efs/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /go/src/github.com/kubernetes-incubator/external-storage/aws/efs
 RUN go install ./cmd/efs-provisioner
 
 
-FROM alpine:3.6
+FROM alpine:3.10.2
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/bin/efs-provisioner /
 ENTRYPOINT ["/efs-provisioner"]


### PR DESCRIPTION
Alpine 3.6 is out of service and has many security vulnerabilities that I introduce into my environment by using this container.

This PR attempts to update the base image to something more current.

Ref: https://wiki.alpinelinux.org/wiki/Alpine_Linux:Releases