### PR TITLE
nfs-client: added support for ppc64le [Power PC]

### DIFF
--- a/nfs-client/Makefile-ppc64le
+++ b/nfs-client/Makefile-ppc64le
@@ -1,0 +1,39 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifeq ($(REGISTRY),)
+        REGISTRY = docker.io/ibmcom/
+endif
+ifeq ($(VERSION),)
+        VERSION = latest
+endif
+IMAGE_PPC64LE = $(REGISTRY)nfs-client-provisioner-ppc64le:$(VERSION) 
+MUTABLE_IMAGE_PPC64LE = $(REGISTRY)nfs-client-provisioner-ppc64le:latest
+
+all: build_ppc64le image_ppc64le
+
+container: build_ppc64le image_ppc64le
+
+ppc64le: build_ppc64le image_ppc64le
+
+build_ppc64le:
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o docker/ppc64le/nfs-client-provisioner ./cmd/nfs-client-provisioner
+
+image_ppc64le:
+	docker build -t $(MUTABLE_IMAGE_PPC64LE) docker/ppc64le
+	docker tag $(MUTABLE_IMAGE_PPC64LE) $(IMAGE_PPC64LE)
+
+push:
+	docker push $(IMAGE_PPC64LE)
+	docker push $(MUTABLE_IMAGE_PPC64LE)

--- a/nfs-client/deploy/deployment-ppc64le.yaml
+++ b/nfs-client/deploy/deployment-ppc64le.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-client-provisioner
+  labels:
+    app: nfs-client-provisioner
+  # replace with namespace where provisioner is deployed
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-client-provisioner
+  template:
+    metadata:
+      labels:
+        app: nfs-client-provisioner
+    spec:
+      serviceAccountName: nfs-client-provisioner
+      containers:
+        - name: nfs-client-provisioner
+          image: docker.io/ibmcom/nfs-client-provisioner-ppc64le:latest
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+          env:
+            - name: PROVISIONER_NAME
+              value: fuseim.pri/ifs
+            - name: NFS_SERVER
+              # replace with ip address of NFS server
+              value: 10.10.10.60
+            - name: NFS_PATH
+              # replace with deployment path of NFS server
+              value: /ifs/kubernetes
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            # replace with ip address of NFS server
+            server: 10.10.10.60
+            # replace with deployment path of NFS server
+            path: /ifs/kubernetes

--- a/nfs-client/deploy/test-pod-ppc64le.yaml
+++ b/nfs-client/deploy/test-pod-ppc64le.yaml
@@ -1,0 +1,22 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: test-pod
+    image: docker.io/busybox:latest
+    imagePullPolicy: IfNotPresent
+    command:
+      - "/bin/sh"
+    args:
+      - "-c"
+      - "touch /mnt/SUCCESS && exit 0 || exit 1"
+    volumeMounts:
+      - name: nfs-pvc
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: nfs-pvc
+      persistentVolumeClaim:
+        claimName: test-claim

--- a/nfs-client/docker/ppc64le/Dockerfile
+++ b/nfs-client/docker/ppc64le/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum update -y && yum install -y ca-certificates
+COPY nfs-client-provisioner /nfs-client-provisioner
+ENTRYPOINT ["/nfs-client-provisioner"]


### PR DESCRIPTION
Adding support in nfs-client-provisioner module for PowerPC (ppc64le) platform.