### PR TITLE
support china efs dns names

### DIFF
--- a/aws/efs/cmd/efs-provisioner/efs-provisioner.go
+++ b/aws/efs/cmd/efs-provisioner/efs-provisioner.go
@@ -100,7 +100,11 @@ func NewEFSProvisioner(client kubernetes.Interface) controller.Provisioner {
 }
 
 func getDNSName(fileSystemID, awsRegion string) string {
-	return fileSystemID + ".efs." + awsRegion + ".amazonaws.com"
+	dnsName := fileSystemID + ".efs." + awsRegion + ".amazonaws.com"
+	if strings.HasPrefix(awsRegion, "cn-") {
+		dnsName += ".cn"
+	}
+	return dnsName
 }
 
 func getMount(dnsName string) (string, string, error) {


### PR DESCRIPTION
**EFS in now GA in AWS China.** However, EFS DNS names in respective regions end with `.cn` which is currently not supported. This PR adds support for china AWS regions.