### PR TITLE
fix to solve an issue regarding with serviceaccount

### DIFF
--- a/aws/efs/deploy/manifest.yaml
+++ b/aws/efs/deploy/manifest.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         app: efs-provisioner
     spec:
+      serviceAccountName: efs-provisioner
       containers:
         - name: efs-provisioner
           image: quay.io/external_storage/efs-provisioner:latest


### PR DESCRIPTION
## kubectl describe pod test-pod
```
Events:
  Type     Reason            Age                 From               Message
  ----     ------            ----                ----               -------
  Warning  FailedScheduling  31s (x26 over 17m)  default-scheduler  pod has unbound immediate PersistentVolumeClaims (repeated 2 times)

kubectl get pvc
NAME   STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
efs    Pending                                      aws-efs        37m
kubectl describe pvc  efs
Events:
  Type    Reason                Age                   From                         Message
  ----    ------                ----                  ----                         -------
  Normal  ExternalProvisioning  36s (x26 over 6m21s)  persistentvolume-controller  waiting for a volume to be created, either by external provisioner "example.com/aws-efs" or manually created by system administrator
```

## kubectl exec -it efs-provisioner-55c9d9d8f6-k9kv4 sh
```
/ # /efs-provisioner
E0927 12:51:47.151981      21 efs-provisioner.go:69] 
W0927 12:51:47.241896      21 efs-provisioner.go:91] couldn't confirm that the EFS file system exists: AccessDeniedException: User: arn:aws:sts::863994147283:assumed-role/eksctl-beautiful-gopher-156957269-NodeInstanceRole-PJI8X35RXRFA/i-06ca449d008106958 is not authorized to perform: elasticfilesystem:DescribeFileSystems on the specified resource
	status code: 403, request id: 3d3a8786-5dfb-4eb6-b34f-9ff56168cc40
I0927 12:51:47.242406      21 leaderelection.go:187] attempting to acquire leader lease  default/kubernetes.io-aws-ebs...
E0927 12:51:47.243727      21 leaderelection.go:252] error retrieving resource lock default/kubernetes.io-aws-ebs: endpoints "kubernetes.io-aws-ebs" is forbidden: User "system:serviceaccount:default:default" cannot get resource "endpoints" in API group "" in the namespace "default"
E0927 12:51:50.481494      21 leaderelection.go:252] error retrieving resource lock default/kubernetes.io-aws-ebs: endpoints "kubernetes.io-aws-ebs" is forbidden: User "system:serviceaccount:default:default" cannot get resource "endpoints" in API group "" in the namespace "default"
```

## You can fix it running this:
kubectl --namespace default patch deploy efs-provisioner -p '{"spec":{"template":{"spec":{"serviceAccount":"efs-provisioner"}}}}'

## Or adding this line -> serviceAccountName: efs-provisioner
```
kind: Deployment
apiVersion: extensions/v1beta1
metadata:
  name: efs-provisioner
spec:
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: efs-provisioner
    spec:
      serviceAccount: efs-provisioner
      serviceAccountName: efs-provisioner
      containers:
	...
```

## kubectl --namespace default get deploy efs-provisioner -o yaml
Now you'll find both lines added:
      serviceAccount: efs-provisioner
      serviceAccountName: efs-provisioner
```
      ...
      securityContext: {}
      serviceAccount: efs-provisioner
      serviceAccountName: efs-provisioner
      terminationGracePeriodSeconds: 30
      ...
```

## kubectl get pv
```
NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM         STORAGECLASS   REASON   AGE
pvc-85763586-e12c-11e9-901f-068f1e15577a   1Mi        RWX            Delete           Bound    default/efs   aws-efs                 6m39s
```

## kubectl get pvc
```
NAME   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
efs    Bound    pvc-85763586-e12c-11e9-901f-068f1e15577a   1Mi        RWX            aws-efs        23m
```

## kubectl logs efs-provisioner-84bdb4749b-49psp
```
I0927 14:32:50.998308       1 controller.go:1026] provision "default/efs" class "aws-efs": volume "pvc-6da6ca9e-e133-11e9-901f-068f1e15577a" provisioned
I0927 14:32:50.998339       1 controller.go:1040] provision "default/efs" class "aws-efs": trying to save persistentvolume "pvc-6da6ca9e-e133-11e9-901f-068f1e15577a"
I0927 14:32:51.054843       1 controller.go:1047] provision "default/efs" class "aws-efs": persistentvolume "pvc-6da6ca9e-e133-11e9-901f-068f1e15577a" saved
I0927 14:32:51.054877       1 controller.go:1088] provision "default/efs" class "aws-efs": succeeded
I0927 14:32:51.054988       1 event.go:221] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"efs", UID:"6da6ca9e-e133-11e9-901f-068f1e15577a", APIVersion:"v1", ResourceVersion:"33227", FieldPath:""}): type: 'Normal' reason: 'ProvisioningSucceeded' Successfully provisioned volume pvc-6da6ca9e-e133-11e9-901f-068f1e15577a
```