### PR TITLE
Add environment variable to allow skipping leader election

### DIFF
--- a/aws/efs/cmd/efs-provisioner/efs-provisioner.go
+++ b/aws/efs/cmd/efs-provisioner/efs-provisioner.go
@@ -40,10 +40,11 @@ import (
 )
 
 const (
-	provisionerNameKey = "PROVISIONER_NAME"
-	fileSystemIDKey    = "FILE_SYSTEM_ID"
-	awsRegionKey       = "AWS_REGION"
-	dnsNameKey         = "DNS_NAME"
+	provisionerNameKey    = "PROVISIONER_NAME"
+	fileSystemIDKey       = "FILE_SYSTEM_ID"
+	awsRegionKey          = "AWS_REGION"
+	dnsNameKey            = "DNS_NAME"
+	skipLeaderElectionKey = "SKIP_LEADER_ELECTION"
 )
 
 type efsProvisioner struct {
@@ -302,6 +303,8 @@ func main() {
 		klog.Fatalf("environment variable %s is not set! Please set it.", provisionerNameKey)
 	}
 
+	leaderElection := os.Getenv(skipLeaderElectionKey) != "1"
+
 	// Start the provision controller which will dynamically provision efs NFS
 	// PVs
 	pc := controller.NewProvisionController(
@@ -309,6 +312,7 @@ func main() {
 		provisionerName,
 		efsProvisioner,
 		serverVersion.GitVersion,
+		controller.LeaderElection(leaderElection),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/ceph/rbd/cmd/rbd-provisioner/main.go
+++ b/ceph/rbd/cmd/rbd-provisioner/main.go
@@ -39,7 +39,8 @@ var (
 )
 
 const (
-	provisionerNameKey = "PROVISIONER_NAME"
+	provisionerNameKey    = "PROVISIONER_NAME"
+	skipLeaderElectionKey = "SKIP_LEADER_ELECTION"
 )
 
 func main() {
@@ -87,6 +88,8 @@ func main() {
 	klog.Infof("Creating RBD provisioner %s with identity: %s", prName, prID)
 	rbdProvisioner := provision.NewRBDProvisioner(clientset, prID, *commandTimeout, *usePVName)
 
+	leaderElection := os.Getenv(skipLeaderElectionKey) != "1"
+
 	// Start the provision controller which will dynamically provision rbd
 	// PVs
 	pc := controller.NewProvisionController(
@@ -95,6 +98,7 @@ func main() {
 		rbdProvisioner,
 		serverVersion.GitVersion,
 		controller.MetricsPort(int32(*metricsPort)),
+		controller.LeaderElection(leaderElection),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
+++ b/gluster/block/cmd/glusterblock-provisioner/glusterblock-provisioner.go
@@ -41,19 +41,20 @@ import (
 )
 
 const (
-	secretKeyName      = "key"
-	provisionerNameKey = "PROVISIONER_NAME"
-	shareIDAnn         = "glusterBlockShare"
-	provisionerIDAnn   = "glusterBlkProvIdentity"
-	creatorAnn         = "kubernetes.io/createdby"
-	volumeTypeAnn      = "gluster.org/type"
-	descAnn            = "Gluster-external: Dynamically provisioned PV"
-	provisionerVersion = "v5.0.0"
-	chapType           = "kubernetes.io/iscsi-chap"
-	blockVolPrefix     = "blockvol_"
-	heketiOpmode       = "heketi"
-	glusterBlockOpmode = "gluster-block"
-	volIDAnn           = "gluster.org/volume-id"
+	secretKeyName         = "key"
+	provisionerNameKey    = "PROVISIONER_NAME"
+	skipLeaderElectionKey = "SKIP_LEADER_ELECTION"
+	shareIDAnn            = "glusterBlockShare"
+	provisionerIDAnn      = "glusterBlkProvIdentity"
+	creatorAnn            = "kubernetes.io/createdby"
+	volumeTypeAnn         = "gluster.org/type"
+	descAnn               = "Gluster-external: Dynamically provisioned PV"
+	provisionerVersion    = "v5.0.0"
+	chapType              = "kubernetes.io/iscsi-chap"
+	blockVolPrefix        = "blockvol_"
+	heketiOpmode          = "heketi"
+	glusterBlockOpmode    = "gluster-block"
+	volIDAnn              = "gluster.org/volume-id"
 	// Error string returned by heketi
 	errIDNotFound = "Id not found"
 )
@@ -910,6 +911,8 @@ func main() {
 	// the controller
 	glusterBlockProvisioner := NewGlusterBlockProvisioner(clientset, provisionerName)
 
+	leaderElection := os.Getenv(skipLeaderElectionKey) != "1"
+
 	// Start the provision controller which will dynamically provision glusterblock
 	// PVs
 
@@ -920,6 +923,7 @@ func main() {
 		serverVersion.GitVersion,
 		controller.Threadiness(2),
 		controller.FailedProvisionThreshold(30),
+		controller.LeaderElection(leaderElection),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
+++ b/gluster/file/cmd/glusterfile-provisioner/glusterfile-provisioner.go
@@ -45,6 +45,7 @@ import (
 const (
 	provisionerName           = "gluster.org/glusterfile"
 	provisionerNameKey        = "PROVISIONER_NAME"
+	skipLeaderElectionKey     = "SKIP_LEADER_ELECTION"
 	descAnn                   = "Gluster-external: Dynamically provisioned PV"
 	restStr                   = "server"
 	dynamicEpSvcPrefix        = "glusterfile-dynamic-"
@@ -924,6 +925,8 @@ func main() {
 	// the controller
 	glusterfileProvisioner := NewglusterfileProvisioner(clientset, provName)
 
+	leaderElection := os.Getenv(skipLeaderElectionKey) != "1"
+
 	// Start the provision controller which will dynamically provision glusterfs
 	// PVs
 
@@ -932,6 +935,7 @@ func main() {
 		provName,
 		glusterfileProvisioner,
 		serverVersion.GitVersion,
+		controller.LeaderElection(leaderElection),
 	)
 
 	pc.Run(wait.NeverStop)

--- a/openebs/openebs-provisioner.go
+++ b/openebs/openebs-provisioner.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	provisionerName = "openebs.io/provisioner-iscsi"
+	provisionerName       = "openebs.io/provisioner-iscsi"
+	skipLeaderElectionKey = "SKIP_LEADER_ELECTION"
 )
 
 type openEBSProvisioner struct {
@@ -208,6 +209,9 @@ func main() {
 	// Create the provisioner: it implements the Provisioner interface expected by
 	// the controller
 	openEBSProvisioner := NewOpenEBSProvisioner(clientset)
+
+	leaderElection := os.Getenv(skipLeaderElectionKey) != "1"
+
 	if openEBSProvisioner != nil {
 		// Start the provision controller which will dynamically provision OpenEBS VSM
 		// PVs
@@ -215,7 +219,9 @@ func main() {
 			clientset,
 			provisionerName,
 			openEBSProvisioner,
-			serverVersion.GitVersion)
+			serverVersion.GitVersion,
+			controller.LeaderElection(leaderElection),
+		)
 
 		pc.Run(wait.NeverStop)
 	} else {


### PR DESCRIPTION
This PR addresses https://github.com/kubernetes-incubator/external-storage/issues/1184 by allowing to turn off leader election as mentioned in https://github.com/kubernetes-incubator/external-storage/issues/1184#issuecomment-624691714.

Leader election can be turned off by setting the env var `SKIP_LEADER_ELECTION=1`.