### PR TITLE
Do not mutate SCC - use RBAC access to it on OpenShift

### DIFF
--- a/nfs-client/README.md
+++ b/nfs-client/README.md
@@ -40,14 +40,15 @@ $ kubectl create -f deploy/rbac.yaml
 
 OpenShift:
 
-On some installations of OpenShift the default admin user does not have cluster-admin permissions. If these commands fail refer to the OpenShift documentation for **User and Role Management** or contact your OpenShift provider to help you grant the right permissions to your admin user. 
+On OpenShift the service account used to bind volumes does not have the necessary permissions requires the permission to use the `hostmount-anyuid` SCC. See also [Role based access to SCC](https://docs.openshift.com/container-platform/4.4/authentication/managing-security-context-constraints.html#role-based-access-to-ssc_configuring-internal-oauth) for more information. If these commands fail refer to the OpenShift documentation for **User and Role Management** or contact your OpenShift provider to help you grant the right permissions to your admin user.
 
 ```sh
 # Set the subject of the RBAC objects to the current namespace where the provisioner is being deployed
 $ NAMESPACE=`oc project -q`
 $ sed -i'' "s/namespace:.*/namespace: $NAMESPACE/g" ./deploy/rbac.yaml
 $ oc create -f deploy/rbac.yaml
-$ oadm policy add-scc-to-user hostmount-anyuid system:serviceaccount:$NAMESPACE:nfs-client-provisioner
+$ oc create role use-scc-hostmount-anyuid --verb=use --resource=scc --resource-name=hostmount-anyuid -n $NAMESPACE
+$ oc adm policy add-role-to-user use-scc-hostmount-anyuid system:serviceaccount:$NAMESPACE:nfs-client-provisioner
 ```
 
 **Step 4: Configure the NFS-Client provisioner**


### PR DESCRIPTION
From OpenShift 4.4 on the built-in SCCs will be managed and thus
you cannot any longer mutate them by adding user. The proper way
is either to copy an existing SCC or use RBAC to access them.

This updates the documentation for the RBAC approach.