### PR TITLE
fix broken links

### DIFF
--- a/openebs/README.md
+++ b/openebs/README.md
@@ -3,7 +3,7 @@
 ## About OpenEBS
 
 OpenEBS is containerized storage for containers. More details on OpenEBS can be found on [OpenEBS project page.](https://github.com/openebs/openebs)
-OpenEBS Kubernetes PV provisioner is using API's exposed by [maya-apiserver](https://github.com/openebs/mayaserver) to perform provision and delete operation.
+OpenEBS Kubernetes PV provisioner is using API's exposed by [maya-apiserver](https://github.com/openebs/maya/tree/master/cmd/maya-apiserver) to perform provision and delete operation.
 
 ## Building OpenEBS provisioner from source
 

--- a/snapshot/doc/examples/aws/README.md
+++ b/snapshot/doc/examples/aws/README.md
@@ -14,7 +14,7 @@ _output/bin/snapshot-controller  -kubeconfig=${HOME}/.kube/config -cloudprovider
 ```bash
 kubectl create namespace myns
 # if no default storage class, create one
-kubectl create -f https://raw.githubusercontent.com/kubernetes/kubernetes/master/examples/persistent-volume-provisioning/aws-ebs.yaml
+kubectl create -f https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/aws-ebs.yaml
 kubectl create -f examples/aws/pvc.yaml
 ```
  * Create a Snapshot Third Party Resource 

--- a/snapshot/doc/volume-snapshotting-proposal.md
+++ b/snapshot/doc/volume-snapshotting-proposal.md
@@ -1,7 +1,7 @@
 Kubernetes Snapshotting Proposal
 ================================
 
-**Authors:** [Cindy Wang](https://github.com/ciwang), [Jing Xu](https://github.com/jinxu97),[Tomas Smetana](https://github.com/tsmetana), [Huamin Chen ](https://github.com/rootfs)
+**Authors:** [Cindy Wang](https://github.com/ciwang), [Jing Xu](https://github.com/jingxu97),[Tomas Smetana](https://github.com/tsmetana), [Huamin Chen ](https://github.com/rootfs)
 
 ## Background
 


### PR DESCRIPTION
Signed-off-by: Dominic Yin <yindongchao@inspur.com>

Fixed several broken links : 

1. https://github.com/openebs/mayaserver moved to >> https://github.com/openebs/maya/tree/master/cmd/maya-apiserver, see https://github.com/openebs/maya/pull/95

2. https://raw.githubusercontent.com/kubernetes/kubernetes/master/examples/persistent-volume-provisioning/aws-ebs.yaml movde to https://github.com/kubernetes/examples/blob/master/staging/persistent-volume-provisioning/aws-ebs.yaml, see https://github.com/kubernetes/kubernetes/issues/23671

3. https://github.com/jinxu97 should be https://github.com/jingxu97, as a typo