### PR TITLE
Added support of building nfsclient arm64 docker images

### DIFF
--- a/nfs-client/Makefile
+++ b/nfs-client/Makefile
@@ -20,18 +20,23 @@ ifeq ($(VERSION),)
 endif
 IMAGE = $(REGISTRY)nfs-client-provisioner:$(VERSION)
 IMAGE_ARM = $(REGISTRY)nfs-client-provisioner-arm:$(VERSION) 
+IMAGE_ARM64 = $(REGISTRY)nfs-client-provisioner-arm64:$(VERSION)
 MUTABLE_IMAGE = $(REGISTRY)nfs-client-provisioner:latest
 MUTABLE_IMAGE_ARM = $(REGISTRY)nfs-client-provisioner-arm:latest
+MUTABLE_IMAGE_ARM64 = $(REGISTRY)nfs-client-provisioner-arm64:latest
 
-all: build image build_arm image_arm 
+all: build image build_arm image_arm build_arm64 image_arm64
 
-container: build image build_arm image_arm
+container: build image build_arm image_arm build_arm64 image_arm64
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o docker/x86_64/nfs-client-provisioner ./cmd/nfs-client-provisioner
 
 build_arm:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -a -ldflags '-extldflags "-static"' -o docker/arm/nfs-client-provisioner ./cmd/nfs-client-provisioner 
+
+build_arm64:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -ldflags '-extldflags "-static"' -o docker/arm64/nfs-client-provisioner ./cmd/nfs-client-provisioner
 
 image:
 	docker build -t $(MUTABLE_IMAGE) docker/x86_64
@@ -42,8 +47,15 @@ image_arm:
 	docker build -t $(MUTABLE_IMAGE_ARM) docker/arm
 	docker tag $(MUTABLE_IMAGE_ARM) $(IMAGE_ARM)
 
+image_arm64:
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker build -t $(MUTABLE_IMAGE_ARM64) docker/arm64
+	docker tag $(MUTABLE_IMAGE_ARM64) $(IMAGE_ARM64)
+
 push:
 	docker push $(IMAGE)
 	docker push $(MUTABLE_IMAGE)
 	docker push $(IMAGE_ARM)
 	docker push $(MUTABLE_IMAGE_ARM)
+	docker push $(IMAGE_ARM64)
+	docker push $(MUTABLE_IMAGE_ARM64)

--- a/nfs-client/docker/arm64/Dockerfile
+++ b/nfs-client/docker/arm64/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM arm64v8/alpine:3
+
+ADD https://github.com/multiarch/qemu-user-static/releases/download/v4.2.0-6/qemu-aarch64-static /usr/bin/qemu-aarch64-static
+RUN apk update --no-cache && apk add ca-certificates && chmod +x /usr/bin/qemu-aarch64-static && ln -s /usr/bin/qemu-aarch64-static /usr/bin/qemu-arm64-static
+COPY nfs-client-provisioner /nfs-client-provisioner
+ENTRYPOINT ["/nfs-client-provisioner"]


### PR DESCRIPTION
Current RPi OS and Ubuntu Focal for RPi both support ARM64 arch. In order to run the container on RPi with 64bit OS, we need to have ARM64 compatible images.