### PR TITLE
Add support for erasure pools in ceph rbd provisioner

### DIFF
--- a/ceph/rbd/pkg/provision/provision.go
+++ b/ceph/rbd/pkg/provision/provision.go
@@ -59,6 +59,8 @@ type rbdProvisionOptions struct {
 	monitors []string
 	// Ceph RBD pool. Default is "rbd".
 	pool string
+	// Optional data pool for erasure pool support, default is ""
+	dataPool string
 	// Ceph client ID that is capable of creating images in the pool. Default is "admin".
 	adminID string
 	// Secret of admin client ID.
@@ -201,6 +203,7 @@ func (p *rbdProvisioner) parseParameters(parameters map[string]string) (*rbdProv
 	// options with default values
 	opts := &rbdProvisionOptions{
 		pool:        "rbd",
+		dataPool:    "",
 		adminID:     "admin",
 		imageFormat: rbdImageFormat2,
 	}
@@ -261,6 +264,8 @@ func (p *rbdProvisioner) parseParameters(parameters map[string]string) (*rbdProv
 				v = "rbd"
 			}
 			opts.pool = v
+		case "datapool":
+			opts.dataPool = v
 		case "usersecretname":
 			if v == "" {
 				return nil, fmt.Errorf("missing user secret name")

--- a/ceph/rbd/pkg/provision/rbd_util.go
+++ b/ceph/rbd/pkg/provision/rbd_util.go
@@ -65,6 +65,9 @@ func (u *RBDUtil) CreateImage(image string, pOpts *rbdProvisionOptions, options 
 		klog.V(4).Infof("rbd: create %s size %s format %s using mon %s, pool %s id %s key %s", image, volSz, pOpts.imageFormat, mon, pOpts.pool, pOpts.adminID, pOpts.adminSecret)
 	}
 	args := []string{"create", image, "--size", volSz, "--pool", pOpts.pool, "--id", pOpts.adminID, "-m", mon, "--key=" + pOpts.adminSecret, "--image-format", pOpts.imageFormat}
+	if pOpts.dataPool != "" {
+		args = append(args, "--data-pool", pOpts.dataPool)
+	}
 	if pOpts.imageFormat == rbdImageFormat2 {
 		// if no image features is provided, it results in empty string
 		// which disable all RBD image format 2 features as we expected


### PR DESCRIPTION
This adds support for ceph rbd provisioner to be able to create rbd images with erasure pool.
In the storage class definition for your kubernetes cluster, you would specify:
pool: <your_rbd_pool_name>
dataPool: <your_erasure_pool_name>

Fixes this issue:
https://github.com/kubernetes-incubator/external-storage/issues/1096

Tested on the local ceph cluster.  