### PR TITLE
Fixed AWS EFS deployment example

### DIFF
--- a/aws/efs/deploy/deployment.yaml
+++ b/aws/efs/deploy/deployment.yaml
@@ -4,11 +4,14 @@ metadata:
   name: efs-provisioner
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: efs-provisioner
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: efs-provisioner
   strategy:
     type: Recreate 
   template:


### PR DESCRIPTION
The purpose of this PR is just to update a deprecated K8s API that no longer works when using AWS EFS.