### PR TITLE
Migrate to policy/v1beta1 API

### DIFF
--- a/nfs/deploy/kubernetes/psp.yaml
+++ b/nfs/deploy/kubernetes/psp.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: nfs-provisioner


### PR DESCRIPTION
Migrate to use the policy/v1beta1 API, available since v1.10. Because PodSecurityPolicy in the extensions/v1beta1 is a Deprecated API Removed In 1.16.