### PR TITLE
feat(nfs-client): update base images to newer version

### DIFF
--- a/nfs-client/docker/arm/Dockerfile
+++ b/nfs-client/docker/arm/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM hypriot/rpi-alpine:3.6
+FROM multiarch/alpine:armhf-v3.10
 RUN apk update --no-cache && apk add ca-certificates
 COPY nfs-client-provisioner /nfs-client-provisioner
 ENTRYPOINT ["/nfs-client-provisioner"]

--- a/nfs-client/docker/x86_64/Dockerfile
+++ b/nfs-client/docker/x86_64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.6
+FROM alpine:3.11
 RUN apk update --no-cache && apk add ca-certificates
 COPY nfs-client-provisioner /nfs-client-provisioner
 ENTRYPOINT ["/nfs-client-provisioner"]


### PR DESCRIPTION
x86_64 to latest Alpine

The arm images is switched to multiarch since the hypriot image hasn't been updated in 3 years:
https://hub.docker.com/r/hypriot/rpi-alpine/tags

Currently the multiarch release of Alpine 3.11 is hold back by QEMU issues, see: 
https://github.com/multiarch/alpine/pull/28 but the update to 3.10 is a huge leap and 3.10 is still under support :)