### PR TITLE
Add iSCSI FlexVol support.

### DIFF
--- a/iscsi/targetd/kubernetes/iscsi-provisioner-d-win.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-d-win.yaml
@@ -1,0 +1,73 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: iscsi-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "create", "update", "patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-iscsi-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: iscsi-provisioner
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: iscsi-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: iscsi-provisioner
+---
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: iscsi-provisioner
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: iscsi-provisioner
+    spec:
+      containers:
+        - name: iscsi-provisioner
+          imagePullPolicy: Always
+          image: aragunathan/iscsi-controller:latest
+          args:
+            - "start"
+          env:
+            - name: PROVISIONER_NAME
+              value: iscsi-targetd
+            - name: LOG_LEVEL
+              value: debug
+            - name: TARGETD_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: targetd-account
+                  key: username
+            - name: TARGETD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: targetd-account
+                  key: password
+            - name: TARGETD_ADDRESS
+              value: 192.168.99.100
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      serviceAccount: iscsi-provisioner

--- a/iscsi/targetd/kubernetes/iscsi-provisioner-flexvol-class.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-flexvol-class.yaml
@@ -1,0 +1,27 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: iscsi-targetd-vg-targetd
+provisioner: iscsi-targetd
+parameters:
+# this is where the iscsi server is running
+  targetPortal: 10.11.12.13:3260
+# file system type for Windows
+  fsType: ntfs
+# this is the iscsi server iqn
+  iqn: iqn.2019-08.com.docker.linux:targetd
+
+# this is the iscsi interface to be used, the default is default
+# iscsiInterface: default
+
+# this must be on eof the volume groups condifgured in targetd.yaml, the default is vg-targetd
+# volumeGroup: vg-targetd
+
+# this is a comma separated list of initiators that will be give access to the created volumes, they must correspond to what you have configured in your nodes.
+  initiators: iqn.1991-05.com.microsoft:janedoe-e06115-win-1
+
+# whether or not to use chap authentication for discovery operations
+  chapAuthDiscovery: "false"
+
+# whether or not to use chap authentication for session operations
+  chapAuthSession: "false"

--- a/iscsi/targetd/kubernetes/iscsi-provisioner-pvc-win.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-pvc-win.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 metadata:
   name: myclaim
   annotations:
-    volume.beta.kubernetes.io/storage-class: "iscsi-targetd-vg-targetd"
     os: "windows"
 spec:
+  storageClassName: "iscsi-targetd-vg-targetd"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/iscsi/targetd/kubernetes/iscsi-provisioner-pvc-win.yaml
+++ b/iscsi/targetd/kubernetes/iscsi-provisioner-pvc-win.yaml
@@ -1,0 +1,14 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: myclaim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: "iscsi-targetd-vg-targetd"
+    os: "windows"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+


### PR DESCRIPTION
Background:
The external targetd provisioner allocates targetd based LUNs. These LUNs are eventually mounted into pods by the kubelet. The in-tree iSCSI support in the kubelet allows for mounting the iSCSI LUNs into pods.

Note that Kubelet's iSCSI in-tree support (discovery, attach, mount) is available on Linux workers only. Although the Windows Kubelet does not provide in-tree iSCSI support, mounting of iSCSI volumes can be accomplished using Windows Flexvolume plugins. https://github.com/microsoft/K8s-Storage-Plugins

Proposed change:
LUNs provisioned by the targetd provisioner can be mounted by Windows iSCSI FlexVolume plugins by creating FlexPersistentVolumeSource for PV Source. This allows Windows pods to use:
    - targetd external provisioner for provisioning.
    - windows flexvol plugins for mounting.

Sample yamls:
    1. iscsi/targetd/kubernetes/iscsi-provisioner-d-win.yaml
        note that deploying this on a mixed cluster of Windows and Linux workers
        requires to qualify that the provisioner runs on Linux only.
        So set nodeSelector to be "beta.kubernetes.io/os: linux"
        TODO: provisioner image is set to aragunathan/iscsi-controller:latest.
        Once this PR merges and official images are built, I'll send a follow on
        PR to update yaml with official image.
    2. iscsi/targetd/kubernetes/iscsi-provisioner-flexvol-class.yaml
  	note "fsType: ntfs" for Windows mounts/workloads.
    3. iscsi/targetd/kubernetes/iscsi-provisioner-pvc-win.yaml
	note that os: "windows" annotation should be added for PVCs.

    Testing:
    Tested on a kubernetes 1.15.0 cluster.
    - Setup targetd server

    - Setup flexvol scripts on Windows workers per https://github.com/microsoft/K8s-Storage-Plugins
    - Using powershell, get the windows worker's iSCSI IQN:
      (Get-InitiatorPort).NodeAddress
      This will be added to the storage class yaml

    - Setup targetd account and secret
    - Deployed storage class: iscsi-provisioner-flexvol-class.yaml
    - Deployed PVC: iscsi-provisioner-pvc-win.yaml
    - Created a Pod to use the claim and observed LUNs mounted successfully.

Signed-off-by: Anusha Ragunathan <anusha.ragunathan@docker.com>